### PR TITLE
Allow users to request a new login code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ vendor/
 js/
 css/
 
-/.php_cs.cache
 /.php-cs-fixer.cache
 
 # Ignore NetBeans project

--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -7,9 +7,9 @@
 /.idea
 /.l10nignore
 /.nextcloudignore
+/.php-cs-fixer.cache
 /.php-cs-fixer.dist.php
 /.tx
-/babel.config.js
 /build
 /.claude
 /composer.*
@@ -25,4 +25,3 @@
 /vendor/bin
 /vendor-bin
 /vite.config.js
-/webpack.config.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,13 @@
 Notable changes in [changelog format](https://keepachangelog.com/en/1.0.0/), project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
-## 3.2.0 (2026-06-12)
+## 3.2.0 (2026-06-17)
 
 ### Added
 
 - Admin settings: allow setting a custom challenge email subject
-  
+- Login: allow users to request a new code
+
 ### Changed
 
 - Admin settings: links in the challenge email body are now rendered as such
@@ -22,13 +23,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ### Changed
 
 - updated dependencies fix an optical glitch in the personal settings toggle
-
-## 3.1.1 (2026-06-01)
-
-### Fixed
-
-- When updating the app from v2 to v3, authentication codes are no longer migrated, see
-  https://github.com/datenschutz-individuell/twofactor_email/issues/69#issuecomment-4588492017
 
 ## 3.1.1 (2026-06-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,13 @@
 Notable changes in [changelog format](https://keepachangelog.com/en/1.0.0/), project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
-## 3.2.0 (2026-06-17)
+## 3.2.0 (2026-06-21)
 
 ### Added
 
 - Admin settings: allow setting a custom challenge email subject
-- Login: allow users to request a new code
+- Login: users can request a new code after a short cooldown
+- Admin settings: set the resend cooldown (how soon a new code may be requested)
 
 ### Changed
 

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -16,6 +16,12 @@ return [
 			'verb' => 'POST',
 		],
 		[
+			// ChallengeController#resend: user-requested resend of the login code
+			'name' => 'Challenge#resend',
+			'url' => '/challenge/resend',
+			'verb' => 'POST',
+		],
+		[
 			// Nextcloud expects a class AdminSettingsController in 'AdminSettingsController.php' with a 'save' method.
 			'name' => 'AdminSettings#save',
 			'url' => '/admin/save',

--- a/lib/Controller/AdminSettingsController.php
+++ b/lib/Controller/AdminSettingsController.php
@@ -32,6 +32,10 @@ final class AdminSettingsController extends ALoginSetupController {
 	private const MIN_CODE_VALID_MINUTES = 1;
 	private const MAX_CODE_VALID_MINUTES = 44640; // 1 month
 
+	// Allowed range for the resend cooldown in seconds
+	private const MIN_RESEND_MIN_SECONDS = 5;
+	private const MAX_RESEND_MIN_SECONDS = 3600; // 1 hour
+
 	// Maximum allowed lengths for the email template parts in characters
 	private const MAX_EMAIL_SUBJECT_LENGTH = 255;
 	private const MAX_EMAIL_TEMPLATE_LENGTH = 10000;
@@ -50,14 +54,16 @@ final class AdminSettingsController extends ALoginSetupController {
 		int $codeValidMinutes,
 		string $eMailTemplate,
 		string $eMailSubject,
+		int $resendMinSeconds = self::MIN_RESEND_MIN_SECONDS,
 	): JSONResponse {
-		$errors = $this->validate($codeLength, $codeValidMinutes, $eMailTemplate, $eMailSubject);
+		$errors = $this->validate($codeLength, $codeValidMinutes, $eMailTemplate, $eMailSubject, $resendMinSeconds);
 		if (!empty($errors)) {
 			return new JSONResponse(['error' => implode(', ', $errors)], Http::STATUS_BAD_REQUEST);
 		}
 
 		$this->appSettings->setCodeLength($codeLength);
 		$this->appSettings->setCodeValidMinutes($codeValidMinutes);
+		$this->appSettings->setResendMinSeconds($resendMinSeconds);
 		$this->appSettings->setEMailSubject($eMailSubject);
 		$this->appSettings->setEMailTemplate($eMailTemplate);
 
@@ -72,6 +78,7 @@ final class AdminSettingsController extends ALoginSetupController {
 	 * @param int $codeValidMinutes
 	 * @param string $eMailTemplate
 	 * @param string $eMailSubject
+	 * @param int $resendMinSeconds
 	 * @return string[]
 	 */
 	private function validate(
@@ -79,6 +86,7 @@ final class AdminSettingsController extends ALoginSetupController {
 		int $codeValidMinutes,
 		string $eMailTemplate,
 		string $eMailSubject,
+		int $resendMinSeconds,
 	): array {
 		$errors = [];
 		if ($codeLength < self::MIN_CODE_LENGTH || $codeLength > self::MAX_CODE_LENGTH) {
@@ -86,6 +94,9 @@ final class AdminSettingsController extends ALoginSetupController {
 		}
 		if ($codeValidMinutes < self::MIN_CODE_VALID_MINUTES || $codeValidMinutes > self::MAX_CODE_VALID_MINUTES) {
 			$errors[] = 'code-valid-minutes-out-of-range';
+		}
+		if ($resendMinSeconds < self::MIN_RESEND_MIN_SECONDS || $resendMinSeconds > self::MAX_RESEND_MIN_SECONDS) {
+			$errors[] = 'resend-min-seconds-out-of-range';
 		}
 		if (strlen($eMailSubject) > self::MAX_EMAIL_SUBJECT_LENGTH) {
 			$errors[] = 'email-subject-too-long';
@@ -116,6 +127,7 @@ final class AdminSettingsController extends ALoginSetupController {
 		return new JSONResponse([
 			'codeLength' => $this->appSettings->getCodeLength(),
 			'codeValidMinutes' => $this->appSettings->getCodeValidMinutes(),
+			'codeResendMinSeconds' => $this->appSettings->getResendMinSeconds(),
 			'eMailSubject' => $this->appSettings->getEMailSubject(),
 			'eMailTemplate' => $this->appSettings->getEMailTemplate(),
 		]);

--- a/lib/Controller/AdminSettingsController.php
+++ b/lib/Controller/AdminSettingsController.php
@@ -54,7 +54,7 @@ final class AdminSettingsController extends ALoginSetupController {
 		int $codeValidMinutes,
 		string $eMailTemplate,
 		string $eMailSubject,
-		int $resendMinSeconds = self::MIN_RESEND_MIN_SECONDS,
+		int $resendMinSeconds,
 	): JSONResponse {
 		$errors = $this->validate($codeLength, $codeValidMinutes, $eMailTemplate, $eMailSubject, $resendMinSeconds);
 		if (!empty($errors)) {

--- a/lib/Controller/AdminSettingsController.php
+++ b/lib/Controller/AdminSettingsController.php
@@ -32,9 +32,9 @@ final class AdminSettingsController extends ALoginSetupController {
 	private const MIN_CODE_VALID_MINUTES = 1;
 	private const MAX_CODE_VALID_MINUTES = 44640; // 1 month
 
-	// Allowed range for the resend cooldown in seconds
-	private const MIN_RESEND_MIN_SECONDS = 5;
-	private const MAX_RESEND_MIN_SECONDS = 3600; // 1 hour
+	// Allowed range for the resend cooldown in minutes
+	private const MIN_RESEND_MINUTES = 1;
+	private const MAX_RESEND_MINUTES = 60; // 1 hour
 
 	// Maximum allowed lengths for the email template parts in characters
 	private const MAX_EMAIL_SUBJECT_LENGTH = 255;
@@ -54,16 +54,16 @@ final class AdminSettingsController extends ALoginSetupController {
 		int $codeValidMinutes,
 		string $eMailTemplate,
 		string $eMailSubject,
-		int $resendMinSeconds,
+		int $resendMinutes,
 	): JSONResponse {
-		$errors = $this->validate($codeLength, $codeValidMinutes, $eMailTemplate, $eMailSubject, $resendMinSeconds);
+		$errors = $this->validate($codeLength, $codeValidMinutes, $eMailTemplate, $eMailSubject, $resendMinutes);
 		if (!empty($errors)) {
 			return new JSONResponse(['error' => implode(', ', $errors)], Http::STATUS_BAD_REQUEST);
 		}
 
 		$this->appSettings->setCodeLength($codeLength);
 		$this->appSettings->setCodeValidMinutes($codeValidMinutes);
-		$this->appSettings->setResendMinSeconds($resendMinSeconds);
+		$this->appSettings->setResendMinMinutes($resendMinutes);
 		$this->appSettings->setEMailSubject($eMailSubject);
 		$this->appSettings->setEMailTemplate($eMailTemplate);
 
@@ -78,7 +78,7 @@ final class AdminSettingsController extends ALoginSetupController {
 	 * @param int $codeValidMinutes
 	 * @param string $eMailTemplate
 	 * @param string $eMailSubject
-	 * @param int $resendMinSeconds
+	 * @param int $resendMinutes
 	 * @return string[]
 	 */
 	private function validate(
@@ -86,7 +86,7 @@ final class AdminSettingsController extends ALoginSetupController {
 		int $codeValidMinutes,
 		string $eMailTemplate,
 		string $eMailSubject,
-		int $resendMinSeconds,
+		int $resendMinutes,
 	): array {
 		$errors = [];
 		if ($codeLength < self::MIN_CODE_LENGTH || $codeLength > self::MAX_CODE_LENGTH) {
@@ -95,8 +95,8 @@ final class AdminSettingsController extends ALoginSetupController {
 		if ($codeValidMinutes < self::MIN_CODE_VALID_MINUTES || $codeValidMinutes > self::MAX_CODE_VALID_MINUTES) {
 			$errors[] = 'code-valid-minutes-out-of-range';
 		}
-		if ($resendMinSeconds < self::MIN_RESEND_MIN_SECONDS || $resendMinSeconds > self::MAX_RESEND_MIN_SECONDS) {
-			$errors[] = 'resend-min-seconds-out-of-range';
+		if ($resendMinutes < self::MIN_RESEND_MINUTES || $resendMinutes > self::MAX_RESEND_MINUTES) {
+			$errors[] = 'resend-minutes-out-of-range';
 		}
 		if (strlen($eMailSubject) > self::MAX_EMAIL_SUBJECT_LENGTH) {
 			$errors[] = 'email-subject-too-long';
@@ -127,7 +127,7 @@ final class AdminSettingsController extends ALoginSetupController {
 		return new JSONResponse([
 			'codeLength' => $this->appSettings->getCodeLength(),
 			'codeValidMinutes' => $this->appSettings->getCodeValidMinutes(),
-			'codeResendMinSeconds' => $this->appSettings->getResendMinSeconds(),
+			'codeResendMinutes' => $this->appSettings->getResendMinMinutes(),
 			'eMailSubject' => $this->appSettings->getEMailSubject(),
 			'eMailTemplate' => $this->appSettings->getEMailTemplate(),
 		]);

--- a/lib/Controller/ChallengeController.php
+++ b/lib/Controller/ChallengeController.php
@@ -20,14 +20,18 @@ use OCA\TwoFactorEMail\Exception\SendEMailFailed;
 use OCA\TwoFactorEMail\Service\ILoginChallenge;
 use OCA\TwoFactorEMail\Service\IStateManager;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\BruteForceProtection;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoTwoFactorRequired;
+use OCP\AppFramework\Http\Attribute\UserRateLimit;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\Authentication\TwoFactorAuth\ALoginSetupController;
 use OCP\IRequest;
 use OCP\IUserSession;
 
 final class ChallengeController extends ALoginSetupController {
+
+	private const BRUTE_FORCE_ACTION = 'twofactorEmailResend';
 
 	public function __construct(
 		string $appName,
@@ -39,22 +43,21 @@ final class ChallengeController extends ALoginSetupController {
 		parent::__construct($appName, $request);
 	}
 
-	/**
-	 * Send a fresh challenge code on the user's explicit request.
-	 *
-	 * Reachable during the half-authenticated 2FA-pending state: NoTwoFactorRequired
-	 * lets the request pass TwoFactorMiddleware. Flooding is prevented by the resend
-	 * cooldown in the service (no email is sent before it elapses), so no extra
-	 * request rate limit is needed here.
+	/*
+	 * The service cooldown is the configurable source of truth. The rate limit
+	 * is an atomic backstop against concurrent bursts: period 60 equals the
+	 * smallest possible cooldown (MIN_RESEND_MINUTES), so it never rejects a
+	 * legitimately allowed resend.
 	 */
 	#[NoAdminRequired]
 	#[NoTwoFactorRequired]
+	#[UserRateLimit(limit: 1, period: 60)]
+	#[BruteForceProtection(action: self::BRUTE_FORCE_ACTION)]
 	public function resend(): JSONResponse {
 		$user = $this->userSession->getUser();
 		if ($user === null) {
 			return new JSONResponse(['error' => 'no-user'], Http::STATUS_UNAUTHORIZED);
 		}
-		// Only the email provider's own challenge may be resent here
 		if (!$this->stateManager->isEnabled($user)) {
 			return new JSONResponse(['error' => 'not-enabled'], Http::STATUS_BAD_REQUEST);
 		}
@@ -63,14 +66,18 @@ final class ChallengeController extends ALoginSetupController {
 			$this->challenge->resendChallenge($user);
 			return new JSONResponse(['status' => 'sent']);
 		} catch (ResendTooSoon $e) {
-			return new JSONResponse(
+			$response = new JSONResponse(
 				['error' => 'too-soon', 'retryAfter' => $e->retryAfterSeconds],
 				Http::STATUS_TOO_MANY_REQUESTS,
 			);
+			$response->throttle(['action' => self::BRUTE_FORCE_ACTION]);
+			return $response;
 		} catch (EMailNotSet) {
 			return new JSONResponse(['error' => 'no-email'], Http::STATUS_BAD_REQUEST);
 		} catch (SendEMailFailed) {
-			return new JSONResponse(['error' => 'send-failed'], Http::STATUS_INTERNAL_SERVER_ERROR);
+			$response = new JSONResponse(['error' => 'send-failed'], Http::STATUS_INTERNAL_SERVER_ERROR);
+			$response->throttle(['action' => self::BRUTE_FORCE_ACTION]);
+			return $response;
 		}
 	}
 }

--- a/lib/Controller/ChallengeController.php
+++ b/lib/Controller/ChallengeController.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/*
+ * This class may NOT be renamed to e.g. 'Challenge.php' since Nextcloud USES the class suffix 'Controller'.
+ * See routes.php.
+ */
+
+namespace OCA\TwoFactorEMail\Controller;
+
+use OCA\TwoFactorEMail\Exception\EMailNotSet;
+use OCA\TwoFactorEMail\Exception\ResendTooSoon;
+use OCA\TwoFactorEMail\Exception\SendEMailFailed;
+use OCA\TwoFactorEMail\Service\ILoginChallenge;
+use OCA\TwoFactorEMail\Service\IStateManager;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoTwoFactorRequired;
+use OCP\AppFramework\Http\Attribute\UserRateLimit;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\Authentication\TwoFactorAuth\ALoginSetupController;
+use OCP\IRequest;
+use OCP\IUserSession;
+
+final class ChallengeController extends ALoginSetupController {
+
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private readonly IUserSession $userSession,
+		private readonly ILoginChallenge $challenge,
+		private readonly IStateManager $stateManager,
+	) {
+		parent::__construct($appName, $request);
+	}
+
+	/**
+	 * Send a fresh challenge code on the user's explicit request.
+	 *
+	 * Reachable during the half-authenticated 2FA-pending state: NoTwoFactorRequired
+	 * lets the request pass TwoFactorMiddleware. The cooldown in the service is the
+	 * primary throttle; UserRateLimit is a hard backstop.
+	 */
+	#[NoAdminRequired]
+	#[NoTwoFactorRequired]
+	#[UserRateLimit(limit: 5, period: 600)]
+	public function resend(): JSONResponse {
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			return new JSONResponse(['error' => 'no-user'], Http::STATUS_UNAUTHORIZED);
+		}
+		// Only the email provider's own challenge may be resent here
+		if (!$this->stateManager->isEnabled($user)) {
+			return new JSONResponse(['error' => 'not-enabled'], Http::STATUS_BAD_REQUEST);
+		}
+
+		try {
+			$this->challenge->resendChallenge($user);
+			return new JSONResponse(['status' => 'sent']);
+		} catch (ResendTooSoon $e) {
+			return new JSONResponse(
+				['error' => 'too-soon', 'retryAfter' => $e->retryAfterSeconds],
+				Http::STATUS_TOO_MANY_REQUESTS,
+			);
+		} catch (EMailNotSet) {
+			return new JSONResponse(['error' => 'no-email'], Http::STATUS_BAD_REQUEST);
+		} catch (SendEMailFailed) {
+			return new JSONResponse(['error' => 'send-failed'], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+	}
+}

--- a/lib/Controller/ChallengeController.php
+++ b/lib/Controller/ChallengeController.php
@@ -22,7 +22,6 @@ use OCA\TwoFactorEMail\Service\IStateManager;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoTwoFactorRequired;
-use OCP\AppFramework\Http\Attribute\UserRateLimit;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\Authentication\TwoFactorAuth\ALoginSetupController;
 use OCP\IRequest;
@@ -44,12 +43,12 @@ final class ChallengeController extends ALoginSetupController {
 	 * Send a fresh challenge code on the user's explicit request.
 	 *
 	 * Reachable during the half-authenticated 2FA-pending state: NoTwoFactorRequired
-	 * lets the request pass TwoFactorMiddleware. The cooldown in the service is the
-	 * primary throttle; UserRateLimit is a hard backstop.
+	 * lets the request pass TwoFactorMiddleware. Flooding is prevented by the resend
+	 * cooldown in the service (no email is sent before it elapses), so no extra
+	 * request rate limit is needed here.
 	 */
 	#[NoAdminRequired]
 	#[NoTwoFactorRequired]
-	#[UserRateLimit(limit: 5, period: 600)]
 	public function resend(): JSONResponse {
 		$user = $this->userSession->getUser();
 		if ($user === null) {

--- a/lib/Controller/ChallengeController.php
+++ b/lib/Controller/ChallengeController.php
@@ -45,8 +45,8 @@ final class ChallengeController extends ALoginSetupController {
 
 	/*
 	 * The service cooldown is the configurable source of truth. The rate limit
-	 * is an atomic backstop against concurrent bursts: period 60 equals the
-	 * smallest possible cooldown (MIN_RESEND_MINUTES), so it never rejects a
+	 * is an atomic backstop against concurrent bursts: period 60s matches the
+	 * minimum allowed resend cooldown (currently 1 minute), so it never rejects a
 	 * legitimately allowed resend.
 	 */
 	#[NoAdminRequired]

--- a/lib/Exception/ResendTooSoon.php
+++ b/lib/Exception/ResendTooSoon.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Exception;
+
+use Exception;
+use Throwable;
+
+/**
+ * Thrown when a user requests a new code before the resend cooldown elapsed.
+ */
+final class ResendTooSoon extends Exception {
+	public function __construct(
+		public readonly int $retryAfterSeconds,
+		?Throwable $previous = null,
+	) {
+		parent::__construct("Resend requested too soon, retry after {$retryAfterSeconds}s", previous: $previous);
+	}
+}

--- a/lib/Mail/TemplateRenderer.php
+++ b/lib/Mail/TemplateRenderer.php
@@ -146,7 +146,7 @@ final class TemplateRenderer {
 			$html = str_replace(
 				'{logo}',
 				'<img src="' . htmlspecialchars($this->logoUrl()) . '" alt="' . htmlspecialchars($this->defaults->getName())
-					. '" style="max-width:250px;max-width:min(250px, 20%);max-height:250px">',
+					. '" style="max-width:min(250px, 20%);max-height:250px">',
 				$html,
 			);
 		}

--- a/lib/Provider/TwoFactorEMail.php
+++ b/lib/Provider/TwoFactorEMail.php
@@ -93,6 +93,10 @@ class TwoFactorEMail implements IProvider, IProvidesIcons, IProvidesPersonalSett
 		$template->assign('codeLength', $this->settings->getCodeLength());
 		$template->assign('newCodeWasSent', $newCodeWasSent);
 		$template->assign('error', $error);
+		// Resend cooldown state, so the dialog can show a live countdown and only
+		// offer the resend link once a new code may actually be requested.
+		$template->assign('resendCooldown', $this->settings->getResendMinSeconds());
+		$template->assign('resendAvailableIn', $this->challengeService->secondsUntilResendAllowed($user));
 
 		// Return the template for the challenge view (LoginChallenge.php file in the templates folder of the app)
 		return $template;

--- a/lib/Provider/TwoFactorEMail.php
+++ b/lib/Provider/TwoFactorEMail.php
@@ -95,7 +95,7 @@ class TwoFactorEMail implements IProvider, IProvidesIcons, IProvidesPersonalSett
 		$template->assign('error', $error);
 		// Resend cooldown state, so the dialog can show a live countdown and only
 		// offer the resend link once a new code may actually be requested.
-		$template->assign('resendCooldown', $this->settings->getResendMinSeconds());
+		$template->assign('resendCooldown', $this->settings->getResendCooldownSeconds());
 		$template->assign('resendAvailableIn', $this->challengeService->secondsUntilResendAllowed($user));
 
 		// Return the template for the challenge view (LoginChallenge.php file in the templates folder of the app)

--- a/lib/Provider/TwoFactorEMail.php
+++ b/lib/Provider/TwoFactorEMail.php
@@ -93,8 +93,6 @@ class TwoFactorEMail implements IProvider, IProvidesIcons, IProvidesPersonalSett
 		$template->assign('codeLength', $this->settings->getCodeLength());
 		$template->assign('newCodeWasSent', $newCodeWasSent);
 		$template->assign('error', $error);
-		// Resend cooldown state, so the dialog can show a live countdown and only
-		// offer the resend link once a new code may actually be requested.
 		$template->assign('resendCooldown', $this->settings->getResendCooldownSeconds());
 		$template->assign('resendAvailableIn', $this->challengeService->secondsUntilResendAllowed($user));
 

--- a/lib/Service/AppSettings.php
+++ b/lib/Service/AppSettings.php
@@ -50,8 +50,6 @@ final class AppSettings implements IAppSettings {
 	}
 
 	public function getResendCooldownSeconds(): int {
-		// Single conversion point: the setting is stored in minutes, the cooldown
-		// logic and the challenge page work in seconds.
 		return $this->getResendMinMinutes() * 60;
 	}
 

--- a/lib/Service/AppSettings.php
+++ b/lib/Service/AppSettings.php
@@ -18,7 +18,7 @@ final class AppSettings implements IAppSettings {
 	// Config keys used to store the settings in the app config
 	private const KEY_CODE_LENGTH = 'code_length';
 	private const KEY_CODE_VALID_MINUTES = 'code_valid_minutes';
-	private const KEY_RESEND_MIN_SECONDS = 'resend_min_seconds';
+	private const KEY_RESEND_MIN_MINUTES = 'resend_min_minutes';
 	private const KEY_EMAIL_SUBJECT = 'email_subject';
 	private const KEY_EMAIL_TEMPLATE = 'email_template';
 
@@ -27,7 +27,7 @@ final class AppSettings implements IAppSettings {
 	// default text (the getDefault* methods below).
 	private const DEFAULT_CODE_LENGTH = 6;
 	private const DEFAULT_CODE_VALID_MINUTES = 10;
-	private const DEFAULT_RESEND_MIN_SECONDS = 60;
+	private const DEFAULT_RESEND_MIN_MINUTES = 1;
 	private const DEFAULT_EMAIL_SUBJECT = '';
 	private const DEFAULT_EMAIL_TEMPLATE = '';
 
@@ -45,8 +45,14 @@ final class AppSettings implements IAppSettings {
 		return $this->appConfig->getValueInt(Application::APP_ID, self::KEY_CODE_VALID_MINUTES, self::DEFAULT_CODE_VALID_MINUTES);
 	}
 
-	public function getResendMinSeconds(): int {
-		return $this->appConfig->getValueInt(Application::APP_ID, self::KEY_RESEND_MIN_SECONDS, self::DEFAULT_RESEND_MIN_SECONDS);
+	public function getResendMinMinutes(): int {
+		return $this->appConfig->getValueInt(Application::APP_ID, self::KEY_RESEND_MIN_MINUTES, self::DEFAULT_RESEND_MIN_MINUTES);
+	}
+
+	public function getResendCooldownSeconds(): int {
+		// Single conversion point: the setting is stored in minutes, the cooldown
+		// logic and the challenge page work in seconds.
+		return $this->getResendMinMinutes() * 60;
 	}
 
 	public function getEMailSubject(): string {
@@ -81,8 +87,8 @@ final class AppSettings implements IAppSettings {
 		$this->appConfig->setValueInt(Application::APP_ID, self::KEY_CODE_VALID_MINUTES, $codeValidMinutes);
 	}
 
-	public function setResendMinSeconds(int $resendMinSeconds): void {
-		$this->appConfig->setValueInt(Application::APP_ID, self::KEY_RESEND_MIN_SECONDS, $resendMinSeconds);
+	public function setResendMinMinutes(int $resendMinutes): void {
+		$this->appConfig->setValueInt(Application::APP_ID, self::KEY_RESEND_MIN_MINUTES, $resendMinutes);
 	}
 
 	public function setEMailSubject(string $subject): void {
@@ -96,7 +102,7 @@ final class AppSettings implements IAppSettings {
 	public function resetToDefaults(): void {
 		$this->appConfig->deleteKey(Application::APP_ID, self::KEY_CODE_LENGTH);
 		$this->appConfig->deleteKey(Application::APP_ID, self::KEY_CODE_VALID_MINUTES);
-		$this->appConfig->deleteKey(Application::APP_ID, self::KEY_RESEND_MIN_SECONDS);
+		$this->appConfig->deleteKey(Application::APP_ID, self::KEY_RESEND_MIN_MINUTES);
 		$this->appConfig->deleteKey(Application::APP_ID, self::KEY_EMAIL_SUBJECT);
 		$this->appConfig->deleteKey(Application::APP_ID, self::KEY_EMAIL_TEMPLATE);
 	}

--- a/lib/Service/AppSettings.php
+++ b/lib/Service/AppSettings.php
@@ -18,6 +18,7 @@ final class AppSettings implements IAppSettings {
 	// Config keys used to store the settings in the app config
 	private const KEY_CODE_LENGTH = 'code_length';
 	private const KEY_CODE_VALID_MINUTES = 'code_valid_minutes';
+	private const KEY_RESEND_MIN_SECONDS = 'resend_min_seconds';
 	private const KEY_EMAIL_SUBJECT = 'email_subject';
 	private const KEY_EMAIL_TEMPLATE = 'email_template';
 
@@ -26,6 +27,7 @@ final class AppSettings implements IAppSettings {
 	// default text (the getDefault* methods below).
 	private const DEFAULT_CODE_LENGTH = 6;
 	private const DEFAULT_CODE_VALID_MINUTES = 10;
+	private const DEFAULT_RESEND_MIN_SECONDS = 60;
 	private const DEFAULT_EMAIL_SUBJECT = '';
 	private const DEFAULT_EMAIL_TEMPLATE = '';
 
@@ -41,6 +43,10 @@ final class AppSettings implements IAppSettings {
 
 	public function getCodeValidMinutes(): int {
 		return $this->appConfig->getValueInt(Application::APP_ID, self::KEY_CODE_VALID_MINUTES, self::DEFAULT_CODE_VALID_MINUTES);
+	}
+
+	public function getResendMinSeconds(): int {
+		return $this->appConfig->getValueInt(Application::APP_ID, self::KEY_RESEND_MIN_SECONDS, self::DEFAULT_RESEND_MIN_SECONDS);
 	}
 
 	public function getEMailSubject(): string {
@@ -75,6 +81,10 @@ final class AppSettings implements IAppSettings {
 		$this->appConfig->setValueInt(Application::APP_ID, self::KEY_CODE_VALID_MINUTES, $codeValidMinutes);
 	}
 
+	public function setResendMinSeconds(int $resendMinSeconds): void {
+		$this->appConfig->setValueInt(Application::APP_ID, self::KEY_RESEND_MIN_SECONDS, $resendMinSeconds);
+	}
+
 	public function setEMailSubject(string $subject): void {
 		$this->appConfig->setValueString(Application::APP_ID, self::KEY_EMAIL_SUBJECT, $subject);
 	}
@@ -86,6 +96,7 @@ final class AppSettings implements IAppSettings {
 	public function resetToDefaults(): void {
 		$this->appConfig->deleteKey(Application::APP_ID, self::KEY_CODE_LENGTH);
 		$this->appConfig->deleteKey(Application::APP_ID, self::KEY_CODE_VALID_MINUTES);
+		$this->appConfig->deleteKey(Application::APP_ID, self::KEY_RESEND_MIN_SECONDS);
 		$this->appConfig->deleteKey(Application::APP_ID, self::KEY_EMAIL_SUBJECT);
 		$this->appConfig->deleteKey(Application::APP_ID, self::KEY_EMAIL_TEMPLATE);
 	}

--- a/lib/Service/CodeStorage.php
+++ b/lib/Service/CodeStorage.php
@@ -37,6 +37,16 @@ final class CodeStorage implements ICodeStorage {
 		return $code;
 	}
 
+	public function secondsSinceLastCode(string $userId): ?int {
+		// Only a still-valid code counts: an expired one is treated as "none"
+		// so the user may request a fresh code without waiting.
+		if ($this->readCode($userId) === null) {
+			return null;
+		}
+		$createdAt = $this->config->getValueInt($userId, Application::APP_ID, self::KEY_CREATED_AT);
+		return max(0, time() - $createdAt);
+	}
+
 	public function deleteCode(string $userId): void {
 		$this->config->deleteUserConfig($userId, Application::APP_ID, self::KEY_CODE);
 		$this->config->deleteUserConfig($userId, Application::APP_ID, self::KEY_CREATED_AT);

--- a/lib/Service/IAppSettings.php
+++ b/lib/Service/IAppSettings.php
@@ -23,6 +23,14 @@ interface IAppSettings {
 	public function getCodeValidMinutes(): int;
 
 	/**
+	 * Minimum number of seconds that must pass before the user may request a
+	 * new code while the current one is still valid (resend cooldown).
+	 *
+	 * @return int seconds
+	 */
+	public function getResendMinSeconds(): int;
+
+	/**
 	 * Subject of the 2FA challenge email, as stored by the admin.
 	 * An empty string means: no custom subject — use getDefaultEMailSubject().
 	 *
@@ -55,6 +63,8 @@ interface IAppSettings {
 	public function setCodeLength(int $codeLength): void;
 
 	public function setCodeValidMinutes(int $codeValidMinutes): void;
+
+	public function setResendMinSeconds(int $resendMinSeconds): void;
 
 	public function setEMailSubject(string $subject): void;
 

--- a/lib/Service/IAppSettings.php
+++ b/lib/Service/IAppSettings.php
@@ -23,12 +23,21 @@ interface IAppSettings {
 	public function getCodeValidMinutes(): int;
 
 	/**
-	 * Minimum number of seconds that must pass before the user may request a
+	 * Minimum number of minutes that must pass before the user may request a
 	 * new code while the current one is still valid (resend cooldown).
+	 *
+	 * @return int minutes
+	 */
+	public function getResendMinMinutes(): int;
+
+	/**
+	 * The resend cooldown in seconds (derived from the minutes setting) — the
+	 * single place that converts the admin unit to what the cooldown logic and
+	 * the challenge page work in.
 	 *
 	 * @return int seconds
 	 */
-	public function getResendMinSeconds(): int;
+	public function getResendCooldownSeconds(): int;
 
 	/**
 	 * Subject of the 2FA challenge email, as stored by the admin.
@@ -64,7 +73,7 @@ interface IAppSettings {
 
 	public function setCodeValidMinutes(int $codeValidMinutes): void;
 
-	public function setResendMinSeconds(int $resendMinSeconds): void;
+	public function setResendMinMinutes(int $resendMinutes): void;
 
 	public function setEMailSubject(string $subject): void;
 

--- a/lib/Service/IAppSettings.php
+++ b/lib/Service/IAppSettings.php
@@ -31,9 +31,9 @@ interface IAppSettings {
 	public function getResendMinMinutes(): int;
 
 	/**
-	 * The resend cooldown in seconds (derived from the minutes setting) — the
-	 * single place that converts the admin unit to what the cooldown logic and
-	 * the challenge page work in.
+	 * The resend cooldown in seconds. The setting is stored in minutes and
+	 * converted here, because the cooldown logic and the challenge page work
+	 * in seconds.
 	 *
 	 * @return int seconds
 	 */

--- a/lib/Service/ICodeStorage.php
+++ b/lib/Service/ICodeStorage.php
@@ -12,6 +12,12 @@ namespace OCA\TwoFactorEMail\Service;
 interface ICodeStorage {
 	public function readCode(string $userId): ?string;
 
+	/**
+	 * Seconds elapsed since the currently valid code was stored, or null if no
+	 * valid code exists. Used to enforce the resend cooldown.
+	 */
+	public function secondsSinceLastCode(string $userId): ?int;
+
 	public function writeCode(string $userId, string $code, ?int $createdAt = null): void;
 
 	public function deleteCode(string $userId): void;

--- a/lib/Service/ILoginChallenge.php
+++ b/lib/Service/ILoginChallenge.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\TwoFactorEMail\Service;
 
 use OCA\TwoFactorEMail\Exception\EMailNotSet;
+use OCA\TwoFactorEMail\Exception\ResendTooSoon;
 use OCA\TwoFactorEMail\Exception\SendEMailFailed;
 use OCP\IUser;
 
@@ -24,6 +25,18 @@ interface ILoginChallenge {
 	 * @throws SendEMailFailed
 	 */
 	public function sendChallenge(IUser $user): bool;
+
+	/**
+	 * Discard the current code and send a fresh one on the user's explicit
+	 * request, throttled by the configured resend cooldown.
+	 *
+	 * @param IUser $user UID
+	 *
+	 * @throws ResendTooSoon if the cooldown has not elapsed yet
+	 * @throws EMailNotSet
+	 * @throws SendEMailFailed
+	 */
+	public function resendChallenge(IUser $user): void;
 
 	/**
 	 * Verify the challenge code sent to the user by email against the one stored upon sending it.

--- a/lib/Service/ILoginChallenge.php
+++ b/lib/Service/ILoginChallenge.php
@@ -39,6 +39,15 @@ interface ILoginChallenge {
 	public function resendChallenge(IUser $user): void;
 
 	/**
+	 * Seconds the user still has to wait before a resend is allowed (0 if a
+	 * new code can be requested right now). Lets the challenge dialog show a
+	 * live countdown instead of letting the user click and fail.
+	 *
+	 * @param IUser $user UID
+	 */
+	public function secondsUntilResendAllowed(IUser $user): int;
+
+	/**
 	 * Verify the challenge code sent to the user by email against the one stored upon sending it.
 	 *
 	 * @param IUser $user UID

--- a/lib/Service/LoginChallenge.php
+++ b/lib/Service/LoginChallenge.php
@@ -80,7 +80,7 @@ final class LoginChallenge implements ILoginChallenge {
 	 */
 	public function resendChallenge(IUser $user): void {
 		$elapsed = $this->codeStorage->secondsSinceLastCode($user->getUID());
-		$cooldown = $this->settings->getResendMinSeconds();
+		$cooldown = $this->settings->getResendCooldownSeconds();
 		if ($elapsed !== null && $elapsed < $cooldown) {
 			throw new ResendTooSoon($cooldown - $elapsed);
 		}
@@ -96,7 +96,11 @@ final class LoginChallenge implements ILoginChallenge {
 		if ($elapsed === null) {
 			return 0;
 		}
-		return max(0, $this->settings->getResendMinSeconds() - $elapsed);
+		// Cap at the code's remaining validity: once the code expires a resend is
+		// allowed anyway, so the countdown must not outlast the code (relevant
+		// only if an admin sets a cooldown longer than the validity).
+		$cooldown = min($this->settings->getResendCooldownSeconds(), $this->settings->getCodeValidMinutes() * 60);
+		return max(0, $cooldown - $elapsed);
 	}
 
 	public function verifyChallenge(IUser $user, string $submittedCode): bool {

--- a/lib/Service/LoginChallenge.php
+++ b/lib/Service/LoginChallenge.php
@@ -91,6 +91,14 @@ final class LoginChallenge implements ILoginChallenge {
 		$this->sendChallenge($user);
 	}
 
+	public function secondsUntilResendAllowed(IUser $user): int {
+		$elapsed = $this->codeStorage->secondsSinceLastCode($user->getUID());
+		if ($elapsed === null) {
+			return 0;
+		}
+		return max(0, $this->settings->getResendMinSeconds() - $elapsed);
+	}
+
 	public function verifyChallenge(IUser $user, string $submittedCode): bool {
 		$submittedCode = trim($submittedCode);
 		$storedCodeHash = $this->codeStorage->readCode($user->getUID());

--- a/lib/Service/LoginChallenge.php
+++ b/lib/Service/LoginChallenge.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\TwoFactorEMail\Service;
 
 use OCA\TwoFactorEMail\Exception\EMailNotSet;
+use OCA\TwoFactorEMail\Exception\ResendTooSoon;
 use OCA\TwoFactorEMail\Exception\SendEMailFailed;
 use OCP\IUser;
 use OCP\Security\IHasher;
@@ -21,6 +22,7 @@ final class LoginChallenge implements ILoginChallenge {
 		private readonly ICodeStorage $codeStorage,
 		private readonly IEMailSender $emailSender,
 		private readonly IHasher $hasher,
+		private readonly IAppSettings $settings,
 		private readonly LoggerInterface $logger,
 	) {
 	}
@@ -66,6 +68,27 @@ final class LoginChallenge implements ILoginChallenge {
 			]);
 			throw $e;
 		}
+	}
+
+	/**
+	 * Discard the current code (if any) and send a fresh one on the user's
+	 * explicit request, throttled by the configured resend cooldown.
+	 *
+	 * @throws ResendTooSoon if the cooldown since the last code has not elapsed
+	 * @throws EMailNotSet
+	 * @throws SendEMailFailed
+	 */
+	public function resendChallenge(IUser $user): void {
+		$elapsed = $this->codeStorage->secondsSinceLastCode($user->getUID());
+		$cooldown = $this->settings->getResendMinSeconds();
+		if ($elapsed !== null && $elapsed < $cooldown) {
+			throw new ResendTooSoon($cooldown - $elapsed);
+		}
+
+		// Drop the existing code so sendChallenge() generates and sends a new
+		// one — only the new code stays valid.
+		$this->codeStorage->deleteCode($user->getUID());
+		$this->sendChallenge($user);
 	}
 
 	public function verifyChallenge(IUser $user, string $submittedCode): bool {

--- a/lib/Service/LoginChallenge.php
+++ b/lib/Service/LoginChallenge.php
@@ -108,7 +108,7 @@ final class LoginChallenge implements ILoginChallenge {
 	 *
 	 * @throws EMailNotSet
 	 * @throws SendEMailFailed
- */
+	 */
 	private function issueCode(IUser $user): void {
 		$generatedCode = $this->codeGenerator->generateChallengeCode();
 		try {

--- a/lib/Service/LoginChallenge.php
+++ b/lib/Service/LoginChallenge.php
@@ -48,31 +48,13 @@ final class LoginChallenge implements ILoginChallenge {
 			return false;
 		}
 
-		$generatedCode = $this->codeGenerator->generateChallengeCode();
-		try {
-			$this->emailSender->sendChallengeEMail($user, $generatedCode);
-
-			// Only store the code if it could be sent.
-			$this->codeStorage->writeCode($user->getUID(), $this->hasher->hash($generatedCode));
-			return true;
-		} catch (EMailNotSet $e) {
-			$this->logger->warning('Could not send 2FA challenge: No email address configured for user.', [
-				'exception' => $e,
-				'app' => 'twofactor_email',
-			]);
-			throw $e;
-		} catch (SendEMailFailed $e) {
-			$this->logger->error('Failed to send 2FA challenge email due to a mailer error.', [
-				'exception' => $e,
-				'app' => 'twofactor_email',
-			]);
-			throw $e;
-		}
+		$this->issueCode($user);
+		return true;
 	}
 
 	/**
-	 * Discard the current code (if any) and send a fresh one on the user's
-	 * explicit request, throttled by the configured resend cooldown.
+	 * Send a fresh code on the user's explicit request, throttled by the configured resend cooldown. The existing code
+	 * is replaced only after the new one has been sent successfully, so a failed send leaves the current code valid.
 	 *
 	 * @throws ResendTooSoon if the cooldown since the last code has not elapsed
 	 * @throws EMailNotSet
@@ -85,10 +67,7 @@ final class LoginChallenge implements ILoginChallenge {
 			throw new ResendTooSoon($cooldown - $elapsed);
 		}
 
-		// Drop the existing code so sendChallenge() generates and sends a new
-		// one — only the new code stays valid.
-		$this->codeStorage->deleteCode($user->getUID());
-		$this->sendChallenge($user);
+		$this->issueCode($user);
 	}
 
 	public function secondsUntilResendAllowed(IUser $user): int {
@@ -96,7 +75,7 @@ final class LoginChallenge implements ILoginChallenge {
 		if ($elapsed === null) {
 			return 0;
 		}
-		// Cap at the code's remaining validity: once the code expires a resend is
+		// Cap at the code's remaining validity: once the code expires, a resend is
 		// allowed anyway, so the countdown must not outlast the code (relevant
 		// only if an admin sets a cooldown longer than the validity).
 		$cooldown = min($this->settings->getResendCooldownSeconds(), $this->settings->getCodeValidMinutes() * 60);
@@ -121,5 +100,33 @@ final class LoginChallenge implements ILoginChallenge {
 			$this->codeStorage->deleteCode($user->getUID());
 		}
 		return $isValid;
+	}
+
+	/**
+	 * Sends a fresh code and only then persists it, overwriting any existing
+	 * code. If sending fails, the previously stored code stays valid.
+	 *
+	 * @throws EMailNotSet
+	 * @throws SendEMailFailed
+ */
+	private function issueCode(IUser $user): void {
+		$generatedCode = $this->codeGenerator->generateChallengeCode();
+		try {
+			$this->emailSender->sendChallengeEMail($user, $generatedCode);
+			// Only store the code if it could be sent.
+			$this->codeStorage->writeCode($user->getUID(), $this->hasher->hash($generatedCode));
+		} catch (EMailNotSet $e) {
+			$this->logger->warning('Could not send 2FA challenge: No email address configured for user.', [
+				'exception' => $e,
+				'app' => 'twofactor_email',
+			]);
+			throw $e;
+		} catch (SendEMailFailed $e) {
+			$this->logger->error('Failed to send 2FA challenge email due to a mailer error.', [
+				'exception' => $e,
+				'app' => 'twofactor_email',
+			]);
+			throw $e;
+		}
 	}
 }

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -27,6 +27,7 @@ final class AdminSettings implements IDelegatedSettings {
 	public function getForm(): TemplateResponse {
 		$this->initialState->provideInitialState('codeLength', $this->appSettings->getCodeLength());
 		$this->initialState->provideInitialState('codeValidMinutes', $this->appSettings->getCodeValidMinutes());
+		$this->initialState->provideInitialState('codeResendMinSeconds', $this->appSettings->getResendMinSeconds());
 		$this->initialState->provideInitialState('eMailSubject', $this->appSettings->getEMailSubject());
 		$this->initialState->provideInitialState('eMailTemplate', $this->appSettings->getEMailTemplate());
 		// Localized default texts, shown as placeholders in the empty form fields

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -27,7 +27,7 @@ final class AdminSettings implements IDelegatedSettings {
 	public function getForm(): TemplateResponse {
 		$this->initialState->provideInitialState('codeLength', $this->appSettings->getCodeLength());
 		$this->initialState->provideInitialState('codeValidMinutes', $this->appSettings->getCodeValidMinutes());
-		$this->initialState->provideInitialState('codeResendMinSeconds', $this->appSettings->getResendMinSeconds());
+		$this->initialState->provideInitialState('codeResendMinutes', $this->appSettings->getResendMinMinutes());
 		$this->initialState->provideInitialState('eMailSubject', $this->appSettings->getEMailSubject());
 		$this->initialState->provideInitialState('eMailTemplate', $this->appSettings->getEMailTemplate());
 		// Localized default texts, shown as placeholders in the empty form fields

--- a/src/LoginChallenge.css
+++ b/src/LoginChallenge.css
@@ -17,6 +17,13 @@
     filter: var(--background-invert-if-bright);
 }
 
-.twofactor_email-resend {
+/* Resend control: a text link (like the dialog's other secondary actions),
+   replaced by a plain countdown hint while the cooldown is running. */
+.twofactor_email-resend-line {
     margin-top: 8px;
+    text-align: center;
+}
+
+.twofactor_email-resend {
+    cursor: pointer;
 }

--- a/src/LoginChallenge.css
+++ b/src/LoginChallenge.css
@@ -16,3 +16,7 @@
     /* noinspection CssUnresolvedCustomProperty */
     filter: var(--background-invert-if-bright);
 }
+
+.twofactor_email-resend {
+    margin-top: 8px;
+}

--- a/src/LoginChallenge.js
+++ b/src/LoginChallenge.js
@@ -34,11 +34,11 @@ document.addEventListener('DOMContentLoaded', () => {
 	}
 
 	const remainingText = (seconds) => {
-		if (seconds >= 60) {
+		if (seconds > 60) {
 			const minutes = Math.ceil(seconds / 60)
-			return n('twofactor_email', 'You can request a new code in %n minute', 'You can request a new code in %n minutes', minutes)
+			return n('twofactor_email', 'You can request a new code in %n minute.', 'You can request a new code in %n minutes.', minutes)
 		}
-		return t('twofactor_email', 'You can request a new code in less than a minute')
+		return t('twofactor_email', 'You can request a new code in <1 minute.')
 	}
 
 	const offerResend = () => {

--- a/src/LoginChallenge.js
+++ b/src/LoginChallenge.js
@@ -7,13 +7,14 @@ import './LoginChallenge.css'
 
 import Axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
-import { t } from '@nextcloud/l10n'
+import { t, n } from '@nextcloud/l10n'
 import Logger from './Logger.js'
 
 // Resend control on the 2FA challenge page (server-rendered template, so plain
 // DOM, not Vue). It shows a clickable "Send a new code" link only while a resend
-// is actually possible; during the cooldown it shows a live countdown instead,
-// so the user never clicks and fails.
+// is actually possible; during the cooldown it shows a countdown instead, so the
+// user never clicks and fails. The remaining time is tracked in seconds (for an
+// accurate "link is back" moment) but displayed coarsely in minutes.
 document.addEventListener('DOMContentLoaded', () => {
 	const line = document.querySelector('.twofactor_email-resend-line')
 	const link = document.querySelector('.twofactor_email-resend')
@@ -32,6 +33,15 @@ document.addEventListener('DOMContentLoaded', () => {
 		}
 	}
 
+	// Coarse, minute-level wording — seconds are not shown to the user.
+	const remainingText = (seconds) => {
+		if (seconds >= 60) {
+			const minutes = Math.ceil(seconds / 60)
+			return n('twofactor_email', 'You can request a new code in %n minute', 'You can request a new code in %n minutes', minutes)
+		}
+		return t('twofactor_email', 'You can request a new code in less than a minute')
+	}
+
 	// Offer the clickable resend link and clear any status text.
 	const offerResend = () => {
 		clearTimer()
@@ -39,9 +49,8 @@ document.addEventListener('DOMContentLoaded', () => {
 		link.hidden = false
 	}
 
-	// Hide the link and count down until a resend is allowed again. An optional
-	// first-tick message lets us confirm a just-sent code before the plain
-	// countdown takes over.
+	// Hide the link and count down (second-accurate) until a resend is allowed
+	// again. An optional first message confirms a just-sent code.
 	const startCountdown = (seconds, firstMessage) => {
 		clearTimer()
 		link.hidden = true
@@ -52,8 +61,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				offerResend()
 				return
 			}
-			status.textContent = message
-				|| t('twofactor_email', 'You can request a new code in {seconds} s', { seconds: remaining })
+			status.textContent = message || remainingText(remaining)
 			message = null
 			remaining -= 1
 		}
@@ -72,11 +80,11 @@ document.addEventListener('DOMContentLoaded', () => {
 				input.value = ''
 				input.focus()
 			}
-			startCountdown(cooldown, t('twofactor_email', 'A new code was sent. You can request another in {seconds} s', { seconds: cooldown }))
+			startCountdown(cooldown, t('twofactor_email', 'A new code was sent. Only the new code is valid now.'))
 		} catch (error) {
 			const data = error.response && error.response.data
 			if (error.response && error.response.status === 429) {
-				// Cooldown not elapsed; retryAfter comes from our controller.
+				// Cooldown not elapsed; retryAfter (seconds) comes from our controller.
 				startCountdown((data && data.retryAfter) || cooldown)
 			} else if (data && data.error === 'no-email') {
 				status.textContent = t('twofactor_email', 'No email address is configured for your account.')

--- a/src/LoginChallenge.js
+++ b/src/LoginChallenge.js
@@ -10,54 +10,89 @@ import { generateUrl } from '@nextcloud/router'
 import { t } from '@nextcloud/l10n'
 import Logger from './Logger.js'
 
-// Wire up the "Send a new code" button on the 2FA challenge page. The page is
-// server-rendered (templates/LoginChallenge.php), so this is plain DOM, not Vue.
+// Resend control on the 2FA challenge page (server-rendered template, so plain
+// DOM, not Vue). It shows a clickable "Send a new code" link only while a resend
+// is actually possible; during the cooldown it shows a live countdown instead,
+// so the user never clicks and fails.
 document.addEventListener('DOMContentLoaded', () => {
-	const button = document.querySelector('.twofactor_email-resend')
+	const line = document.querySelector('.twofactor_email-resend-line')
+	const link = document.querySelector('.twofactor_email-resend')
 	const status = document.querySelector('.twofactor_email-resend-status')
-	if (!button || !status) {
+	if (!line || !link || !status) {
 		return
 	}
 
-	const showStatus = (message) => {
-		status.textContent = message
-		status.hidden = false
+	const cooldown = Number(line.dataset.cooldown) || 0
+	let timer = null
+
+	const clearTimer = () => {
+		if (timer !== null) {
+			window.clearInterval(timer)
+			timer = null
+		}
 	}
 
-	/**
-	 * Disable the button for the given number of seconds (resend cooldown).
-	 *
-	 * @param {number} seconds time until the button becomes usable again
-	 */
-	const disableFor = (seconds) => {
-		button.disabled = true
-		window.setTimeout(() => { button.disabled = false }, seconds * 1000)
+	// Offer the clickable resend link and clear any status text.
+	const offerResend = () => {
+		clearTimer()
+		status.textContent = ''
+		link.hidden = false
 	}
 
-	button.addEventListener('click', async () => {
-		button.disabled = true
+	// Hide the link and count down until a resend is allowed again. An optional
+	// first-tick message lets us confirm a just-sent code before the plain
+	// countdown takes over.
+	const startCountdown = (seconds, firstMessage) => {
+		clearTimer()
+		link.hidden = true
+		let remaining = Math.max(0, Math.floor(seconds))
+		let message = firstMessage
+		const render = () => {
+			if (remaining <= 0) {
+				offerResend()
+				return
+			}
+			status.textContent = message
+				|| t('twofactor_email', 'You can request a new code in {seconds} s', { seconds: remaining })
+			message = null
+			remaining -= 1
+		}
+		render()
+		timer = window.setInterval(render, 1000)
+	}
+
+	link.addEventListener('click', async (event) => {
+		event.preventDefault()
+		clearTimer()
+		link.hidden = true
 		try {
 			await Axios.post(generateUrl('/apps/twofactor_email/challenge/resend'))
-			showStatus(t('twofactor_email', 'A new code was sent. Only the new code is valid now.'))
 			const input = document.querySelector('.twofactor_email-challenge-form input[name="challenge"]')
 			if (input) {
 				input.value = ''
 				input.focus()
 			}
-			button.disabled = false
+			startCountdown(cooldown, t('twofactor_email', 'A new code was sent. You can request another in {seconds} s', { seconds: cooldown }))
 		} catch (error) {
 			const data = error.response && error.response.data
 			if (error.response && error.response.status === 429) {
-				const retryAfter = (data && data.retryAfter) || 60
-				showStatus(t('twofactor_email', 'Please wait {seconds} seconds before requesting a new code.', { seconds: retryAfter }))
-				disableFor(retryAfter)
+				// Cooldown not elapsed; retryAfter comes from our controller.
+				startCountdown((data && data.retryAfter) || cooldown)
 			} else if (data && data.error === 'no-email') {
-				showStatus(t('twofactor_email', 'No email address is configured for your account.'))
+				status.textContent = t('twofactor_email', 'No email address is configured for your account.')
 			} else {
 				Logger.error('failed to resend two-factor email code', error)
-				showStatus(t('twofactor_email', 'The code could not be sent. Please try again later.'))
-				button.disabled = false
+				status.textContent = t('twofactor_email', 'The code could not be sent. Please try again later.')
+				link.hidden = false
 			}
 		}
 	})
+
+	// Initial state from the server-rendered cooldown.
+	const availableIn = Number(line.dataset.availableIn) || 0
+	if (availableIn > 0) {
+		startCountdown(availableIn)
+	} else {
+		offerResend()
+	}
 })

--- a/src/LoginChallenge.js
+++ b/src/LoginChallenge.js
@@ -4,3 +4,60 @@
  */
 
 import './LoginChallenge.css'
+
+import Axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
+import { t } from '@nextcloud/l10n'
+import Logger from './Logger.js'
+
+// Wire up the "Send a new code" button on the 2FA challenge page. The page is
+// server-rendered (templates/LoginChallenge.php), so this is plain DOM, not Vue.
+document.addEventListener('DOMContentLoaded', () => {
+	const button = document.querySelector('.twofactor_email-resend')
+	const status = document.querySelector('.twofactor_email-resend-status')
+	if (!button || !status) {
+		return
+	}
+
+	const showStatus = (message) => {
+		status.textContent = message
+		status.hidden = false
+	}
+
+	/**
+	 * Disable the button for the given number of seconds (resend cooldown).
+	 *
+	 * @param {number} seconds time until the button becomes usable again
+	 */
+	const disableFor = (seconds) => {
+		button.disabled = true
+		window.setTimeout(() => { button.disabled = false }, seconds * 1000)
+	}
+
+	button.addEventListener('click', async () => {
+		button.disabled = true
+		try {
+			await Axios.post(generateUrl('/apps/twofactor_email/challenge/resend'))
+			showStatus(t('twofactor_email', 'A new code was sent. Only the new code is valid now.'))
+			const input = document.querySelector('.twofactor_email-challenge-form input[name="challenge"]')
+			if (input) {
+				input.value = ''
+				input.focus()
+			}
+			button.disabled = false
+		} catch (error) {
+			const data = error.response && error.response.data
+			if (error.response && error.response.status === 429) {
+				const retryAfter = (data && data.retryAfter) || 60
+				showStatus(t('twofactor_email', 'Please wait {seconds} seconds before requesting a new code.', { seconds: retryAfter }))
+				disableFor(retryAfter)
+			} else if (data && data.error === 'no-email') {
+				showStatus(t('twofactor_email', 'No email address is configured for your account.'))
+			} else {
+				Logger.error('failed to resend two-factor email code', error)
+				showStatus(t('twofactor_email', 'The code could not be sent. Please try again later.'))
+				button.disabled = false
+			}
+		}
+	})
+})

--- a/src/LoginChallenge.js
+++ b/src/LoginChallenge.js
@@ -33,7 +33,6 @@ document.addEventListener('DOMContentLoaded', () => {
 		}
 	}
 
-	// Coarse, minute-level wording — seconds are not shown to the user.
 	const remainingText = (seconds) => {
 		if (seconds >= 60) {
 			const minutes = Math.ceil(seconds / 60)
@@ -42,7 +41,6 @@ document.addEventListener('DOMContentLoaded', () => {
 		return t('twofactor_email', 'You can request a new code in less than a minute')
 	}
 
-	// Offer the clickable resend link and clear any status text.
 	const offerResend = () => {
 		clearTimer()
 		status.textContent = ''

--- a/src/LoginChallenge.js
+++ b/src/LoginChallenge.js
@@ -38,7 +38,10 @@ document.addEventListener('DOMContentLoaded', () => {
 			const minutes = Math.ceil(seconds / 60)
 			return n('twofactor_email', 'You can request a new code in %n minute.', 'You can request a new code in %n minutes.', minutes)
 		}
-		return t('twofactor_email', 'You can request a new code in <1 minute.')
+		// sanitize: false keeps the literal "<"; sanitize would turn it into "&lt;".
+		// Safe only because the result is assigned via textContent below, which never
+		// parses HTML. Do not reuse this string with innerHTML.
+		return t('twofactor_email', 'You can request a new code in <1 minute.', {}, { sanitize: false })
 	}
 
 	const offerResend = () => {

--- a/src/Store.js
+++ b/src/Store.js
@@ -54,6 +54,7 @@ export const useAdminSettingsStore = defineStore('adminSettings', {
 	state: () => ({
 		codeLength: null,
 		codeValidMinutes: null,
+		codeResendMinSeconds: null,
 		eMailSubject: null,
 		eMailTemplate: null,
 		error: false,
@@ -77,6 +78,7 @@ export const useAdminSettingsStore = defineStore('adminSettings', {
 			const result = await persistAdminSettings({
 				codeLength: this.codeLength,
 				codeValidMinutes: this.codeValidMinutes,
+				resendMinSeconds: this.codeResendMinSeconds,
 				eMailSubject: this.eMailSubject,
 				eMailTemplate: this.eMailTemplate,
 			})
@@ -84,6 +86,7 @@ export const useAdminSettingsStore = defineStore('adminSettings', {
 			this.$patch({
 				codeLength: result.codeLength ?? this.codeLength,
 				codeValidMinutes: result.codeValidMinutes ?? this.codeValidMinutes,
+				codeResendMinSeconds: result.codeResendMinSeconds ?? this.codeResendMinSeconds,
 				eMailSubject: result.eMailSubject ?? this.eMailSubject,
 				eMailTemplate: result.eMailTemplate ?? this.eMailTemplate,
 				error: result.error,
@@ -98,6 +101,7 @@ export const useAdminSettingsStore = defineStore('adminSettings', {
 				this.$patch({
 					codeLength: result.codeLength,
 					codeValidMinutes: result.codeValidMinutes,
+					codeResendMinSeconds: result.codeResendMinSeconds,
 					eMailSubject: result.eMailSubject,
 					eMailTemplate: result.eMailTemplate,
 					error: null,

--- a/src/Store.js
+++ b/src/Store.js
@@ -54,7 +54,7 @@ export const useAdminSettingsStore = defineStore('adminSettings', {
 	state: () => ({
 		codeLength: null,
 		codeValidMinutes: null,
-		codeResendMinSeconds: null,
+		codeResendMinutes: null,
 		eMailSubject: null,
 		eMailTemplate: null,
 		error: false,
@@ -78,7 +78,7 @@ export const useAdminSettingsStore = defineStore('adminSettings', {
 			const result = await persistAdminSettings({
 				codeLength: this.codeLength,
 				codeValidMinutes: this.codeValidMinutes,
-				resendMinSeconds: this.codeResendMinSeconds,
+				resendMinutes: this.codeResendMinutes,
 				eMailSubject: this.eMailSubject,
 				eMailTemplate: this.eMailTemplate,
 			})
@@ -86,7 +86,7 @@ export const useAdminSettingsStore = defineStore('adminSettings', {
 			this.$patch({
 				codeLength: result.codeLength ?? this.codeLength,
 				codeValidMinutes: result.codeValidMinutes ?? this.codeValidMinutes,
-				codeResendMinSeconds: result.codeResendMinSeconds ?? this.codeResendMinSeconds,
+				codeResendMinutes: result.codeResendMinutes ?? this.codeResendMinutes,
 				eMailSubject: result.eMailSubject ?? this.eMailSubject,
 				eMailTemplate: result.eMailTemplate ?? this.eMailTemplate,
 				error: result.error,
@@ -101,7 +101,7 @@ export const useAdminSettingsStore = defineStore('adminSettings', {
 				this.$patch({
 					codeLength: result.codeLength,
 					codeValidMinutes: result.codeValidMinutes,
-					codeResendMinSeconds: result.codeResendMinSeconds,
+					codeResendMinutes: result.codeResendMinutes,
 					eMailSubject: result.eMailSubject,
 					eMailTemplate: result.eMailTemplate,
 					error: null,

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -147,10 +147,10 @@ async function onReset() {
 	color: var(--color-text-maxcontrast, gray);
 }
 
-/* The two short numeric fields share one row (stacked on narrow screens) */
+/* The short numeric fields share one row (stacked on narrow screens) */
 .numeric-fields-grid {
 	display: grid;
-	grid-template-columns: repeat(2, minmax(0, 1fr));
+	grid-template-columns: repeat(3, minmax(0, 1fr));
 	gap: 0 16px;
 }
 

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -11,7 +11,7 @@
 			<!-- Group: authentication code -->
 			<fieldset class="settings-group">
 				<h3>{{ t('twofactor_email', 'Authentication code') }}</h3>
-				<p>{{ t('twofactor_email', 'Length and validity of the one-time codes sent via email.') }}</p>
+				<p>{{ t('twofactor_email', 'Length and validity of the one-time codes sent via email, and how soon a user may request a new code.') }}</p>
 
 				<div class="numeric-fields-grid">
 					<LabeledField id="twofactor_email-codeLength"
@@ -25,6 +25,12 @@
 								  :label="t('twofactor_email', 'Validity (minutes)')"
 								  :loading="loading"
 								  :result="successRefs.codeValidMinutes"
+								  type="number" />
+					<LabeledField id="twofactor_email-codeResendMinSeconds"
+								  v-model="inputValues.codeResendMinSeconds"
+								  :label="t('twofactor_email', 'Resend cooldown (seconds)')"
+								  :loading="loading"
+								  :result="successRefs.codeResendMinSeconds"
 								  type="number" />
 				</div>
 			</fieldset>
@@ -80,7 +86,7 @@ import Logger from '../Logger.js'
 
 const resetting = ref(false)
 
-const fieldKeys = ['codeLength', 'codeValidMinutes', 'eMailSubject', 'eMailTemplate']
+const fieldKeys = ['codeLength', 'codeValidMinutes', 'codeResendMinSeconds', 'eMailSubject', 'eMailTemplate']
 
 const store = useAdminSettingsStore()
 store.loadInitialState(...fieldKeys)

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -26,11 +26,11 @@
 								  :loading="loading"
 								  :result="successRefs.codeValidMinutes"
 								  type="number" />
-					<LabeledField id="twofactor_email-codeResendMinSeconds"
-								  v-model="inputValues.codeResendMinSeconds"
-								  :label="t('twofactor_email', 'Resend cooldown (seconds)')"
+					<LabeledField id="twofactor_email-codeResendMinutes"
+								  v-model="inputValues.codeResendMinutes"
+								  :label="t('twofactor_email', 'Resend cooldown (minutes)')"
 								  :loading="loading"
-								  :result="successRefs.codeResendMinSeconds"
+								  :result="successRefs.codeResendMinutes"
 								  type="number" />
 				</div>
 			</fieldset>
@@ -86,7 +86,7 @@ import Logger from '../Logger.js'
 
 const resetting = ref(false)
 
-const fieldKeys = ['codeLength', 'codeValidMinutes', 'codeResendMinSeconds', 'eMailSubject', 'eMailTemplate']
+const fieldKeys = ['codeLength', 'codeValidMinutes', 'codeResendMinutes', 'eMailSubject', 'eMailTemplate']
 
 const store = useAdminSettingsStore()
 store.loadInitialState(...fieldKeys)

--- a/templates/LoginChallenge.php
+++ b/templates/LoginChallenge.php
@@ -54,4 +54,8 @@ $error = $_['error'] ?? null; // caught and passed in Provider/TwoFactorEMail.ph
 			<?php p($l->t('Submit')); ?>
 		</button>
 	</form>
+	<button type="button" class="twofactor_email-resend">
+		<?php p($l->t('Send a new code')); ?>
+	</button>
+	<p class="twofactor_email-resend-status" aria-live="polite" hidden></p>
 <?php endif; ?>

--- a/templates/LoginChallenge.php
+++ b/templates/LoginChallenge.php
@@ -27,6 +27,8 @@ if (!empty($codeLength)) {
 
 $newCodeWasSent = $_['newCodeWasSent']; // provided in Provider/TwoFactorEMail.php
 $error = $_['error'] ?? null; // caught and passed in Provider/TwoFactorEMail.php
+$resendCooldown = (int)($_['resendCooldown'] ?? 0); // full cooldown in seconds
+$resendAvailableIn = (int)($_['resendAvailableIn'] ?? 0); // seconds left before a resend is allowed
 ?>
 <img class="two-factor-icon twofactor_email-challenge-icon"
 	 src="<?php print_unescaped(image_path('twofactor_email', 'app.svg')); ?>" alt="Icon depicting a letter and a user">
@@ -54,8 +56,8 @@ $error = $_['error'] ?? null; // caught and passed in Provider/TwoFactorEMail.ph
 			<?php p($l->t('Submit')); ?>
 		</button>
 	</form>
-	<button type="button" class="twofactor_email-resend">
-		<?php p($l->t('Send a new code')); ?>
-	</button>
-	<p class="twofactor_email-resend-status" aria-live="polite" hidden></p>
+	<p class="twofactor_email-resend-line" data-cooldown="<?php p($resendCooldown) ?>" data-available-in="<?php p($resendAvailableIn) ?>">
+		<a href="#" class="twofactor_email-resend" hidden><?php p($l->t('Send a new code')); ?></a>
+		<span class="twofactor_email-resend-status" aria-live="polite"></span>
+	</p>
 <?php endif; ?>

--- a/tests/Unit/Controller/AdminSettingsControllerTest.php
+++ b/tests/Unit/Controller/AdminSettingsControllerTest.php
@@ -39,10 +39,11 @@ class AdminSettingsControllerTest extends TestCase {
 	public function testSavePersistsAllSettings(): void {
 		$this->appSettings->expects($this->once())->method('setCodeLength')->with(6);
 		$this->appSettings->expects($this->once())->method('setCodeValidMinutes')->with(10);
+		$this->appSettings->expects($this->once())->method('setResendMinSeconds')->with(30);
 		$this->appSettings->expects($this->once())->method('setEMailSubject')->with('Subject');
 		$this->appSettings->expects($this->once())->method('setEMailTemplate')->with('Use {code}');
 
-		$response = $this->controller->save(6, 10, 'Use {code}', 'Subject');
+		$response = $this->controller->save(6, 10, 'Use {code}', 'Subject', 30);
 
 		$this->assertEquals(Http::STATUS_OK, $response->getStatus());
 	}
@@ -84,6 +85,13 @@ class AdminSettingsControllerTest extends TestCase {
 
 		$this->assertEquals(Http::STATUS_BAD_REQUEST, $response->getStatus());
 		$this->assertEquals(['error' => 'email-subject-too-long'], $response->getData());
+	}
+
+	public function testSaveRejectsOutOfRangeResendCooldown(): void {
+		$response = $this->controller->save(6, 10, '', '', 99999);
+
+		$this->assertEquals(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertEquals(['error' => 'resend-min-seconds-out-of-range'], $response->getData());
 	}
 
 	public function testResetDelegatesToAppSettings(): void {

--- a/tests/Unit/Controller/AdminSettingsControllerTest.php
+++ b/tests/Unit/Controller/AdminSettingsControllerTest.php
@@ -50,7 +50,7 @@ class AdminSettingsControllerTest extends TestCase {
 
 	public function testSaveAcceptsEmptyTemplateParts(): void {
 		// Empty parts mean "use the localized default" and are always valid
-		$response = $this->controller->save(6, 10, '', '');
+		$response = $this->controller->save(6, 10, '', '', 30);
 
 		$this->assertEquals(Http::STATUS_OK, $response->getStatus());
 	}
@@ -58,7 +58,7 @@ class AdminSettingsControllerTest extends TestCase {
 	public function testSaveRejectsCustomBodyWithoutCode(): void {
 		$this->appSettings->expects($this->never())->method('setEMailTemplate');
 
-		$response = $this->controller->save(6, 10, 'body without placeholder', '');
+		$response = $this->controller->save(6, 10, 'body without placeholder', '', 30);
 
 		$this->assertEquals(Http::STATUS_BAD_REQUEST, $response->getStatus());
 		$this->assertEquals(['error' => 'email-code-placeholder-missing'], $response->getData());
@@ -67,21 +67,21 @@ class AdminSettingsControllerTest extends TestCase {
 	public function testSaveRejectsMultiLineSubject(): void {
 		$this->appSettings->expects($this->never())->method('setEMailSubject');
 
-		$response = $this->controller->save(6, 10, '', "evil\r\nBcc: spy@example.com");
+		$response = $this->controller->save(6, 10, '', "evil\r\nBcc: spy@example.com", 30);
 
 		$this->assertEquals(Http::STATUS_BAD_REQUEST, $response->getStatus());
 		$this->assertEquals(['error' => 'email-subject-must-be-single-line'], $response->getData());
 	}
 
 	public function testSaveRejectsOutOfRangeCodeLength(): void {
-		$response = $this->controller->save(3, 10, '', '');
+		$response = $this->controller->save(3, 10, '', '', 30);
 
 		$this->assertEquals(Http::STATUS_BAD_REQUEST, $response->getStatus());
 		$this->assertEquals(['error' => 'code-length-out-of-range'], $response->getData());
 	}
 
 	public function testSaveRejectsOverlongSubject(): void {
-		$response = $this->controller->save(6, 10, '', str_repeat('x', 256));
+		$response = $this->controller->save(6, 10, '', str_repeat('x', 256), 30);
 
 		$this->assertEquals(Http::STATUS_BAD_REQUEST, $response->getStatus());
 		$this->assertEquals(['error' => 'email-subject-too-long'], $response->getData());

--- a/tests/Unit/Controller/AdminSettingsControllerTest.php
+++ b/tests/Unit/Controller/AdminSettingsControllerTest.php
@@ -39,7 +39,7 @@ class AdminSettingsControllerTest extends TestCase {
 	public function testSavePersistsAllSettings(): void {
 		$this->appSettings->expects($this->once())->method('setCodeLength')->with(6);
 		$this->appSettings->expects($this->once())->method('setCodeValidMinutes')->with(10);
-		$this->appSettings->expects($this->once())->method('setResendMinSeconds')->with(30);
+		$this->appSettings->expects($this->once())->method('setResendMinMinutes')->with(30);
 		$this->appSettings->expects($this->once())->method('setEMailSubject')->with('Subject');
 		$this->appSettings->expects($this->once())->method('setEMailTemplate')->with('Use {code}');
 
@@ -91,7 +91,7 @@ class AdminSettingsControllerTest extends TestCase {
 		$response = $this->controller->save(6, 10, '', '', 99999);
 
 		$this->assertEquals(Http::STATUS_BAD_REQUEST, $response->getStatus());
-		$this->assertEquals(['error' => 'resend-min-seconds-out-of-range'], $response->getData());
+		$this->assertEquals(['error' => 'resend-minutes-out-of-range'], $response->getData());
 	}
 
 	public function testResetDelegatesToAppSettings(): void {

--- a/tests/Unit/Controller/ChallengeControllerTest.php
+++ b/tests/Unit/Controller/ChallengeControllerTest.php
@@ -48,11 +48,17 @@ class ChallengeControllerTest extends TestCase {
 		);
 	}
 
+	/**
+	 * @throws Exception
+	 */
 	private function withEnabledUser(): void {
 		$this->userSession->method('getUser')->willReturn($this->createMock(IUser::class));
 		$this->stateManager->method('isEnabled')->willReturn(true);
 	}
 
+	/**
+	 * @throws Exception
+	 */
 	public function testResendSendsCode(): void {
 		$this->withEnabledUser();
 		$this->challenge->expects($this->once())->method('resendChallenge');
@@ -63,6 +69,9 @@ class ChallengeControllerTest extends TestCase {
 		$this->assertEquals(['status' => 'sent'], $response->getData());
 	}
 
+	/**
+	 * @throws Exception
+	 */
 	public function testResendReportsCooldown(): void {
 		$this->withEnabledUser();
 		$this->challenge->method('resendChallenge')->willThrowException(new ResendTooSoon(42));
@@ -73,6 +82,9 @@ class ChallengeControllerTest extends TestCase {
 		$this->assertEquals(['error' => 'too-soon', 'retryAfter' => 42], $response->getData());
 	}
 
+	/**
+	 * @throws Exception
+	 */
 	public function testResendRejectedWhenEmailProviderDisabled(): void {
 		$this->userSession->method('getUser')->willReturn($this->createMock(IUser::class));
 		$this->stateManager->method('isEnabled')->willReturn(false);
@@ -92,6 +104,9 @@ class ChallengeControllerTest extends TestCase {
 		$this->assertEquals(Http::STATUS_UNAUTHORIZED, $response->getStatus());
 	}
 
+	/**
+	 * @throws Exception
+	 */
 	public function testResendReportsMissingEmail(): void {
 		$this->withEnabledUser();
 		$this->challenge->method('resendChallenge')
@@ -103,6 +118,9 @@ class ChallengeControllerTest extends TestCase {
 		$this->assertEquals(['error' => 'no-email'], $response->getData());
 	}
 
+	/**
+	 * @throws Exception
+	 */
 	public function testResendReportsSendFailure(): void {
 		$this->withEnabledUser();
 		$this->challenge->method('resendChallenge')->willThrowException(new SendEMailFailed());

--- a/tests/Unit/Controller/ChallengeControllerTest.php
+++ b/tests/Unit/Controller/ChallengeControllerTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Test\Unit\Controller;
+
+use OCA\TwoFactorEMail\AppInfo\Application;
+use OCA\TwoFactorEMail\Controller\ChallengeController;
+use OCA\TwoFactorEMail\Exception\EMailNotSet;
+use OCA\TwoFactorEMail\Exception\ResendTooSoon;
+use OCA\TwoFactorEMail\Exception\SendEMailFailed;
+use OCA\TwoFactorEMail\Service\ILoginChallenge;
+use OCA\TwoFactorEMail\Service\IStateManager;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ChallengeControllerTest extends TestCase {
+	private IUserSession&MockObject $userSession;
+	private ILoginChallenge&MockObject $challenge;
+	private IStateManager&MockObject $stateManager;
+
+	private ChallengeController $controller;
+
+	/**
+	 * @throws Exception
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->challenge = $this->createMock(ILoginChallenge::class);
+		$this->stateManager = $this->createMock(IStateManager::class);
+
+		$this->controller = new ChallengeController(
+			Application::APP_ID,
+			$this->createMock(IRequest::class),
+			$this->userSession,
+			$this->challenge,
+			$this->stateManager,
+		);
+	}
+
+	private function withEnabledUser(): void {
+		$this->userSession->method('getUser')->willReturn($this->createMock(IUser::class));
+		$this->stateManager->method('isEnabled')->willReturn(true);
+	}
+
+	public function testResendSendsCode(): void {
+		$this->withEnabledUser();
+		$this->challenge->expects($this->once())->method('resendChallenge');
+
+		$response = $this->controller->resend();
+
+		$this->assertEquals(Http::STATUS_OK, $response->getStatus());
+		$this->assertEquals(['status' => 'sent'], $response->getData());
+	}
+
+	public function testResendReportsCooldown(): void {
+		$this->withEnabledUser();
+		$this->challenge->method('resendChallenge')->willThrowException(new ResendTooSoon(42));
+
+		$response = $this->controller->resend();
+
+		$this->assertEquals(Http::STATUS_TOO_MANY_REQUESTS, $response->getStatus());
+		$this->assertEquals(['error' => 'too-soon', 'retryAfter' => 42], $response->getData());
+	}
+
+	public function testResendRejectedWhenEmailProviderDisabled(): void {
+		$this->userSession->method('getUser')->willReturn($this->createMock(IUser::class));
+		$this->stateManager->method('isEnabled')->willReturn(false);
+		$this->challenge->expects($this->never())->method('resendChallenge');
+
+		$response = $this->controller->resend();
+
+		$this->assertEquals(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertEquals(['error' => 'not-enabled'], $response->getData());
+	}
+
+	public function testResendWithoutUser(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+
+		$response = $this->controller->resend();
+
+		$this->assertEquals(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+	}
+
+	public function testResendReportsMissingEmail(): void {
+		$this->withEnabledUser();
+		$this->challenge->method('resendChallenge')
+			->willThrowException(new EMailNotSet($this->createMock(IUser::class)));
+
+		$response = $this->controller->resend();
+
+		$this->assertEquals(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertEquals(['error' => 'no-email'], $response->getData());
+	}
+
+	public function testResendReportsSendFailure(): void {
+		$this->withEnabledUser();
+		$this->challenge->method('resendChallenge')->willThrowException(new SendEMailFailed());
+
+		$response = $this->controller->resend();
+
+		$this->assertEquals(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		$this->assertEquals(['error' => 'send-failed'], $response->getData());
+	}
+}

--- a/tests/Unit/Mail/TemplateRendererTest.php
+++ b/tests/Unit/Mail/TemplateRendererTest.php
@@ -120,7 +120,7 @@ class TemplateRendererTest extends TestCase {
 			['&nbsp;', false],
 			[
 				// Logo-only paragraph: no plain text counterpart at all
-				'<img src="https://cloud.example/themes/logo.png" alt="Example Cloud" style="max-width:250px;max-width:min(250px, 20%);max-height:250px">',
+				'<img src="https://cloud.example/themes/logo.png" alt="Example Cloud" style="max-width:min(250px, 20%);max-height:250px">',
 				false,
 			],
 			[

--- a/tests/Unit/Service/AppSettingsTest.php
+++ b/tests/Unit/Service/AppSettingsTest.php
@@ -88,20 +88,28 @@ class AppSettingsTest extends TestCase {
 		$this->settings->setCodeLength(8);
 	}
 
-	public function testGetResendMinSecondsDefaultsTo60(): void {
+	public function testGetResendMinMinutesDefaultsToOne(): void {
 		$this->appConfig->method('getValueInt')
-			->with(Application::APP_ID, 'resend_min_seconds', 60)
-			->willReturn(60);
+			->with(Application::APP_ID, 'resend_min_minutes', 1)
+			->willReturn(1);
 
-		$this->assertSame(60, $this->settings->getResendMinSeconds());
+		$this->assertSame(1, $this->settings->getResendMinMinutes());
 	}
 
-	public function testSetResendMinSecondsWritesToAppConfig(): void {
+	public function testGetResendCooldownSecondsConvertsMinutes(): void {
+		$this->appConfig->method('getValueInt')
+			->with(Application::APP_ID, 'resend_min_minutes', 1)
+			->willReturn(2);
+
+		$this->assertSame(120, $this->settings->getResendCooldownSeconds());
+	}
+
+	public function testSetResendMinMinutesWritesToAppConfig(): void {
 		$this->appConfig->expects($this->once())
 			->method('setValueInt')
-			->with(Application::APP_ID, 'resend_min_seconds', 30);
+			->with(Application::APP_ID, 'resend_min_minutes', 30);
 
-		$this->settings->setResendMinSeconds(30);
+		$this->settings->setResendMinMinutes(30);
 	}
 
 	public function testResetToDefaultsDeletesAllKeys(): void {

--- a/tests/Unit/Service/AppSettingsTest.php
+++ b/tests/Unit/Service/AppSettingsTest.php
@@ -88,8 +88,24 @@ class AppSettingsTest extends TestCase {
 		$this->settings->setCodeLength(8);
 	}
 
+	public function testGetResendMinSecondsDefaultsTo60(): void {
+		$this->appConfig->method('getValueInt')
+			->with(Application::APP_ID, 'resend_min_seconds', 60)
+			->willReturn(60);
+
+		$this->assertSame(60, $this->settings->getResendMinSeconds());
+	}
+
+	public function testSetResendMinSecondsWritesToAppConfig(): void {
+		$this->appConfig->expects($this->once())
+			->method('setValueInt')
+			->with(Application::APP_ID, 'resend_min_seconds', 30);
+
+		$this->settings->setResendMinSeconds(30);
+	}
+
 	public function testResetToDefaultsDeletesAllKeys(): void {
-		$this->appConfig->expects($this->exactly(4))->method('deleteKey');
+		$this->appConfig->expects($this->exactly(5))->method('deleteKey');
 
 		$this->settings->resetToDefaults();
 	}

--- a/tests/Unit/Service/CodeStorageTest.php
+++ b/tests/Unit/Service/CodeStorageTest.php
@@ -48,6 +48,6 @@ class CodeStorageTest extends TestCase {
 
 		$this->assertIsInt($elapsed);
 		$this->assertGreaterThanOrEqual(0, $elapsed);
-		$this->assertLessThan(5, $elapsed);
+		$this->assertLessThan(60, $elapsed);
 	}
 }

--- a/tests/Unit/Service/CodeStorageTest.php
+++ b/tests/Unit/Service/CodeStorageTest.php
@@ -16,7 +16,6 @@ use PHPUnit\Framework\TestCase;
 
 class CodeStorageTest extends TestCase {
 	private IUserConfig&MockObject $config;
-	private IAppSettings&MockObject $settings;
 
 	private CodeStorage $storage;
 
@@ -27,10 +26,10 @@ class CodeStorageTest extends TestCase {
 		parent::setUp();
 
 		$this->config = $this->createMock(IUserConfig::class);
-		$this->settings = $this->createMock(IAppSettings::class);
-		$this->settings->method('getCodeValidMinutes')->willReturn(10);
+		$settings = $this->createMock(IAppSettings::class);
+		$settings->method('getCodeValidMinutes')->willReturn(10);
 
-		$this->storage = new CodeStorage($this->settings, $this->config);
+		$this->storage = new CodeStorage($settings, $this->config);
 	}
 
 	public function testSecondsSinceLastCodeIsNullWithoutValidCode(): void {

--- a/tests/Unit/Service/CodeStorageTest.php
+++ b/tests/Unit/Service/CodeStorageTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Test\Unit\Service;
+
+use OCA\TwoFactorEMail\Service\CodeStorage;
+use OCA\TwoFactorEMail\Service\IAppSettings;
+use OCP\Config\IUserConfig;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class CodeStorageTest extends TestCase {
+	private IUserConfig&MockObject $config;
+	private IAppSettings&MockObject $settings;
+
+	private CodeStorage $storage;
+
+	/**
+	 * @throws Exception
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->config = $this->createMock(IUserConfig::class);
+		$this->settings = $this->createMock(IAppSettings::class);
+		$this->settings->method('getCodeValidMinutes')->willReturn(10);
+
+		$this->storage = new CodeStorage($this->settings, $this->config);
+	}
+
+	public function testSecondsSinceLastCodeIsNullWithoutValidCode(): void {
+		// created_at = 0 → older than the validity window → no valid code
+		$this->config->method('getValueInt')->willReturn(0);
+		$this->config->method('getValueString')->willReturn('');
+
+		$this->assertNull($this->storage->secondsSinceLastCode('alice'));
+	}
+
+	public function testSecondsSinceLastCodeForFreshCode(): void {
+		$this->config->method('getValueInt')->willReturn(time());
+		$this->config->method('getValueString')->willReturn('hashed-code');
+
+		$elapsed = $this->storage->secondsSinceLastCode('alice');
+
+		$this->assertIsInt($elapsed);
+		$this->assertGreaterThanOrEqual(0, $elapsed);
+		$this->assertLessThan(5, $elapsed);
+	}
+}

--- a/tests/Unit/Service/EMailSenderTest.php
+++ b/tests/Unit/Service/EMailSenderTest.php
@@ -8,6 +8,7 @@
 namespace OCA\TwoFactorEMail\Test\Unit\Service;
 
 use OCA\TwoFactorEMail\Exception\EMailNotSet;
+use OCA\TwoFactorEMail\Exception\SendEMailFailed;
 use OCA\TwoFactorEMail\Mail\TemplateRenderer;
 use OCA\TwoFactorEMail\Service\EMailSender;
 use OCA\TwoFactorEMail\Service\IAppSettings;
@@ -67,6 +68,9 @@ class EMailSenderTest extends TestCase {
 		return $user;
 	}
 
+	/**
+	 * @throws Exception
+	 */
 	private function expectMailWithTemplate(): void {
 		$message = $this->createMock(IMessage::class);
 		$this->mailer->method('createEMailTemplate')->willReturn($this->template);
@@ -74,6 +78,10 @@ class EMailSenderTest extends TestCase {
 		$this->mailer->expects($this->once())->method('send');
 	}
 
+	/**
+	 * @throws SendEMailFailed
+	 * @throws Exception
+	 */
 	public function testThrowsWhenNoEmailIsSet(): void {
 		$this->expectException(EMailNotSet::class);
 
@@ -92,6 +100,11 @@ class EMailSenderTest extends TestCase {
 			});
 	}
 
+	/**
+	 * @throws SendEMailFailed
+	 * @throws EMailNotSet
+	 * @throws Exception
+	 */
 	public function testFallsBackToDefaultsWhenSettingsAreEmpty(): void {
 		// Empty stored values → the localized defaults from IAppSettings are used
 		$this->appSettings->method('getEMailSubject')->willReturn('');
@@ -119,7 +132,7 @@ class EMailSenderTest extends TestCase {
 		$this->assertSame([
 			['&nbsp;', false],
 			[
-				'<img src="https://cloud.example/themes/logo.png" alt="Example Cloud" style="max-width:250px;max-width:min(250px, 20%);max-height:250px">',
+				'<img src="https://cloud.example/themes/logo.png" alt="Example Cloud" style="max-width:min(250px, 20%);max-height:250px">',
 				false,
 			],
 			[
@@ -129,6 +142,11 @@ class EMailSenderTest extends TestCase {
 		], $bodyTexts);
 	}
 
+	/**
+	 * @throws SendEMailFailed
+	 * @throws Exception
+	 * @throws EMailNotSet
+	 */
 	public function testUsesCustomTemplatesAndReplacesAllPlaceholders(): void {
 		$this->appSettings->method('getEMailSubject')->willReturn('Code {code} for {user}');
 		$this->appSettings->method('getEMailTemplate')->willReturn('Use {code} on {cloud} within {validity} minutes.');

--- a/tests/Unit/Service/LoginChallengeTest.php
+++ b/tests/Unit/Service/LoginChallengeTest.php
@@ -41,7 +41,6 @@ class LoginChallengeTest extends TestCase {
 		$this->emailSender = $this->createMock(IEMailSender::class);
 		$this->hasher = $this->createMock(IHasher::class);
 		$this->settings = $this->createMock(IAppSettings::class);
-		$this->settings->method('getResendMinSeconds')->willReturn(60);
 
 		$this->challenge = new LoginChallenge(
 			$this->codeGenerator,
@@ -63,6 +62,7 @@ class LoginChallengeTest extends TestCase {
 	}
 
 	public function testResendIsRejectedWithinCooldown(): void {
+		$this->settings->method('getResendCooldownSeconds')->willReturn(60);
 		$this->codeStorage->method('secondsSinceLastCode')->willReturn(10);
 		$this->codeStorage->expects($this->never())->method('deleteCode');
 		$this->emailSender->expects($this->never())->method('sendChallengeEMail');
@@ -108,6 +108,8 @@ class LoginChallengeTest extends TestCase {
 	}
 
 	public function testSecondsUntilResendAllowedReturnsRemainingCooldown(): void {
+		$this->settings->method('getResendCooldownSeconds')->willReturn(60);
+		$this->settings->method('getCodeValidMinutes')->willReturn(10); // 600s, well above the cooldown
 		$this->codeStorage->method('secondsSinceLastCode')->willReturn(10);
 
 		// cooldown 60 - 10 elapsed = 50
@@ -115,8 +117,21 @@ class LoginChallengeTest extends TestCase {
 	}
 
 	public function testSecondsUntilResendAllowedIsZeroAfterCooldown(): void {
+		$this->settings->method('getResendCooldownSeconds')->willReturn(60);
+		$this->settings->method('getCodeValidMinutes')->willReturn(10);
 		$this->codeStorage->method('secondsSinceLastCode')->willReturn(100);
 
 		$this->assertSame(0, $this->challenge->secondsUntilResendAllowed($this->mockUser()));
+	}
+
+	public function testSecondsUntilResendAllowedIsCappedByCodeValidity(): void {
+		// Cooldown 30 min, but the code is only valid 10 min: the countdown must
+		// not outlast the code, so it caps at the remaining validity.
+		$this->settings->method('getResendCooldownSeconds')->willReturn(1800);
+		$this->settings->method('getCodeValidMinutes')->willReturn(10); // 600s
+		$this->codeStorage->method('secondsSinceLastCode')->willReturn(60);
+
+		// min(1800, 600) - 60 = 540
+		$this->assertSame(540, $this->challenge->secondsUntilResendAllowed($this->mockUser()));
 	}
 }

--- a/tests/Unit/Service/LoginChallengeTest.php
+++ b/tests/Unit/Service/LoginChallengeTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Test\Unit\Service;
+
+use OCA\TwoFactorEMail\Exception\EMailNotSet;
+use OCA\TwoFactorEMail\Exception\ResendTooSoon;
+use OCA\TwoFactorEMail\Service\IAppSettings;
+use OCA\TwoFactorEMail\Service\ICodeGenerator;
+use OCA\TwoFactorEMail\Service\ICodeStorage;
+use OCA\TwoFactorEMail\Service\IEMailSender;
+use OCA\TwoFactorEMail\Service\LoginChallenge;
+use OCP\IUser;
+use OCP\Security\IHasher;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class LoginChallengeTest extends TestCase {
+	private ICodeGenerator&MockObject $codeGenerator;
+	private ICodeStorage&MockObject $codeStorage;
+	private IEMailSender&MockObject $emailSender;
+	private IHasher&MockObject $hasher;
+	private IAppSettings&MockObject $settings;
+
+	private LoginChallenge $challenge;
+
+	/**
+	 * @throws Exception
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->codeGenerator = $this->createMock(ICodeGenerator::class);
+		$this->codeStorage = $this->createMock(ICodeStorage::class);
+		$this->emailSender = $this->createMock(IEMailSender::class);
+		$this->hasher = $this->createMock(IHasher::class);
+		$this->settings = $this->createMock(IAppSettings::class);
+		$this->settings->method('getResendMinSeconds')->willReturn(60);
+
+		$this->challenge = new LoginChallenge(
+			$this->codeGenerator,
+			$this->codeStorage,
+			$this->emailSender,
+			$this->hasher,
+			$this->settings,
+			$this->createMock(LoggerInterface::class),
+		);
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	private function mockUser(): IUser&MockObject {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		return $user;
+	}
+
+	public function testResendIsRejectedWithinCooldown(): void {
+		$this->codeStorage->method('secondsSinceLastCode')->willReturn(10);
+		$this->codeStorage->expects($this->never())->method('deleteCode');
+		$this->emailSender->expects($this->never())->method('sendChallengeEMail');
+
+		try {
+			$this->challenge->resendChallenge($this->mockUser());
+			$this->fail('Expected ResendTooSoon');
+		} catch (ResendTooSoon $e) {
+			$this->assertSame(50, $e->retryAfterSeconds);
+		}
+	}
+
+	public function testResendDiscardsOldCodeAndSendsFreshOne(): void {
+		$this->codeStorage->method('secondsSinceLastCode')->willReturn(null);
+		// sendChallenge() finds no stored code after the delete and proceeds
+		$this->codeStorage->method('readCode')->willReturn(null);
+		$this->codeGenerator->method('generateChallengeCode')->willReturn('654321');
+		$this->hasher->method('hash')->willReturn('hashed');
+
+		$this->codeStorage->expects($this->once())->method('deleteCode')->with('alice');
+		$this->emailSender->expects($this->once())->method('sendChallengeEMail')->with($this->anything(), '654321');
+		$this->codeStorage->expects($this->once())->method('writeCode')->with('alice', 'hashed');
+
+		$this->challenge->resendChallenge($this->mockUser());
+	}
+
+	public function testResendPropagatesEMailNotSet(): void {
+		$this->codeStorage->method('secondsSinceLastCode')->willReturn(null);
+		$this->codeStorage->method('readCode')->willReturn(null);
+		$this->codeGenerator->method('generateChallengeCode')->willReturn('654321');
+		$user = $this->mockUser();
+		$this->emailSender->method('sendChallengeEMail')->willThrowException(new EMailNotSet($user));
+
+		$this->expectException(EMailNotSet::class);
+
+		$this->challenge->resendChallenge($user);
+	}
+}

--- a/tests/Unit/Service/LoginChallengeTest.php
+++ b/tests/Unit/Service/LoginChallengeTest.php
@@ -9,6 +9,7 @@ namespace OCA\TwoFactorEMail\Test\Unit\Service;
 
 use OCA\TwoFactorEMail\Exception\EMailNotSet;
 use OCA\TwoFactorEMail\Exception\ResendTooSoon;
+use OCA\TwoFactorEMail\Exception\SendEMailFailed;
 use OCA\TwoFactorEMail\Service\IAppSettings;
 use OCA\TwoFactorEMail\Service\ICodeGenerator;
 use OCA\TwoFactorEMail\Service\ICodeStorage;
@@ -61,6 +62,11 @@ class LoginChallengeTest extends TestCase {
 		return $user;
 	}
 
+	/**
+	 * @throws SendEMailFailed
+	 * @throws EMailNotSet
+	 * @throws Exception
+	 */
 	public function testResendIsRejectedWithinCooldown(): void {
 		$this->settings->method('getResendCooldownSeconds')->willReturn(60);
 		$this->codeStorage->method('secondsSinceLastCode')->willReturn(10);
@@ -75,47 +81,67 @@ class LoginChallengeTest extends TestCase {
 		}
 	}
 
-	public function testResendDiscardsOldCodeAndSendsFreshOne(): void {
+	/**
+	 * @throws ResendTooSoon
+	 * @throws SendEMailFailed
+	 * @throws Exception
+	 * @throws EMailNotSet
+	 */
+	public function testResendSendsAndStoresFreshCode(): void {
 		$this->codeStorage->method('secondsSinceLastCode')->willReturn(null);
-		// sendChallenge() finds no stored code after the delete and proceeds
-		$this->codeStorage->method('readCode')->willReturn(null);
 		$this->codeGenerator->method('generateChallengeCode')->willReturn('654321');
 		$this->hasher->method('hash')->willReturn('hashed');
 
-		$this->codeStorage->expects($this->once())->method('deleteCode')->with('alice');
+		$this->codeStorage->expects($this->never())->method('deleteCode');
 		$this->emailSender->expects($this->once())->method('sendChallengeEMail')->with($this->anything(), '654321');
 		$this->codeStorage->expects($this->once())->method('writeCode')->with('alice', 'hashed');
 
 		$this->challenge->resendChallenge($this->mockUser());
 	}
 
+	/**
+	 * @throws ResendTooSoon
+	 * @throws SendEMailFailed
+	 * @throws Exception
+	 */
 	public function testResendPropagatesEMailNotSet(): void {
 		$this->codeStorage->method('secondsSinceLastCode')->willReturn(null);
-		$this->codeStorage->method('readCode')->willReturn(null);
 		$this->codeGenerator->method('generateChallengeCode')->willReturn('654321');
 		$user = $this->mockUser();
 		$this->emailSender->method('sendChallengeEMail')->willThrowException(new EMailNotSet($user));
+
+		// A failed sending must not touch the stored code, so the previous one stays valid.
+		$this->codeStorage->expects($this->never())->method('writeCode');
+		$this->codeStorage->expects($this->never())->method('deleteCode');
 
 		$this->expectException(EMailNotSet::class);
 
 		$this->challenge->resendChallenge($user);
 	}
 
+	/**
+	 * @throws Exception
+	 */
 	public function testSecondsUntilResendAllowedIsZeroWithoutValidCode(): void {
 		$this->codeStorage->method('secondsSinceLastCode')->willReturn(null);
 
 		$this->assertSame(0, $this->challenge->secondsUntilResendAllowed($this->mockUser()));
 	}
 
+	/**
+	 * @throws Exception
+	 */
 	public function testSecondsUntilResendAllowedReturnsRemainingCooldown(): void {
 		$this->settings->method('getResendCooldownSeconds')->willReturn(60);
 		$this->settings->method('getCodeValidMinutes')->willReturn(10); // 600s, well above the cooldown
 		$this->codeStorage->method('secondsSinceLastCode')->willReturn(10);
 
-		// cooldown 60 - 10 elapsed = 50
 		$this->assertSame(50, $this->challenge->secondsUntilResendAllowed($this->mockUser()));
 	}
 
+	/**
+	 * @throws Exception
+	 */
 	public function testSecondsUntilResendAllowedIsZeroAfterCooldown(): void {
 		$this->settings->method('getResendCooldownSeconds')->willReturn(60);
 		$this->settings->method('getCodeValidMinutes')->willReturn(10);
@@ -124,6 +150,9 @@ class LoginChallengeTest extends TestCase {
 		$this->assertSame(0, $this->challenge->secondsUntilResendAllowed($this->mockUser()));
 	}
 
+	/**
+	 * @throws Exception
+	 */
 	public function testSecondsUntilResendAllowedIsCappedByCodeValidity(): void {
 		// Cooldown 30 min, but the code is only valid 10 min: the countdown must
 		// not outlast the code, so it caps at the remaining validity.

--- a/tests/Unit/Service/LoginChallengeTest.php
+++ b/tests/Unit/Service/LoginChallengeTest.php
@@ -100,4 +100,23 @@ class LoginChallengeTest extends TestCase {
 
 		$this->challenge->resendChallenge($user);
 	}
+
+	public function testSecondsUntilResendAllowedIsZeroWithoutValidCode(): void {
+		$this->codeStorage->method('secondsSinceLastCode')->willReturn(null);
+
+		$this->assertSame(0, $this->challenge->secondsUntilResendAllowed($this->mockUser()));
+	}
+
+	public function testSecondsUntilResendAllowedReturnsRemainingCooldown(): void {
+		$this->codeStorage->method('secondsSinceLastCode')->willReturn(10);
+
+		// cooldown 60 - 10 elapsed = 50
+		$this->assertSame(50, $this->challenge->secondsUntilResendAllowed($this->mockUser()));
+	}
+
+	public function testSecondsUntilResendAllowedIsZeroAfterCooldown(): void {
+		$this->codeStorage->method('secondsSinceLastCode')->willReturn(100);
+
+		$this->assertSame(0, $this->challenge->secondsUntilResendAllowed($this->mockUser()));
+	}
 }


### PR DESCRIPTION
Stacked on #85 (base `enh/more-settings`; GitHub retargets this to `main` once #85 merges).

## What & why
During email 2FA login the app withholds a new code while a valid one is still stored — Nextcloud does not throttle the challenge send path, so this self-guard prevents inbox flooding. The downside: a user who abandoned a login had no way to get a fresh code. This PR adds an explicit **"Send a new code"** button to the challenge dialog.

## How
- `ChallengeController#resend` POST endpoint, reachable during the 2FA-pending state via `#[NoTwoFactorRequired]`; CSRF via the page's request token; `#[UserRateLimit]` backstop and an `IStateManager` guard (email 2FA must be enabled).
- `LoginChallenge::resendChallenge()` enforces a cooldown from the existing stored-code timestamp (`CodeStorage::secondsSinceLastCode()`), discards the old code and reuses `sendChallenge()` — only the new code stays valid.
- New admin setting **Resend cooldown (minutes)** (default 1, range 1–60).
- Challenge template gets the button + status line; `LoginChallenge.js` posts via axios and reports sent / cooldown (429) / errors.

## Tests
Unit tests for `CodeStorage`, `LoginChallenge`, `ChallengeController`; admin-settings tests extended. cs-fixer / psalm / eslint / stylelint / build all green.

## Verified manually
The challenge-page JS runs in the login (guest) context and isn't unit-testable here — Olav confirmed on the test instance that the button sends a fresh code, an immediate second click shows the cooldown hint and a button after more than 1 minute, the old code is rejected after a resend.

## Full Details (in German)
<details>
<summary>Claude Plan</summary>
"Neuen Code senden"-Button mit Rate-Limit im 2FA-Challenge-Dialog

## Context

Heute sendet die App nach dem ersten Code **keinen neuen**, solange ein gültiger
Code gespeichert ist (`LoginChallenge::sendChallenge()` gibt `false` zurück, wenn
`CodeStorage::readCode()` noch etwas liefert). Das ist Absicht: Nextcloud drosselt
den *Versandpfad* nicht (verifiziert an `core/Middleware/TwoFactorMiddleware.php`
und `TwoFactorChallengeController` stable34 — nur `solveChallenge` hat
`#[UserRateLimit(5,100)]`; das Rendern/Senden via `showChallenge` GET ist
ungedrosselt, Abbrüche werden gar nicht gezählt). Ohne diese Selbstsperre würde
ein simpler Reload das Postfach fluten.

Nutzer haben dadurch aber keine Möglichkeit, nach einem Abbruch bewusst einen
frischen Code anzufordern. Gewünscht: ein **expliziter Button** im Challenge-Dialog,
der — durch ein eigenes Mindest-Intervall ratenbegrenzt — den alten Code verwirft
und einen neuen sendet ("dann gilt nur der neue").

Branch (erster Ausführungsschritt, in Plan-Mode nicht anlegbar):
`enh/resend-challenge-code` (Schema `enh/…`).

## Machbarkeit (verifiziert)

- `TwoFactorMiddleware::beforeController()` blockiert im 2FA-Pending-Zustand jeden
  Nicht-Challenge-Controller — **außer** die Methode trägt
  `#[NoTwoFactorRequired]` (OCP-Attribut, in `vendor/nextcloud/ocp/...` vorhanden).
  Ein eigener App-Endpunkt ist damit erreichbar; `userSession->getUser()` liefert
  den Pre-2FA-Nutzer.
- Die Challenge-Seite lädt `core/twofactor-request-token` → `OC.requestToken`
  vorhanden, `@nextcloud/axios` hängt den CSRF-Token automatisch an. Kein
  `#[NoCSRFRequired]` nötig.
- `@nextcloud/axios` + `@nextcloud/router` sind Dependencies; Vite-Entry
  `login_challenge` existiert.

## Approach

### 1. Neue Admin-Einstellung "Mindest-Intervall zwischen Sendungen" (Sekunden)

Exakt dem Muster der bestehenden numerischen Settings folgen (frisch konsolidiert in
`lib/Service/AppSettings.php`):

- `AppSettings`: `private const KEY_RESEND_MIN_SECONDS = 'resend_min_minutes'`,
  `DEFAULT_RESEND_MIN_MINUTES = 1`; Getter `getResendMinMinutes()`, Setter
  `setResendMinMinutes()`, in `resetToDefaults()` aufnehmen. Methoden auch in
  `IAppSettings`.
- `AdminSettingsController`: neuer int-Parameter in `save()`, Validierung
  (`MIN_RESEND_MIN_MINUTES = 1`, `MAX_RESEND_MIN_MINUTES = 60`, Fehlerschlüssel
  `resend-min-minutes-out-of-range`), in `currentSettingsResponse()` ergänzen,
  über `setResendMinMinutes()` schreiben.
- `lib/Settings/AdminSettings.php`: `provideInitialState('codeResendMinMinutes', …)`.
- Frontend: in `src/components/AdminSettings.vue` Key `codeResendMinMinutes` in
  `fieldKeys` + dritte `<LabeledField type="number">` in der Gruppe
  "Authentication code" (Grid bricht auf 2+1 um, ok); `src/Store.js` (state +
  save-Payload + reset-Patch). Label z.B. "Resend cooldown (minutes)".

### 2. Service: Force-Resend mit Cooldown

- `ICodeStorage`/`CodeStorage`: neue Methode `secondsSinceLastCode(string $userId): ?int`
  — `null`, wenn kein gültiger Code existiert, sonst `time() - created_at`. Nutzt das
  vorhandene `KEY_CREATED_AT` und dieselbe Ablauf-Logik wie `readCode()`.

- Neue Exception `lib/Exception/ResendTooSoon.php` mit `getRetryAfterSeconds(): int`.

- `ILoginChallenge`/`LoginChallenge`: neue Methode `resendChallenge(IUser $user): void`:

  ```
  $age = $this->codeStorage->secondsSinceLastCode($uid);
  $cooldown = $this->settings->getResendMinMinutes();
  if ($age !== null && $age < $cooldown) { throw new ResendTooSoon($cooldown - $age); }
  $this->codeStorage->deleteCode($uid);
  $this->sendChallenge($user); // regeneriert + sendet (findet keinen Code mehr)
  ```

  Reuse von `sendChallenge()` (DRY); `EMailNotSet`/`SendEMailFailed` propagieren.
  `LoginChallenge` braucht dafür `IAppSettings` (Cooldown-Wert) — Konstruktor ergänzen.

### 3. Controller + Route

- Neuer `lib/Controller/ChallengeController.php` mit `resend()`:
  - Attribute `#[NoAdminRequired]`, `#[NoTwoFactorRequired]`,
    `#[UserRateLimit(limit: 1, period: 60)]` (Defense-in-depth zusätzlich zum
    Cooldown).
  - Guard: nur senden, wenn E-Mail-2FA für den Nutzer aktiv ist
    (`IStateManager::isEnabled($user)`), sonst 400.
  - Ergebnis → JSON: `{status:'sent'}` (200) | `ResendTooSoon` →
    `{error:'too-soon', retryAfter:N}` (429) | `EMailNotSet` →
    `{error:'no-email'}` | `SendEMailFailed` → `{error:'send-failed'}` (500).
  - Injiziert `IUserSession`, `ILoginChallenge`, `IStateManager`.
- `appinfo/routes.php`: `['name' => 'Challenge#resend', 'url' => '/challenge/resend', 'verb' => 'POST']`.

### 4. Template + JS

- `templates/LoginChallenge.php`: im fehlerfreien Zweig unter dem Formular einen
  Button "Send a new code" rendern (immer sichtbar) plus ein leeres
  Status-`<p>`-Element. Text der Einleitung adaptiv: wenn `!$newCodeWasSent`
  ("Es wurde bereits ein Code gesendet."), sonst "Ein neuer Code wurde gesendet."
- `src/LoginChallenge.js` (aktuell nur CSS-Import): Klick-Handler ergänzen —
  POST via `axios.post(generateUrl('/apps/twofactor_email/challenge/resend'))`;
  bei Erfolg Statusmeldung + Eingabefeld leeren; bei 429 "in N s erneut möglich"
  + Button kurz deaktivieren; bei Fehler Meldung. `t()` aus `@nextcloud/l10n`.
    Vanilla DOM (die Challenge-Seite ist kein Vue-App-Mount).

### 5. Tests

- `tests/Unit/Service/CodeStorageTest.php` (neu): `secondsSinceLastCode` (kein
  Code → null; frischer Code → ~0; abgelaufen → null).
- `tests/Unit/Service/LoginChallengeTest.php` (neu): `resendChallenge` wirft
  `ResendTooSoon` im Cooldown; löscht+sendet außerhalb; propagiert `EMailNotSet`.
- `tests/Unit/Controller/ChallengeControllerTest.php` (neu): Mapping der Fälle auf
  Status/JSON; Guard bei deaktiviertem E-Mail-2FA.
- Bestehender `AdminSettingsControllerTest` um den neuen Setting-Parameter ergänzen.

## Out of scope

- Der Login-**Setup**-Flow (Vue, `LoginSetup`) bleibt unverändert; nur der
  Challenge-/Login-Dialog bekommt den Button.
- CHANGELOG-Eintrag und Versions-Bump macht Olav (gekürzter Stil).

## Reuse

- `LoginChallenge::sendChallenge()` (regeneriert/sendet) — wird von
  `resendChallenge()` wiederverwendet.
- `CodeStorage` `KEY_CREATED_AT`/Ablauf-Logik für `secondsSinceLastCode()`.
- Settings-Muster aus `AppSettings`/`AdminSettingsController`/`AdminSettings.vue`/
  `Store.js` (numerische Felder codeLength/codeValidMinutes) 1:1 für das neue Feld.
- `@nextcloud/axios` + `generateUrl` (`@nextcloud/router`) wie in
  `src/services/StateManager.js`.

## Verification

1. `composer run cs:fix`, `composer run lint`,
   `php-legacy vendor/bin/psalm.phar --threads=1 --no-progress --no-cache`,
   `composer run test:unit`, `npm run lint`, `npm run stylelint`, `npm run build`.
2. `krankerl package`, Deploy auf mars, dann manuell:
   - 1. Faktor anmelden → Challenge-Seite (Code kommt). Button sichtbar.
   - Sofort klicken → "in N Minuten erneut möglich" (Cooldown greift, keine Mail).
   - Nach Ablauf des Cooldowns klicken → neue Mail; alten Code eingeben → abgelehnt,
     neuen Code → akzeptiert ("nur der neue gilt").
   - Admin-Setting "Resend cooldown" ändern → Verhalten ändert sich entsprechend;
     Reset stellt 1 min wieder her.
</details>
