### PR TITLE
Allow admins to show and change the app settings via occ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Admin settings: show and change all app settings via occ
+
 ## 3.2.0 (2026-07-05)
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -71,6 +71,7 @@ at the bottom of "Personal Settings/Security").]]></description>
     </two-factor-providers>
     <commands>
         <command>OCA\TwoFactorEMail\Command\CleanUp</command>
+        <command>OCA\TwoFactorEMail\Command\Settings</command>
     </commands>
     <settings>
         <admin>OCA\TwoFactorEMail\Settings\AdminSettings</admin>

--- a/lib/Command/Settings.php
+++ b/lib/Command/Settings.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Command;
+
+use OCA\TwoFactorEMail\Service\AppSettings;
+use OCA\TwoFactorEMail\Service\IAppSettings;
+use OCA\TwoFactorEMail\Service\SettingsValidator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Shows or changes the app-wide admin settings, validated by the same
+ * rules as the admin settings web UI.
+ */
+final class Settings extends Command {
+
+	private const INT_SETTINGS = ['code_length', 'code_valid_minutes', 'resend_min_minutes'];
+	private const STRING_SETTINGS = ['email_subject', 'email_template'];
+
+	public function __construct(
+		private readonly IAppSettings $appSettings,
+		private readonly SettingsValidator $validator,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		$settings = implode(', ', [...self::INT_SETTINGS, ...self::STRING_SETTINGS]);
+		$this
+			->setName('twofactor_email:settings')
+			->setDescription('Show or change the app-wide settings of the Two-Factor Email provider.')
+			->addArgument('key', InputArgument::OPTIONAL, 'Setting to show or change: ' . $settings)
+			->addArgument('value', InputArgument::OPTIONAL, 'New value for the setting; an empty email_subject or email_template means: use the localized default text')
+			->addOption('reset', null, InputOption::VALUE_NONE, 'Reset all settings to their defaults');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$io = new SymfonyStyle($input, $output);
+		$key = $input->getArgument('key');
+		$value = $input->getArgument('value');
+
+		if ($input->getOption('reset')) {
+			if ($key !== null) {
+				$io->error('The --reset option resets all settings and cannot be combined with a key. To reset a single text setting, set it to an empty string; for the numeric settings, set the default value.');
+				return Command::INVALID;
+			}
+			$this->appSettings->resetToDefaults();
+			$io->success('All settings were reset to their defaults.');
+			return Command::SUCCESS;
+		}
+
+		if ($key === null) {
+			$this->listSettings($io);
+			return Command::SUCCESS;
+		}
+
+		if (!in_array($key, self::INT_SETTINGS, true) && !in_array($key, self::STRING_SETTINGS, true)) {
+			$io->error('Unknown setting "' . $key . '". Valid settings are: ' . implode(', ', [...self::INT_SETTINGS, ...self::STRING_SETTINGS]) . '.');
+			return Command::INVALID;
+		}
+
+		if ($value === null) {
+			$output->writeln((string)$this->currentValue($key));
+			return Command::SUCCESS;
+		}
+
+		return $this->setValue($io, $key, $value);
+	}
+
+	private function listSettings(SymfonyStyle $io): void {
+		$emptyMeansDefault = '(empty — the localized default text is used)';
+		$io->table(['Setting', 'Value', 'Default'], [
+			['code_length', $this->appSettings->getCodeLength(), AppSettings::DEFAULT_CODE_LENGTH],
+			['code_valid_minutes', $this->appSettings->getCodeValidMinutes(), AppSettings::DEFAULT_CODE_VALID_MINUTES],
+			['resend_min_minutes', $this->appSettings->getResendMinMinutes(), AppSettings::DEFAULT_RESEND_MIN_MINUTES],
+			['email_subject', $this->appSettings->getEMailSubject() ?: $emptyMeansDefault, $this->preview($this->appSettings->getDefaultEMailSubject())],
+			['email_template', $this->preview($this->appSettings->getEMailTemplate()) ?: $emptyMeansDefault, $this->preview($this->appSettings->getDefaultEMailBody())],
+		]);
+	}
+
+	/**
+	 * Shortens a possibly long, multi-line text to a single table-friendly line.
+	 */
+	private function preview(string $text): string {
+		$singleLine = str_replace(["\r\n", "\n"], ' ⏎ ', $text);
+		if (mb_strlen($singleLine) > 60) {
+			return mb_substr($singleLine, 0, 59) . '…';
+		}
+		return $singleLine;
+	}
+
+	private function currentValue(string $key): int|string {
+		return match ($key) {
+			'code_length' => $this->appSettings->getCodeLength(),
+			'code_valid_minutes' => $this->appSettings->getCodeValidMinutes(),
+			'resend_min_minutes' => $this->appSettings->getResendMinMinutes(),
+			'email_subject' => $this->appSettings->getEMailSubject(),
+			'email_template' => $this->appSettings->getEMailTemplate(),
+		};
+	}
+
+	private function setValue(SymfonyStyle $io, string $key, string $value): int {
+		if (in_array($key, self::INT_SETTINGS, true) && preg_match('/^\d+$/', $value) !== 1) {
+			$io->error($key . ' must be a non-negative integer.');
+			return Command::INVALID;
+		}
+
+		// Validate the full settings set with the new value in place, so all
+		// rules stay in one place (SettingsValidator, shared with the web UI).
+		$codeLength = $this->appSettings->getCodeLength();
+		$codeValidMinutes = $this->appSettings->getCodeValidMinutes();
+		$resendMinutes = $this->appSettings->getResendMinMinutes();
+		$eMailSubject = $this->appSettings->getEMailSubject();
+		$eMailTemplate = $this->appSettings->getEMailTemplate();
+		match ($key) {
+			'code_length' => $codeLength = (int)$value,
+			'code_valid_minutes' => $codeValidMinutes = (int)$value,
+			'resend_min_minutes' => $resendMinutes = (int)$value,
+			'email_subject' => $eMailSubject = $value,
+			'email_template' => $eMailTemplate = $value,
+		};
+
+		$errors = $this->validator->validate($codeLength, $codeValidMinutes, $resendMinutes, $eMailSubject, $eMailTemplate);
+		if (!empty($errors)) {
+			foreach ($errors as $error) {
+				$io->error($this->errorMessage($error));
+			}
+			return Command::INVALID;
+		}
+
+		match ($key) {
+			'code_length' => $this->appSettings->setCodeLength((int)$value),
+			'code_valid_minutes' => $this->appSettings->setCodeValidMinutes((int)$value),
+			'resend_min_minutes' => $this->appSettings->setResendMinMinutes((int)$value),
+			'email_subject' => $this->appSettings->setEMailSubject($value),
+			'email_template' => $this->appSettings->setEMailTemplate($value),
+		};
+		$io->success($key . ' was set to "' . $value . '".');
+		return Command::SUCCESS;
+	}
+
+	/**
+	 * Turns a validation error key into a human-readable message.
+	 */
+	private function errorMessage(string $errorKey): string {
+		return match ($errorKey) {
+			'code-length-out-of-range' => sprintf('code_length must be between %d and %d.', SettingsValidator::MIN_CODE_LENGTH, SettingsValidator::MAX_CODE_LENGTH),
+			'code-valid-minutes-out-of-range' => sprintf('code_valid_minutes must be between %d and %d.', SettingsValidator::MIN_CODE_VALID_MINUTES, SettingsValidator::MAX_CODE_VALID_MINUTES),
+			'resend-minutes-out-of-range' => sprintf('resend_min_minutes must be between %d and %d.', SettingsValidator::MIN_RESEND_MINUTES, SettingsValidator::MAX_RESEND_MINUTES),
+			'email-subject-too-long' => sprintf('email_subject must not exceed %d characters.', SettingsValidator::MAX_EMAIL_SUBJECT_LENGTH),
+			'email-subject-must-be-single-line' => 'email_subject must be a single line.',
+			'email-template-too-long' => sprintf('email_template must not exceed %d characters.', SettingsValidator::MAX_EMAIL_TEMPLATE_LENGTH),
+			'email-code-placeholder-missing' => 'email_template must contain the {code} placeholder.',
+			default => $errorKey,
+		};
+	}
+}

--- a/lib/Controller/AdminSettingsController.php
+++ b/lib/Controller/AdminSettingsController.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace OCA\TwoFactorEMail\Controller;
 
 use OCA\TwoFactorEMail\Service\IAppSettings;
+use OCA\TwoFactorEMail\Service\SettingsValidator;
 use OCA\TwoFactorEMail\Settings\AdminSettings;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
@@ -24,26 +25,11 @@ use OCP\IRequest;
 
 final class AdminSettingsController extends ALoginSetupController {
 
-	// Allowed range for the number of digits in a 2FA code
-	private const MIN_CODE_LENGTH = 4;
-	private const MAX_CODE_LENGTH = 16;
-
-	// Allowed range for code validity in minutes
-	private const MIN_CODE_VALID_MINUTES = 1;
-	private const MAX_CODE_VALID_MINUTES = 44640; // 1 month
-
-	// Allowed range for the resend cooldown in minutes
-	private const MIN_RESEND_MINUTES = 1;
-	private const MAX_RESEND_MINUTES = 60; // 1 hour
-
-	// Maximum allowed lengths for the email template parts in characters
-	private const MAX_EMAIL_SUBJECT_LENGTH = 255;
-	private const MAX_EMAIL_TEMPLATE_LENGTH = 10000;
-
 	public function __construct(
 		string $appName,
 		IRequest $request,
 		private readonly IAppSettings $appSettings,
+		private readonly SettingsValidator $validator,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -56,7 +42,7 @@ final class AdminSettingsController extends ALoginSetupController {
 		string $eMailSubject,
 		int $resendMinutes,
 	): JSONResponse {
-		$errors = $this->validate($codeLength, $codeValidMinutes, $eMailTemplate, $eMailSubject, $resendMinutes);
+		$errors = $this->validator->validate($codeLength, $codeValidMinutes, $resendMinutes, $eMailSubject, $eMailTemplate);
 		if (!empty($errors)) {
 			return new JSONResponse(['error' => implode(', ', $errors)], Http::STATUS_BAD_REQUEST);
 		}
@@ -68,52 +54,6 @@ final class AdminSettingsController extends ALoginSetupController {
 		$this->appSettings->setEMailTemplate($eMailTemplate);
 
 		return $this->currentSettingsResponse();
-	}
-
-	/**
-	 * Validates the given admin settings.
-	 * Returns an array of error strings, or an empty array if all values are valid.
-	 *
-	 * @param int $codeLength
-	 * @param int $codeValidMinutes
-	 * @param string $eMailTemplate
-	 * @param string $eMailSubject
-	 * @param int $resendMinutes
-	 * @return string[]
-	 */
-	private function validate(
-		int $codeLength,
-		int $codeValidMinutes,
-		string $eMailTemplate,
-		string $eMailSubject,
-		int $resendMinutes,
-	): array {
-		$errors = [];
-		if ($codeLength < self::MIN_CODE_LENGTH || $codeLength > self::MAX_CODE_LENGTH) {
-			$errors[] = 'code-length-out-of-range';
-		}
-		if ($codeValidMinutes < self::MIN_CODE_VALID_MINUTES || $codeValidMinutes > self::MAX_CODE_VALID_MINUTES) {
-			$errors[] = 'code-valid-minutes-out-of-range';
-		}
-		if ($resendMinutes < self::MIN_RESEND_MINUTES || $resendMinutes > self::MAX_RESEND_MINUTES) {
-			$errors[] = 'resend-minutes-out-of-range';
-		}
-		if (strlen($eMailSubject) > self::MAX_EMAIL_SUBJECT_LENGTH) {
-			$errors[] = 'email-subject-too-long';
-		}
-		// Guard against header injection — the subject must stay a single line
-		if (preg_match('/[\r\n]/', $eMailSubject) === 1) {
-			$errors[] = 'email-subject-must-be-single-line';
-		}
-		if (strlen($eMailTemplate) > self::MAX_EMAIL_TEMPLATE_LENGTH) {
-			$errors[] = 'email-template-too-long';
-		}
-		// The code must reach the user: an empty body falls back to the default
-		// which contains {code}, so only a customized body can lose it.
-		if ($eMailTemplate !== '' && !str_contains($eMailTemplate, '{code}')) {
-			$errors[] = 'email-code-placeholder-missing';
-		}
-		return $errors;
 	}
 
 	#[AuthorizedAdminSetting(settings: AdminSettings::class)]

--- a/lib/Service/AppSettings.php
+++ b/lib/Service/AppSettings.php
@@ -25,9 +25,10 @@ final class AppSettings implements IAppSettings {
 	// Default values — used when no value has been stored in the app config.
 	// For the email template parts an empty string means: use the localized
 	// default text (the getDefault* methods below).
-	private const DEFAULT_CODE_LENGTH = 6;
-	private const DEFAULT_CODE_VALID_MINUTES = 10;
-	private const DEFAULT_RESEND_MIN_MINUTES = 1;
+	// The int defaults are public so the occ settings command can display them.
+	public const DEFAULT_CODE_LENGTH = 6;
+	public const DEFAULT_CODE_VALID_MINUTES = 10;
+	public const DEFAULT_RESEND_MIN_MINUTES = 1;
 	private const DEFAULT_EMAIL_SUBJECT = '';
 	private const DEFAULT_EMAIL_TEMPLATE = '';
 

--- a/lib/Service/SettingsValidator.php
+++ b/lib/Service/SettingsValidator.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Service;
+
+/**
+ * Validates the admin settings. Used by the admin settings web UI and the
+ * occ command, so both enforce the same limits.
+ */
+final class SettingsValidator {
+
+	// Allowed range for the number of digits in a 2FA code
+	public const MIN_CODE_LENGTH = 4;
+	public const MAX_CODE_LENGTH = 16;
+
+	// Allowed range for code validity in minutes
+	public const MIN_CODE_VALID_MINUTES = 1;
+	public const MAX_CODE_VALID_MINUTES = 44640; // 1 month
+
+	// Allowed range for the resend cooldown in minutes
+	public const MIN_RESEND_MINUTES = 1;
+	public const MAX_RESEND_MINUTES = 60; // 1 hour
+
+	// Maximum allowed lengths for the email template parts in characters
+	public const MAX_EMAIL_SUBJECT_LENGTH = 255;
+	public const MAX_EMAIL_TEMPLATE_LENGTH = 10000;
+
+	/**
+	 * Validates the given admin settings.
+	 * Returns an array of error keys, or an empty array if all values are valid.
+	 *
+	 * @return string[]
+	 */
+	public function validate(
+		int $codeLength,
+		int $codeValidMinutes,
+		int $resendMinutes,
+		string $eMailSubject,
+		string $eMailTemplate,
+	): array {
+		$errors = [];
+		if ($codeLength < self::MIN_CODE_LENGTH || $codeLength > self::MAX_CODE_LENGTH) {
+			$errors[] = 'code-length-out-of-range';
+		}
+		if ($codeValidMinutes < self::MIN_CODE_VALID_MINUTES || $codeValidMinutes > self::MAX_CODE_VALID_MINUTES) {
+			$errors[] = 'code-valid-minutes-out-of-range';
+		}
+		if ($resendMinutes < self::MIN_RESEND_MINUTES || $resendMinutes > self::MAX_RESEND_MINUTES) {
+			$errors[] = 'resend-minutes-out-of-range';
+		}
+		if (strlen($eMailSubject) > self::MAX_EMAIL_SUBJECT_LENGTH) {
+			$errors[] = 'email-subject-too-long';
+		}
+		// Guard against header injection — the subject must stay a single line
+		if (preg_match('/[\r\n]/', $eMailSubject) === 1) {
+			$errors[] = 'email-subject-must-be-single-line';
+		}
+		if (strlen($eMailTemplate) > self::MAX_EMAIL_TEMPLATE_LENGTH) {
+			$errors[] = 'email-template-too-long';
+		}
+		// The code must reach the user: an empty body falls back to the default
+		// which contains {code}, so only a customized body can lose it.
+		if ($eMailTemplate !== '' && !str_contains($eMailTemplate, '{code}')) {
+			$errors[] = 'email-code-placeholder-missing';
+		}
+		return $errors;
+	}
+}

--- a/tests/Unit/Command/SettingsTest.php
+++ b/tests/Unit/Command/SettingsTest.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Test\Unit\Command;
+
+use OCA\TwoFactorEMail\Command\Settings;
+use OCA\TwoFactorEMail\Service\IAppSettings;
+use OCA\TwoFactorEMail\Service\SettingsValidator;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class SettingsTest extends TestCase {
+	private IAppSettings&MockObject $appSettings;
+
+	private CommandTester $tester;
+
+	/**
+	 * @throws Exception
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->appSettings = $this->createMock(IAppSettings::class);
+		// Valid current values; single tests override where needed
+		$this->appSettings->method('getCodeLength')->willReturn(6);
+		$this->appSettings->method('getCodeValidMinutes')->willReturn(10);
+		$this->appSettings->method('getResendMinMinutes')->willReturn(1);
+		$this->appSettings->method('getEMailSubject')->willReturn('');
+		$this->appSettings->method('getEMailTemplate')->willReturn('');
+		$this->appSettings->method('getDefaultEMailSubject')->willReturn('Login attempt for {user} @ {cloud}');
+		$this->appSettings->method('getDefaultEMailBody')->willReturn("{logo}\n\nYour code is {code}.");
+
+		$this->tester = new CommandTester(new Settings($this->appSettings, new SettingsValidator()));
+	}
+
+	public function testListsAllSettingsWithoutArguments(): void {
+		$exitCode = $this->tester->execute([]);
+
+		$this->assertSame(Command::SUCCESS, $exitCode);
+		$display = $this->tester->getDisplay();
+		foreach (['code_length', 'code_valid_minutes', 'resend_min_minutes', 'email_subject', 'email_template'] as $key) {
+			$this->assertStringContainsString($key, $display);
+		}
+	}
+
+	public function testShowsSingleValue(): void {
+		$exitCode = $this->tester->execute(['key' => 'code_length']);
+
+		$this->assertSame(Command::SUCCESS, $exitCode);
+		$this->assertSame('6', trim($this->tester->getDisplay()));
+	}
+
+	public function testSetsValidIntValue(): void {
+		$this->appSettings->expects($this->once())->method('setCodeLength')->with(8);
+
+		$exitCode = $this->tester->execute(['key' => 'code_length', 'value' => '8']);
+
+		$this->assertSame(Command::SUCCESS, $exitCode);
+	}
+
+	public function testSetsValidTemplate(): void {
+		$this->appSettings->expects($this->once())->method('setEMailTemplate')->with('Use {code} now');
+
+		$exitCode = $this->tester->execute(['key' => 'email_template', 'value' => 'Use {code} now']);
+
+		$this->assertSame(Command::SUCCESS, $exitCode);
+	}
+
+	public function testRejectsOutOfRangeValue(): void {
+		$this->appSettings->expects($this->never())->method('setCodeLength');
+
+		$exitCode = $this->tester->execute(['key' => 'code_length', 'value' => '3']);
+
+		$this->assertSame(Command::INVALID, $exitCode);
+		$this->assertStringContainsString('between 4 and 16', $this->tester->getDisplay());
+	}
+
+	public function testRejectsNonIntegerValueForIntSetting(): void {
+		$this->appSettings->expects($this->never())->method('setCodeLength');
+
+		$exitCode = $this->tester->execute(['key' => 'code_length', 'value' => 'six']);
+
+		$this->assertSame(Command::INVALID, $exitCode);
+		$this->assertStringContainsString('integer', $this->tester->getDisplay());
+	}
+
+	public function testRejectsTemplateWithoutCodePlaceholder(): void {
+		$this->appSettings->expects($this->never())->method('setEMailTemplate');
+
+		$exitCode = $this->tester->execute(['key' => 'email_template', 'value' => 'no placeholder here']);
+
+		$this->assertSame(Command::INVALID, $exitCode);
+		$this->assertStringContainsString('{code}', $this->tester->getDisplay());
+	}
+
+	public function testRejectsUnknownKey(): void {
+		$exitCode = $this->tester->execute(['key' => 'no_such_setting']);
+
+		$this->assertSame(Command::INVALID, $exitCode);
+		$this->assertStringContainsString('Unknown setting', $this->tester->getDisplay());
+	}
+
+	public function testResetResetsAllSettings(): void {
+		$this->appSettings->expects($this->once())->method('resetToDefaults');
+
+		$exitCode = $this->tester->execute(['--reset' => true]);
+
+		$this->assertSame(Command::SUCCESS, $exitCode);
+	}
+
+	public function testResetRejectsCombinationWithKey(): void {
+		$this->appSettings->expects($this->never())->method('resetToDefaults');
+
+		$exitCode = $this->tester->execute(['key' => 'code_length', '--reset' => true]);
+
+		$this->assertSame(Command::INVALID, $exitCode);
+	}
+}

--- a/tests/Unit/Controller/AdminSettingsControllerTest.php
+++ b/tests/Unit/Controller/AdminSettingsControllerTest.php
@@ -10,6 +10,7 @@ namespace OCA\TwoFactorEMail\Test\Unit\Controller;
 use OCA\TwoFactorEMail\AppInfo\Application;
 use OCA\TwoFactorEMail\Controller\AdminSettingsController;
 use OCA\TwoFactorEMail\Service\IAppSettings;
+use OCA\TwoFactorEMail\Service\SettingsValidator;
 use OCP\AppFramework\Http;
 use OCP\IRequest;
 use PHPUnit\Framework\MockObject\Exception;
@@ -33,6 +34,7 @@ class AdminSettingsControllerTest extends TestCase {
 			Application::APP_ID,
 			$this->createMock(IRequest::class),
 			$this->appSettings,
+			new SettingsValidator(),
 		);
 	}
 


### PR DESCRIPTION
Implements the occ part of the roadmap (#7), as suggested in #8:
  
- New command `twofactor_email:settings`, modeled after `theming:config`:
  - no arguments: list all settings with their current and default values
  - `<key>`: print the current value (script-friendly)
  - `<key> <value>`: change the setting; an empty `email_subject`/`email_template` means "use the localized default"
  - `--reset`: reset all settings to their defaults
- Validation moved from `AdminSettingsController` into the new `SettingsValidator` service, so occ and the web UI enforce exactly
  the same limits (unlike the generic `occ config:app:set`)
- 10 new unit tests (75 total)
  
🤖 Generated with [Claude Code](https://claude.com/claude-code), approved by nursoda.