### PR TITLE
 Allow admins to delete stored codes via occ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Admin settings: show and change all app settings via occ
+- Admins can delete the stored codes of one or all users via occ
 
 ## 3.2.0 (2026-07-05)
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -71,6 +71,7 @@ at the bottom of "Personal Settings/Security").]]></description>
     </two-factor-providers>
     <commands>
         <command>OCA\TwoFactorEMail\Command\CleanUp</command>
+        <command>OCA\TwoFactorEMail\Command\DeleteCodes</command>
         <command>OCA\TwoFactorEMail\Command\Settings</command>
     </commands>
     <settings>

--- a/lib/Command/DeleteCodes.php
+++ b/lib/Command/DeleteCodes.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Command;
+
+use OCA\TwoFactorEMail\Service\ICodeStorage;
+use OCP\IUserManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\InvalidOptionException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Deletes the stored two-factor email codes — for one user or for all users.
+ * Affected users simply request a new code at their next login.
+ */
+final class DeleteCodes extends Command {
+
+	public function __construct(
+		private readonly ICodeStorage $codeStorage,
+		private readonly IUserManager $userManager,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		$this
+			->setName('twofactor_email:delete-codes')
+			->setDescription('Delete the stored two-factor email codes of one user or of all users.')
+			->addArgument('uid', InputArgument::OPTIONAL, 'Delete the code of the user with this user id')
+			->addOption('all', null, InputOption::VALUE_NONE, 'Delete the codes of all users');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$io = new SymfonyStyle($input, $output);
+		$uid = $input->getArgument('uid');
+		$all = $input->getOption('all');
+
+		// Symfony renders the error and the command synopsis for this exception,
+		// matching core commands like trashbin:cleanup.
+		if (($uid !== null && $all) || ($uid === null && !$all)) {
+			throw new InvalidOptionException('Specify either a user id or --all.');
+		}
+
+		if ($all) {
+			$count = $this->codeStorage->deleteAllCodes();
+			$io->success(sprintf('Deleted the stored codes of %d user(s).', $count));
+			return Command::SUCCESS;
+		}
+
+		// Deleting is also allowed for users unknown to Nextcloud: their
+		// leftover codes should be removable, but warn about possible typos.
+		if ($this->userManager->get($uid) === null) {
+			$io->warning('No user with id "' . $uid . '" exists — deleting leftover codes anyway.');
+		}
+		$this->codeStorage->deleteCode($uid);
+		$io->success('Deleted the stored code of "' . $uid . '".');
+		return Command::SUCCESS;
+	}
+}

--- a/lib/Service/CodeStorage.php
+++ b/lib/Service/CodeStorage.php
@@ -58,6 +58,13 @@ final class CodeStorage implements ICodeStorage {
 		$this->config->setValueInt($userId, Application::APP_ID, self::KEY_CREATED_AT, $createdAt);
 	}
 
+	public function deleteAllCodes(): int {
+		$count = count($this->config->getValuesByUsers(Application::APP_ID, self::KEY_CREATED_AT, ValueType::INT));
+		$this->config->deleteKey(Application::APP_ID, self::KEY_CODE);
+		$this->config->deleteKey(Application::APP_ID, self::KEY_CREATED_AT);
+		return $count;
+	}
+
 	public function deleteExpired(): void {
 		$expiresBefore = time() - $this->settings->getCodeValidMinutes() * 60;
 		$creationTime = $this->config->getValuesByUsers(Application::APP_ID, self::KEY_CREATED_AT, ValueType::INT);

--- a/lib/Service/ICodeStorage.php
+++ b/lib/Service/ICodeStorage.php
@@ -22,5 +22,12 @@ interface ICodeStorage {
 
 	public function deleteCode(string $userId): void;
 
+	/**
+	 * Deletes the stored codes of all users.
+	 *
+	 * @return int the number of users that had a code stored
+	 */
+	public function deleteAllCodes(): int;
+
 	public function deleteExpired(): void;
 }

--- a/tests/Unit/Command/DeleteCodesTest.php
+++ b/tests/Unit/Command/DeleteCodesTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Test\Unit\Command;
+
+use OCA\TwoFactorEMail\Command\DeleteCodes;
+use OCA\TwoFactorEMail\Service\ICodeStorage;
+use OCP\IUser;
+use OCP\IUserManager;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\InvalidOptionException;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class DeleteCodesTest extends TestCase {
+	private ICodeStorage&MockObject $codeStorage;
+
+	private IUserManager&MockObject $userManager;
+
+	private CommandTester $tester;
+
+	/**
+	 * @throws Exception
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->codeStorage = $this->createMock(ICodeStorage::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+
+		$this->tester = new CommandTester(new DeleteCodes($this->codeStorage, $this->userManager));
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testDeletesCodeOfSingleUser(): void {
+		$this->userManager->method('get')->with('alice')->willReturn($this->createMock(IUser::class));
+		$this->codeStorage->expects($this->once())->method('deleteCode')->with('alice');
+		$this->codeStorage->expects($this->never())->method('deleteAllCodes');
+
+		$exitCode = $this->tester->execute(['uid' => 'alice']);
+
+		$this->assertSame(Command::SUCCESS, $exitCode);
+	}
+
+	public function testWarnsAboutUnknownUserButStillDeletes(): void {
+		$this->userManager->method('get')->with('ghost')->willReturn(null);
+		$this->codeStorage->expects($this->once())->method('deleteCode')->with('ghost');
+
+		$exitCode = $this->tester->execute(['uid' => 'ghost']);
+
+		$this->assertSame(Command::SUCCESS, $exitCode);
+		$this->assertStringContainsString('No user with id "ghost" exists', $this->tester->getDisplay());
+	}
+
+	public function testDeletesCodesOfAllUsers(): void {
+		$this->codeStorage->expects($this->once())->method('deleteAllCodes')->willReturn(3);
+		$this->codeStorage->expects($this->never())->method('deleteCode');
+
+		$exitCode = $this->tester->execute(['--all' => true]);
+
+		$this->assertSame(Command::SUCCESS, $exitCode);
+		$this->assertStringContainsString('3 user(s)', $this->tester->getDisplay());
+	}
+
+	public function testRejectsMissingUserIdAndAll(): void {
+		$this->codeStorage->expects($this->never())->method('deleteCode');
+		$this->codeStorage->expects($this->never())->method('deleteAllCodes');
+
+		$this->expectException(InvalidOptionException::class);
+
+		$this->tester->execute([]);
+	}
+
+	public function testRejectsUserIdCombinedWithAll(): void {
+		$this->codeStorage->expects($this->never())->method('deleteCode');
+		$this->codeStorage->expects($this->never())->method('deleteAllCodes');
+
+		$this->expectException(InvalidOptionException::class);
+
+		$this->tester->execute(['uid' => 'alice', '--all' => true]);
+	}
+}

--- a/tests/Unit/Service/CodeStorageTest.php
+++ b/tests/Unit/Service/CodeStorageTest.php
@@ -40,6 +40,18 @@ class CodeStorageTest extends TestCase {
 		$this->assertNull($this->storage->secondsSinceLastCode('alice'));
 	}
 
+	public function testDeleteAllCodesDeletesBothKeysAndReturnsUserCount(): void {
+		$this->config->method('getValuesByUsers')->willReturn(['alice' => 100, 'bob' => 200]);
+		$deletedKeys = [];
+		$this->config->expects($this->exactly(2))->method('deleteKey')
+			->willReturnCallback(function (string $app, string $key) use (&$deletedKeys): void {
+				$deletedKeys[] = $key;
+			});
+
+		$this->assertSame(2, $this->storage->deleteAllCodes());
+		$this->assertSame(['code', 'code_created_at'], $deletedKeys);
+	}
+
 	public function testSecondsSinceLastCodeForFreshCode(): void {
 		$this->config->method('getValueInt')->willReturn(time());
 		$this->config->method('getValueString')->willReturn('hashed-code');


### PR DESCRIPTION
Implements the code-deletion items of the roadmap (#7). Based on the occ settings PR #99 — merge that first.

- New command `twofactor_email:delete-codes`, following the occ convention of an explicit target (like `trashbin:cleanup`):
  - `<uid>`: delete the stored code of that user; an unknown uid warns about a possible typo but still deletes leftover codes
  - `--all`: delete the stored codes of all users, reporting how many users were affected
  - neither or both: `InvalidOptionException` — Symfony prints the error plus the command synopsis
- No confirmation prompt: occ core commands delete without asking, and affected users simply request a new code at their next
  login
- New `ICodeStorage::deleteAllCodes(): int` using `IUserConfig::deleteKey()` (one bulk delete instead of a per-user loop)
- 5 new unit tests (81 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.