### PR TITLE
Fix automatic disable when an account loses its email address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Admin settings: show and change all app settings via occ
 - Admins can delete the stored codes of one or all users via occ
 
+### Fixed
+
+- Wrong and repeated activity entries for accounts without an email address
+
 ## 3.2.0 (2026-07-05)
 
 ### Added

--- a/lib/Activity/Notification.php
+++ b/lib/Activity/Notification.php
@@ -14,6 +14,7 @@ enum Notification: string {
 	case DISABLED_BY_USER = 'twofactor_email_disabled_by_user';
 	case ENABLED_BY_ADMIN = 'twofactor_email_enabled_by_admin';
 	case DISABLED_BY_ADMIN = 'twofactor_email_disabled_by_admin';
+	case DISABLED_NO_EMAIL = 'twofactor_email_disabled_no_email';
 
 	public function getSubjectText(): string {
 		return match ($this) {
@@ -21,6 +22,7 @@ enum Notification: string {
 			Notification::DISABLED_BY_USER => 'You disabled email two-factor authentication for your account',
 			Notification::ENABLED_BY_ADMIN => 'Email two-factor authentication was enabled by an admin',
 			Notification::DISABLED_BY_ADMIN => 'Email two-factor authentication was disabled by an admin',
+			Notification::DISABLED_NO_EMAIL => 'Email two-factor authentication was disabled because your account has no email address',
 		};
 	}
 }

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -32,6 +32,7 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\User\Events\UserChangedEvent;
 
 final class Application extends App implements IBootstrap {
 	public const APP_ID = 'twofactor_email';
@@ -54,6 +55,7 @@ final class Application extends App implements IBootstrap {
 		$context->registerEventListener(StateChanged::class, StateChangeActivity::class);
 		$context->registerEventListener(StateChanged::class, StateChangeRegistryUpdater::class);
 		$context->registerEventListener(UserUpdatedEvent::class, EMailDeleted::class);
+		$context->registerEventListener(UserChangedEvent::class, EMailDeleted::class);
 	}
 
 	public function boot(IBootContext $context): void {

--- a/lib/Event/StateChangeActor.php
+++ b/lib/Event/StateChangeActor.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Event;
+
+/**
+ * Who caused a provider state change. SYSTEM means the app itself, e.g.
+ * the automatic disable when an account loses its email address.
+ */
+enum StateChangeActor {
+	case USER;
+	case ADMIN;
+	case SYSTEM;
+}

--- a/lib/Event/StateChanged.php
+++ b/lib/Event/StateChanged.php
@@ -17,7 +17,7 @@ final class StateChanged extends Event {
 	public function __construct(
 		private readonly IUser $user,
 		private readonly bool $enabled,
-		private readonly bool $byAdmin = false,
+		private readonly StateChangeActor $actor = StateChangeActor::USER,
 	) {
 		parent::__construct();
 	}
@@ -30,7 +30,7 @@ final class StateChanged extends Event {
 		return $this->enabled;
 	}
 
-	public function byAdmin(): bool {
-		return $this->byAdmin;
+	public function getActor(): StateChangeActor {
+		return $this->actor;
 	}
 }

--- a/lib/Listener/EMailDeleted.php
+++ b/lib/Listener/EMailDeleted.php
@@ -23,8 +23,14 @@ use OCP\User\Events\UserChangedEvent;
  * UI paths: profile/account updates (UserUpdatedEvent) and direct email
  * changes, e.g. by an admin via the users page (UserChangedEvent).
  *
- * Not covered (Nextcloud fires no event): raw preference edits like
- * `occ user:setting <uid> settings email --delete`.
+ * This also covers `occ user:setting <uid> settings email`: at least since
+ * Nextcloud 32 the command routes email changes through
+ * IUser::setEMailAddress(), which fires UserChangedEvent. Only writes that
+ * bypass IUser (e.g. direct database edits) fire no event.
+ *
+ * `occ user:profile <uid> email --delete` clears only the account/profile
+ * property, not the system email (IUser::getEMailAddress() keeps returning
+ * the address, codes stay deliverable) — so not disabling is correct there.
  *
  * @template-implements IEventListener<UserUpdatedEvent|UserChangedEvent>
  */

--- a/lib/Listener/EMailDeleted.php
+++ b/lib/Listener/EMailDeleted.php
@@ -9,13 +9,24 @@ declare(strict_types=1);
 
 namespace OCA\TwoFactorEMail\Listener;
 
+use OCA\TwoFactorEMail\Event\StateChangeActor;
 use OCA\TwoFactorEMail\Service\IStateManager;
 use OCP\Accounts\UserUpdatedEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
+use OCP\IUser;
+use OCP\User\Events\UserChangedEvent;
 
 /**
- * @template-implements IEventListener<UserUpdatedEvent>
+ * Disables the provider when an account loses its email address — codes
+ * could no longer be delivered. Listens on both events that cover the two
+ * UI paths: profile/account updates (UserUpdatedEvent) and direct email
+ * changes, e.g. by an admin via the users page (UserChangedEvent).
+ *
+ * Not covered (Nextcloud fires no event): raw preference edits like
+ * `occ user:setting <uid> settings email --delete`.
+ *
+ * @template-implements IEventListener<UserUpdatedEvent|UserChangedEvent>
  */
 final class EMailDeleted implements IEventListener {
 
@@ -25,8 +36,26 @@ final class EMailDeleted implements IEventListener {
 	}
 
 	public function handle(Event $event): void {
-		if ($event->getUser()->getEMailAddress() === null) {
-			$this->service->disable($event->getUser());
+		$user = $this->affectedUser($event);
+		if ($user === null || $user->getEMailAddress() !== null) {
+			return;
 		}
+		// Only disable an enabled provider: without this guard, every profile
+		// update of a user without an email address would dispatch another
+		// StateChanged event and create a bogus activity entry.
+		if (!$this->service->isEnabled($user)) {
+			return;
+		}
+		$this->service->disable($user, StateChangeActor::SYSTEM);
+	}
+
+	private function affectedUser(Event $event): ?IUser {
+		if ($event instanceof UserUpdatedEvent) {
+			return $event->getUser();
+		}
+		if ($event instanceof UserChangedEvent && $event->getFeature() === 'eMailAddress') {
+			return $event->getUser();
+		}
+		return null;
 	}
 }

--- a/lib/Listener/StateChangeActivity.php
+++ b/lib/Listener/StateChangeActivity.php
@@ -11,6 +11,7 @@ namespace OCA\TwoFactorEMail\Listener;
 
 use OCA\TwoFactorEMail\Activity\Notification;
 use OCA\TwoFactorEMail\AppInfo\Application;
+use OCA\TwoFactorEMail\Event\StateChangeActor;
 use OCA\TwoFactorEMail\Event\StateChanged;
 use OCP\Activity\IManager as ActivityManager;
 use OCP\EventDispatcher\Event;
@@ -27,15 +28,19 @@ final class StateChangeActivity implements IEventListener {
 	}
 
 	public function handle(Event $event): void {
-		if ($event->byAdmin()) {
-			$notification = $event->isEnabled()
-				? Notification::ENABLED_BY_ADMIN
-				: Notification::DISABLED_BY_ADMIN;
-		} else {
-			$notification = $event->isEnabled()
-				? Notification::ENABLED_BY_USER
-				: Notification::DISABLED_BY_USER;
+		if (!$event instanceof StateChanged) {
+			return;
 		}
+		$notification = match ($event->getActor()) {
+			StateChangeActor::USER => $event->isEnabled()
+				? Notification::ENABLED_BY_USER
+				: Notification::DISABLED_BY_USER,
+			StateChangeActor::ADMIN => $event->isEnabled()
+				? Notification::ENABLED_BY_ADMIN
+				: Notification::DISABLED_BY_ADMIN,
+			// The system only ever disables (account lost its email address)
+			StateChangeActor::SYSTEM => Notification::DISABLED_NO_EMAIL,
+		};
 		$user = $event->getUser();
 
 		$activity = $this->activityManager->generateEvent();

--- a/lib/Provider/TwoFactorEMail.php
+++ b/lib/Provider/TwoFactorEMail.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\TwoFactorEMail\Provider;
 
 use OCA\TwoFactorEMail\AppInfo\Application;
+use OCA\TwoFactorEMail\Event\StateChangeActor;
 use OCA\TwoFactorEMail\Exception\EMailNotSet;
 use OCA\TwoFactorEMail\Exception\SendEMailFailed;
 use OCA\TwoFactorEMail\Service\IAppSettings;
@@ -131,11 +132,11 @@ class TwoFactorEMail implements IProvider, IProvidesIcons, IProvidesPersonalSett
 	}
 
 	public function disableFor(IUser $user): void {
-		$this->stateManager->disable($user, true);
+		$this->stateManager->disable($user, StateChangeActor::ADMIN);
 	}
 
 	public function enableFor(IUser $user): void {
-		$this->stateManager->enable($user, true);
+		$this->stateManager->enable($user, StateChangeActor::ADMIN);
 	}
 
 	/**

--- a/lib/Service/IStateManager.php
+++ b/lib/Service/IStateManager.php
@@ -9,12 +9,13 @@ declare(strict_types=1);
 
 namespace OCA\TwoFactorEMail\Service;
 
+use OCA\TwoFactorEMail\Event\StateChangeActor;
 use OCP\IUser;
 
 interface IStateManager {
-	public function enable(IUser $user, bool $byAdmin = false): void;
+	public function enable(IUser $user, StateChangeActor $actor = StateChangeActor::USER): void;
 
-	public function disable(IUser $user, bool $byAdmin = false): void;
+	public function disable(IUser $user, StateChangeActor $actor = StateChangeActor::USER): void;
 
 	public function isEnabled(IUser $user): bool;
 }

--- a/lib/Service/StateManager.php
+++ b/lib/Service/StateManager.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\TwoFactorEMail\Service;
 
+use OCA\TwoFactorEMail\Event\StateChangeActor;
 use OCA\TwoFactorEMail\Event\StateChanged;
 use OCP\Authentication\TwoFactorAuth\IRegistry;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -26,12 +27,12 @@ final class StateManager implements IStateManager {
 	) {
 	}
 
-	public function enable(IUser $user, bool $byAdmin = false): void {
-		$this->eventDispatcher->dispatchTyped(new StateChanged($user, true, $byAdmin));
+	public function enable(IUser $user, StateChangeActor $actor = StateChangeActor::USER): void {
+		$this->eventDispatcher->dispatchTyped(new StateChanged($user, true, $actor));
 	}
 
-	public function disable(IUser $user, bool $byAdmin = false): void {
-		$this->eventDispatcher->dispatchTyped(new StateChanged($user, false, $byAdmin));
+	public function disable(IUser $user, StateChangeActor $actor = StateChangeActor::USER): void {
+		$this->eventDispatcher->dispatchTyped(new StateChanged($user, false, $actor));
 	}
 
 	public function isEnabled(IUser $user): bool {

--- a/tests/Unit/Listener/EMailDeletedTest.php
+++ b/tests/Unit/Listener/EMailDeletedTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Test\Unit\Listener;
+
+use OCA\TwoFactorEMail\Event\StateChangeActor;
+use OCA\TwoFactorEMail\Listener\EMailDeleted;
+use OCA\TwoFactorEMail\Service\IStateManager;
+use OCP\Accounts\UserUpdatedEvent;
+use OCP\EventDispatcher\Event;
+use OCP\IUser;
+use OCP\User\Events\UserChangedEvent;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class EMailDeletedTest extends TestCase {
+	private IStateManager&MockObject $stateManager;
+
+	private EMailDeleted $listener;
+
+	/**
+	 * @throws Exception
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->stateManager = $this->createMock(IStateManager::class);
+
+		$this->listener = new EMailDeleted($this->stateManager);
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	private function mockUser(?string $email): IUser&MockObject {
+		$user = $this->createMock(IUser::class);
+		$user->method('getEMailAddress')->willReturn($email);
+		return $user;
+	}
+
+	public function testDisablesEnabledProviderOnAccountUpdateWithoutEmail(): void {
+		$user = $this->mockUser(null);
+		$this->stateManager->method('isEnabled')->with($user)->willReturn(true);
+		$this->stateManager->expects($this->once())->method('disable')->with($user, StateChangeActor::SYSTEM);
+
+		$this->listener->handle(new UserUpdatedEvent($user, []));
+	}
+
+	public function testDisablesEnabledProviderWhenEmailFeatureIsCleared(): void {
+		$user = $this->mockUser(null);
+		$this->stateManager->method('isEnabled')->with($user)->willReturn(true);
+		$this->stateManager->expects($this->once())->method('disable')->with($user, StateChangeActor::SYSTEM);
+
+		$this->listener->handle(new UserChangedEvent($user, 'eMailAddress', '', 'old@example.com'));
+	}
+
+	public function testKeepsProviderWhenEmailIsPresent(): void {
+		$user = $this->mockUser('alice@example.com');
+		$this->stateManager->expects($this->never())->method('disable');
+
+		$this->listener->handle(new UserUpdatedEvent($user, []));
+	}
+
+	public function testDoesNotDisableAnAlreadyDisabledProvider(): void {
+		// Guards against bogus activity entries on every profile update
+		// of users without an email address
+		$user = $this->mockUser(null);
+		$this->stateManager->method('isEnabled')->with($user)->willReturn(false);
+		$this->stateManager->expects($this->never())->method('disable');
+
+		$this->listener->handle(new UserUpdatedEvent($user, []));
+	}
+
+	public function testIgnoresOtherChangedFeatures(): void {
+		$user = $this->mockUser(null);
+		$this->stateManager->expects($this->never())->method('disable');
+
+		$this->listener->handle(new UserChangedEvent($user, 'displayName', 'Alice'));
+	}
+
+	public function testIgnoresForeignEvents(): void {
+		$this->stateManager->expects($this->never())->method('disable');
+
+		$this->listener->handle(new Event());
+	}
+}

--- a/tests/Unit/Listener/StateChangeActivityTest.php
+++ b/tests/Unit/Listener/StateChangeActivityTest.php
@@ -10,10 +10,12 @@ declare(strict_types=1);
 namespace OCA\TwoFactorEMail\Test\Unit\Listener;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\TwoFactorEMail\Event\StateChangeActor;
 use OCA\TwoFactorEMail\Event\StateChanged;
 use OCA\TwoFactorEMail\Listener\StateChangeActivity;
 use OCP\Activity\IEvent;
 use OCP\Activity\IManager;
+use OCP\EventDispatcher\Event;
 use OCP\IUser;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -57,6 +59,34 @@ class StateChangeActivityTest extends TestCase {
 			->with($activityEvent);
 
 		$this->listener->handle($event);
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testSystemDisableCreatesNoEmailActivity(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('user234');
+		$event = new StateChanged($user, false, StateChangeActor::SYSTEM);
+		$activityEvent = $this->createMock(IEvent::class);
+		$activityEvent->method('setApp')->willReturnSelf();
+		$activityEvent->method('setType')->willReturnSelf();
+		$activityEvent->method('setAuthor')->willReturnSelf();
+		$activityEvent->method('setAffectedUser')->willReturnSelf();
+		$activityEvent->expects($this->once())
+			->method('setSubject')
+			->with('twofactor_email_disabled_no_email')
+			->willReturnSelf();
+		$this->activityManager->method('generateEvent')->willReturn($activityEvent);
+		$this->activityManager->expects($this->once())->method('publish');
+
+		$this->listener->handle($event);
+	}
+
+	public function testIgnoresForeignEvents(): void {
+		$this->activityManager->expects($this->never())->method('generateEvent');
+
+		$this->listener->handle(new Event());
 	}
 
 	/**


### PR DESCRIPTION
Implements the event verification and email-deletion items of the roadmap (#7). Based on the occ delete-codes PR (#100) — merge #99 and #100 first.

Verified event chains (admin enable/disable via `occ twofactorauth:*` → registry + activity) and fixed what the analysis surfaced:

- The `EMailDeleted` listener disabled the provider on **every** account update of a user without an email address — even when the provider was not enabled — creating a bogus "You disabled email two-factor authentication" activity entry on every profile change. It now checks `isEnabled()` first and verifies the event type.
- It additionally listens on `UserChangedEvent` (feature `eMailAddress`), so direct changes (admin users page, provisioning API) are covered independently of the accounts sync. Not coverable (Nextcloud fires no event): raw edits via `occ user:setting … --delete`; documented in the listener.
- State changes now carry an actor (`USER`/`ADMIN`/`SYSTEM`) instead of a `byAdmin` flag. The automatic disable gets its own activity text ("… was disabled because your account has no email address") instead of pretending the user did it.
- 8 new unit tests (89 total).

The remaining roadmap item "immediate notification in the web UI" builds on this and follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.