### PR TITLE
Notify users about state changes they did not make themselves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Admin settings: show and change all app settings via occ
 - Admins can delete the stored codes of one or all users via occ
+- Notify the user if an admin (de)activated this 2FA provider or the primary email address was deleted
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Admin settings: show and change all app settings via occ
 - Admins can delete the stored codes of one or all users via occ
 
+### Fixed
+
+- Wrong and repeated activity entries for accounts without an email address
+
 ## 3.2.0 (2026-07-05)
 
 ### Added

--- a/lib/Activity/Notification.php
+++ b/lib/Activity/Notification.php
@@ -14,6 +14,7 @@ enum Notification: string {
 	case DISABLED_BY_USER = 'twofactor_email_disabled_by_user';
 	case ENABLED_BY_ADMIN = 'twofactor_email_enabled_by_admin';
 	case DISABLED_BY_ADMIN = 'twofactor_email_disabled_by_admin';
+	case DISABLED_NO_EMAIL = 'twofactor_email_disabled_no_email';
 
 	public function getSubjectText(): string {
 		return match ($this) {
@@ -21,6 +22,7 @@ enum Notification: string {
 			Notification::DISABLED_BY_USER => 'You disabled email two-factor authentication for your account',
 			Notification::ENABLED_BY_ADMIN => 'Email two-factor authentication was enabled by an admin',
 			Notification::DISABLED_BY_ADMIN => 'Email two-factor authentication was disabled by an admin',
+			Notification::DISABLED_NO_EMAIL => 'Email two-factor authentication was disabled because your account has no email address',
 		};
 	}
 }

--- a/lib/Activity/Notification.php
+++ b/lib/Activity/Notification.php
@@ -9,12 +9,23 @@ declare(strict_types=1);
 
 namespace OCA\TwoFactorEMail\Activity;
 
+use OCA\TwoFactorEMail\Event\StateChangeActor;
+
 enum Notification: string {
 	case ENABLED_BY_USER = 'twofactor_email_enabled_by_user';
 	case DISABLED_BY_USER = 'twofactor_email_disabled_by_user';
 	case ENABLED_BY_ADMIN = 'twofactor_email_enabled_by_admin';
 	case DISABLED_BY_ADMIN = 'twofactor_email_disabled_by_admin';
 	case DISABLED_NO_EMAIL = 'twofactor_email_disabled_no_email';
+
+	public static function fromStateChange(StateChangeActor $actor, bool $enabled): self {
+		return match ($actor) {
+			StateChangeActor::USER => $enabled ? self::ENABLED_BY_USER : self::DISABLED_BY_USER,
+			StateChangeActor::ADMIN => $enabled ? self::ENABLED_BY_ADMIN : self::DISABLED_BY_ADMIN,
+			// The system only ever disables (account lost its email address)
+			StateChangeActor::SYSTEM => self::DISABLED_NO_EMAIL,
+		};
+	}
 
 	public function getSubjectText(): string {
 		return match ($this) {

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -32,6 +32,7 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\User\Events\UserChangedEvent;
 
 final class Application extends App implements IBootstrap {
 	public const APP_ID = 'twofactor_email';
@@ -54,6 +55,7 @@ final class Application extends App implements IBootstrap {
 		$context->registerEventListener(StateChanged::class, StateChangeActivity::class);
 		$context->registerEventListener(StateChanged::class, StateChangeRegistryUpdater::class);
 		$context->registerEventListener(UserUpdatedEvent::class, EMailDeleted::class);
+		$context->registerEventListener(UserChangedEvent::class, EMailDeleted::class);
 	}
 
 	public function boot(IBootContext $context): void {

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -12,7 +12,9 @@ namespace OCA\TwoFactorEMail\AppInfo;
 use OCA\TwoFactorEMail\Event\StateChanged;
 use OCA\TwoFactorEMail\Listener\EMailDeleted;
 use OCA\TwoFactorEMail\Listener\StateChangeActivity;
+use OCA\TwoFactorEMail\Listener\StateChangeNotification;
 use OCA\TwoFactorEMail\Listener\StateChangeRegistryUpdater;
+use OCA\TwoFactorEMail\Notification\Notifier;
 use OCA\TwoFactorEMail\Service\AppSettings;
 use OCA\TwoFactorEMail\Service\CodeStorage;
 use OCA\TwoFactorEMail\Service\EMailAddressMasker;
@@ -53,9 +55,12 @@ final class Application extends App implements IBootstrap {
 		$context->registerServiceAlias(IStateManager::class, StateManager::class);
 
 		$context->registerEventListener(StateChanged::class, StateChangeActivity::class);
+		$context->registerEventListener(StateChanged::class, StateChangeNotification::class);
 		$context->registerEventListener(StateChanged::class, StateChangeRegistryUpdater::class);
 		$context->registerEventListener(UserUpdatedEvent::class, EMailDeleted::class);
 		$context->registerEventListener(UserChangedEvent::class, EMailDeleted::class);
+
+		$context->registerNotifierService(Notifier::class);
 	}
 
 	public function boot(IBootContext $context): void {

--- a/lib/Event/StateChangeActor.php
+++ b/lib/Event/StateChangeActor.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Event;
+
+/**
+ * Who caused a provider state change. SYSTEM means the app itself, e.g.
+ * the automatic disable when an account loses its email address.
+ */
+enum StateChangeActor {
+	case USER;
+	case ADMIN;
+	case SYSTEM;
+}

--- a/lib/Event/StateChanged.php
+++ b/lib/Event/StateChanged.php
@@ -17,7 +17,7 @@ final class StateChanged extends Event {
 	public function __construct(
 		private readonly IUser $user,
 		private readonly bool $enabled,
-		private readonly bool $byAdmin = false,
+		private readonly StateChangeActor $actor = StateChangeActor::USER,
 	) {
 		parent::__construct();
 	}
@@ -30,7 +30,7 @@ final class StateChanged extends Event {
 		return $this->enabled;
 	}
 
-	public function byAdmin(): bool {
-		return $this->byAdmin;
+	public function getActor(): StateChangeActor {
+		return $this->actor;
 	}
 }

--- a/lib/Listener/EMailDeleted.php
+++ b/lib/Listener/EMailDeleted.php
@@ -9,13 +9,24 @@ declare(strict_types=1);
 
 namespace OCA\TwoFactorEMail\Listener;
 
+use OCA\TwoFactorEMail\Event\StateChangeActor;
 use OCA\TwoFactorEMail\Service\IStateManager;
 use OCP\Accounts\UserUpdatedEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
+use OCP\IUser;
+use OCP\User\Events\UserChangedEvent;
 
 /**
- * @template-implements IEventListener<UserUpdatedEvent>
+ * Disables the provider when an account loses its email address — codes
+ * could no longer be delivered. Listens on both events that cover the two
+ * UI paths: profile/account updates (UserUpdatedEvent) and direct email
+ * changes, e.g. by an admin via the users page (UserChangedEvent).
+ *
+ * Not covered (Nextcloud fires no event): raw preference edits like
+ * `occ user:setting <uid> settings email --delete`.
+ *
+ * @template-implements IEventListener<UserUpdatedEvent|UserChangedEvent>
  */
 final class EMailDeleted implements IEventListener {
 
@@ -25,8 +36,26 @@ final class EMailDeleted implements IEventListener {
 	}
 
 	public function handle(Event $event): void {
-		if ($event->getUser()->getEMailAddress() === null) {
-			$this->service->disable($event->getUser());
+		$user = $this->affectedUser($event);
+		if ($user === null || $user->getEMailAddress() !== null) {
+			return;
 		}
+		// Only disable an enabled provider: without this guard, every profile
+		// update of a user without an email address would dispatch another
+		// StateChanged event and create a bogus activity entry.
+		if (!$this->service->isEnabled($user)) {
+			return;
+		}
+		$this->service->disable($user, StateChangeActor::SYSTEM);
+	}
+
+	private function affectedUser(Event $event): ?IUser {
+		if ($event instanceof UserUpdatedEvent) {
+			return $event->getUser();
+		}
+		if ($event instanceof UserChangedEvent && $event->getFeature() === 'eMailAddress') {
+			return $event->getUser();
+		}
+		return null;
 	}
 }

--- a/lib/Listener/StateChangeActivity.php
+++ b/lib/Listener/StateChangeActivity.php
@@ -11,6 +11,7 @@ namespace OCA\TwoFactorEMail\Listener;
 
 use OCA\TwoFactorEMail\Activity\Notification;
 use OCA\TwoFactorEMail\AppInfo\Application;
+use OCA\TwoFactorEMail\Event\StateChangeActor;
 use OCA\TwoFactorEMail\Event\StateChanged;
 use OCP\Activity\IManager as ActivityManager;
 use OCP\EventDispatcher\Event;
@@ -27,15 +28,19 @@ final class StateChangeActivity implements IEventListener {
 	}
 
 	public function handle(Event $event): void {
-		if ($event->byAdmin()) {
-			$notification = $event->isEnabled()
-				? Notification::ENABLED_BY_ADMIN
-				: Notification::DISABLED_BY_ADMIN;
-		} else {
-			$notification = $event->isEnabled()
-				? Notification::ENABLED_BY_USER
-				: Notification::DISABLED_BY_USER;
+		if (!$event instanceof StateChanged) {
+			return;
 		}
+		$notification = match ($event->getActor()) {
+			StateChangeActor::USER => $event->isEnabled()
+				? Notification::ENABLED_BY_USER
+				: Notification::DISABLED_BY_USER,
+			StateChangeActor::ADMIN => $event->isEnabled()
+				? Notification::ENABLED_BY_ADMIN
+				: Notification::DISABLED_BY_ADMIN,
+			// The system only ever disables (account lost its email address)
+			StateChangeActor::SYSTEM => Notification::DISABLED_NO_EMAIL,
+		};
 		$user = $event->getUser();
 
 		$activity = $this->activityManager->generateEvent();

--- a/lib/Listener/StateChangeActivity.php
+++ b/lib/Listener/StateChangeActivity.php
@@ -11,7 +11,6 @@ namespace OCA\TwoFactorEMail\Listener;
 
 use OCA\TwoFactorEMail\Activity\Notification;
 use OCA\TwoFactorEMail\AppInfo\Application;
-use OCA\TwoFactorEMail\Event\StateChangeActor;
 use OCA\TwoFactorEMail\Event\StateChanged;
 use OCP\Activity\IManager as ActivityManager;
 use OCP\EventDispatcher\Event;
@@ -31,16 +30,7 @@ final class StateChangeActivity implements IEventListener {
 		if (!$event instanceof StateChanged) {
 			return;
 		}
-		$notification = match ($event->getActor()) {
-			StateChangeActor::USER => $event->isEnabled()
-				? Notification::ENABLED_BY_USER
-				: Notification::DISABLED_BY_USER,
-			StateChangeActor::ADMIN => $event->isEnabled()
-				? Notification::ENABLED_BY_ADMIN
-				: Notification::DISABLED_BY_ADMIN,
-			// The system only ever disables (account lost its email address)
-			StateChangeActor::SYSTEM => Notification::DISABLED_NO_EMAIL,
-		};
+		$notification = Notification::fromStateChange($event->getActor(), $event->isEnabled());
 		$user = $event->getUser();
 
 		$activity = $this->activityManager->generateEvent();

--- a/lib/Listener/StateChangeNotification.php
+++ b/lib/Listener/StateChangeNotification.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Listener;
+
+use OCA\TwoFactorEMail\Activity\Notification;
+use OCA\TwoFactorEMail\AppInfo\Application;
+use OCA\TwoFactorEMail\Event\StateChangeActor;
+use OCA\TwoFactorEMail\Event\StateChanged;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Notification\IManager as NotificationManager;
+
+/**
+ * Sends the affected user an immediate Nextcloud notification when their
+ * provider state was changed by someone else (admin) or something else
+ * (automatic disable). Users changing the state themselves see the result
+ * in the settings UI and get no notification.
+ *
+ * @template-implements IEventListener<StateChanged>
+ */
+final class StateChangeNotification implements IEventListener {
+
+	public function __construct(
+		private readonly NotificationManager $notificationManager,
+		private readonly ITimeFactory $timeFactory,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!$event instanceof StateChanged) {
+			return;
+		}
+		if ($event->getActor() === StateChangeActor::USER) {
+			return;
+		}
+
+		$subject = Notification::fromStateChange($event->getActor(), $event->isEnabled());
+		$uid = $event->getUser()->getUID();
+
+		$notification = $this->notificationManager->createNotification();
+		$notification->setApp(Application::APP_ID)
+			->setUser($uid)
+			->setDateTime($this->timeFactory->getDateTime())
+			->setObject('twofactor_email_state', $uid)
+			->setSubject($subject->value);
+		$this->notificationManager->notify($notification);
+	}
+}

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Notification;
+
+use OCA\TwoFactorEMail\Activity\Notification;
+use OCA\TwoFactorEMail\AppInfo\Application;
+use OCP\IURLGenerator;
+use OCP\L10N\IFactory as L10nFactory;
+use OCP\Notification\INotification;
+use OCP\Notification\INotifier;
+use OCP\Notification\UnknownNotificationException;
+
+/**
+ * Renders the notifications sent by StateChangeNotification. The subject
+ * texts are shared with the activity entries (Activity\Notification).
+ */
+final class Notifier implements INotifier {
+
+	public function __construct(
+		private readonly L10nFactory $l10nFactory,
+		private readonly IURLGenerator $urlGenerator,
+	) {
+	}
+
+	public function getID(): string {
+		return Application::APP_ID;
+	}
+
+	public function getName(): string {
+		return $this->l10nFactory->get(Application::APP_ID)->t('Email two-factor authentication');
+	}
+
+	public function prepare(INotification $notification, string $languageCode): INotification {
+		if ($notification->getApp() !== Application::APP_ID) {
+			throw new UnknownNotificationException();
+		}
+		$subject = Notification::tryFrom($notification->getSubject());
+		if ($subject === null) {
+			throw new UnknownNotificationException();
+		}
+
+		$l = $this->l10nFactory->get(Application::APP_ID, $languageCode);
+		$notification->setParsedSubject($l->t($subject->getSubjectText()));
+		$notification->setIcon($this->urlGenerator->getAbsoluteURL(
+			$this->urlGenerator->imagePath(Application::APP_ID, 'app-dark.svg'),
+		));
+		return $notification;
+	}
+}

--- a/lib/Provider/TwoFactorEMail.php
+++ b/lib/Provider/TwoFactorEMail.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\TwoFactorEMail\Provider;
 
 use OCA\TwoFactorEMail\AppInfo\Application;
+use OCA\TwoFactorEMail\Event\StateChangeActor;
 use OCA\TwoFactorEMail\Exception\EMailNotSet;
 use OCA\TwoFactorEMail\Exception\SendEMailFailed;
 use OCA\TwoFactorEMail\Service\IAppSettings;
@@ -131,11 +132,11 @@ class TwoFactorEMail implements IProvider, IProvidesIcons, IProvidesPersonalSett
 	}
 
 	public function disableFor(IUser $user): void {
-		$this->stateManager->disable($user, true);
+		$this->stateManager->disable($user, StateChangeActor::ADMIN);
 	}
 
 	public function enableFor(IUser $user): void {
-		$this->stateManager->enable($user, true);
+		$this->stateManager->enable($user, StateChangeActor::ADMIN);
 	}
 
 	/**

--- a/lib/Service/IStateManager.php
+++ b/lib/Service/IStateManager.php
@@ -9,12 +9,13 @@ declare(strict_types=1);
 
 namespace OCA\TwoFactorEMail\Service;
 
+use OCA\TwoFactorEMail\Event\StateChangeActor;
 use OCP\IUser;
 
 interface IStateManager {
-	public function enable(IUser $user, bool $byAdmin = false): void;
+	public function enable(IUser $user, StateChangeActor $actor = StateChangeActor::USER): void;
 
-	public function disable(IUser $user, bool $byAdmin = false): void;
+	public function disable(IUser $user, StateChangeActor $actor = StateChangeActor::USER): void;
 
 	public function isEnabled(IUser $user): bool;
 }

--- a/lib/Service/StateManager.php
+++ b/lib/Service/StateManager.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\TwoFactorEMail\Service;
 
+use OCA\TwoFactorEMail\Event\StateChangeActor;
 use OCA\TwoFactorEMail\Event\StateChanged;
 use OCP\Authentication\TwoFactorAuth\IRegistry;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -26,12 +27,12 @@ final class StateManager implements IStateManager {
 	) {
 	}
 
-	public function enable(IUser $user, bool $byAdmin = false): void {
-		$this->eventDispatcher->dispatchTyped(new StateChanged($user, true, $byAdmin));
+	public function enable(IUser $user, StateChangeActor $actor = StateChangeActor::USER): void {
+		$this->eventDispatcher->dispatchTyped(new StateChanged($user, true, $actor));
 	}
 
-	public function disable(IUser $user, bool $byAdmin = false): void {
-		$this->eventDispatcher->dispatchTyped(new StateChanged($user, false, $byAdmin));
+	public function disable(IUser $user, StateChangeActor $actor = StateChangeActor::USER): void {
+		$this->eventDispatcher->dispatchTyped(new StateChanged($user, false, $actor));
 	}
 
 	public function isEnabled(IUser $user): bool {

--- a/tests/Unit/Listener/EMailDeletedTest.php
+++ b/tests/Unit/Listener/EMailDeletedTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Test\Unit\Listener;
+
+use OCA\TwoFactorEMail\Event\StateChangeActor;
+use OCA\TwoFactorEMail\Listener\EMailDeleted;
+use OCA\TwoFactorEMail\Service\IStateManager;
+use OCP\Accounts\UserUpdatedEvent;
+use OCP\EventDispatcher\Event;
+use OCP\IUser;
+use OCP\User\Events\UserChangedEvent;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class EMailDeletedTest extends TestCase {
+	private IStateManager&MockObject $stateManager;
+
+	private EMailDeleted $listener;
+
+	/**
+	 * @throws Exception
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->stateManager = $this->createMock(IStateManager::class);
+
+		$this->listener = new EMailDeleted($this->stateManager);
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	private function mockUser(?string $email): IUser&MockObject {
+		$user = $this->createMock(IUser::class);
+		$user->method('getEMailAddress')->willReturn($email);
+		return $user;
+	}
+
+	public function testDisablesEnabledProviderOnAccountUpdateWithoutEmail(): void {
+		$user = $this->mockUser(null);
+		$this->stateManager->method('isEnabled')->with($user)->willReturn(true);
+		$this->stateManager->expects($this->once())->method('disable')->with($user, StateChangeActor::SYSTEM);
+
+		$this->listener->handle(new UserUpdatedEvent($user, []));
+	}
+
+	public function testDisablesEnabledProviderWhenEmailFeatureIsCleared(): void {
+		$user = $this->mockUser(null);
+		$this->stateManager->method('isEnabled')->with($user)->willReturn(true);
+		$this->stateManager->expects($this->once())->method('disable')->with($user, StateChangeActor::SYSTEM);
+
+		$this->listener->handle(new UserChangedEvent($user, 'eMailAddress', '', 'old@example.com'));
+	}
+
+	public function testKeepsProviderWhenEmailIsPresent(): void {
+		$user = $this->mockUser('alice@example.com');
+		$this->stateManager->expects($this->never())->method('disable');
+
+		$this->listener->handle(new UserUpdatedEvent($user, []));
+	}
+
+	public function testDoesNotDisableAnAlreadyDisabledProvider(): void {
+		// Guards against bogus activity entries on every profile update
+		// of users without an email address
+		$user = $this->mockUser(null);
+		$this->stateManager->method('isEnabled')->with($user)->willReturn(false);
+		$this->stateManager->expects($this->never())->method('disable');
+
+		$this->listener->handle(new UserUpdatedEvent($user, []));
+	}
+
+	public function testIgnoresOtherChangedFeatures(): void {
+		$user = $this->mockUser(null);
+		$this->stateManager->expects($this->never())->method('disable');
+
+		$this->listener->handle(new UserChangedEvent($user, 'displayName', 'Alice'));
+	}
+
+	public function testIgnoresForeignEvents(): void {
+		$this->stateManager->expects($this->never())->method('disable');
+
+		$this->listener->handle(new Event());
+	}
+}

--- a/tests/Unit/Listener/StateChangeActivityTest.php
+++ b/tests/Unit/Listener/StateChangeActivityTest.php
@@ -10,10 +10,12 @@ declare(strict_types=1);
 namespace OCA\TwoFactorEMail\Test\Unit\Listener;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\TwoFactorEMail\Event\StateChangeActor;
 use OCA\TwoFactorEMail\Event\StateChanged;
 use OCA\TwoFactorEMail\Listener\StateChangeActivity;
 use OCP\Activity\IEvent;
 use OCP\Activity\IManager;
+use OCP\EventDispatcher\Event;
 use OCP\IUser;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -57,6 +59,34 @@ class StateChangeActivityTest extends TestCase {
 			->with($activityEvent);
 
 		$this->listener->handle($event);
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testSystemDisableCreatesNoEmailActivity(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('user234');
+		$event = new StateChanged($user, false, StateChangeActor::SYSTEM);
+		$activityEvent = $this->createMock(IEvent::class);
+		$activityEvent->method('setApp')->willReturnSelf();
+		$activityEvent->method('setType')->willReturnSelf();
+		$activityEvent->method('setAuthor')->willReturnSelf();
+		$activityEvent->method('setAffectedUser')->willReturnSelf();
+		$activityEvent->expects($this->once())
+			->method('setSubject')
+			->with('twofactor_email_disabled_no_email')
+			->willReturnSelf();
+		$this->activityManager->method('generateEvent')->willReturn($activityEvent);
+		$this->activityManager->expects($this->once())->method('publish');
+
+		$this->listener->handle($event);
+	}
+
+	public function testIgnoresForeignEvents(): void {
+		$this->activityManager->expects($this->never())->method('generateEvent');
+
+		$this->listener->handle(new Event());
 	}
 
 	/**

--- a/tests/Unit/Listener/StateChangeNotificationTest.php
+++ b/tests/Unit/Listener/StateChangeNotificationTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Test\Unit\Listener;
+
+use DateTime;
+use OCA\TwoFactorEMail\Event\StateChangeActor;
+use OCA\TwoFactorEMail\Event\StateChanged;
+use OCA\TwoFactorEMail\Listener\StateChangeNotification;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\EventDispatcher\Event;
+use OCP\IUser;
+use OCP\Notification\IManager;
+use OCP\Notification\INotification;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class StateChangeNotificationTest extends TestCase {
+	private IManager&MockObject $notificationManager;
+
+	private StateChangeNotification $listener;
+
+	/**
+	 * @throws Exception
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->notificationManager = $this->createMock(IManager::class);
+		$timeFactory = $this->createMock(ITimeFactory::class);
+		$timeFactory->method('getDateTime')->willReturn(new DateTime());
+
+		$this->listener = new StateChangeNotification($this->notificationManager, $timeFactory);
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	private function mockUser(): IUser&MockObject {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		return $user;
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	private function expectNotificationWithSubject(string $subject): void {
+		$notification = $this->createMock(INotification::class);
+		$notification->method('setApp')->willReturnSelf();
+		$notification->method('setUser')->with('alice')->willReturnSelf();
+		$notification->method('setDateTime')->willReturnSelf();
+		$notification->method('setObject')->willReturnSelf();
+		$notification->expects($this->once())
+			->method('setSubject')
+			->with($subject)
+			->willReturnSelf();
+		$this->notificationManager->method('createNotification')->willReturn($notification);
+		$this->notificationManager->expects($this->once())->method('notify');
+	}
+
+	public function testNotifiesOnAdminEnable(): void {
+		$this->expectNotificationWithSubject('twofactor_email_enabled_by_admin');
+
+		$this->listener->handle(new StateChanged($this->mockUser(), true, StateChangeActor::ADMIN));
+	}
+
+	public function testNotifiesOnAutomaticDisable(): void {
+		$this->expectNotificationWithSubject('twofactor_email_disabled_no_email');
+
+		$this->listener->handle(new StateChanged($this->mockUser(), false, StateChangeActor::SYSTEM));
+	}
+
+	public function testDoesNotNotifyAboutOwnChanges(): void {
+		$this->notificationManager->expects($this->never())->method('notify');
+
+		$this->listener->handle(new StateChanged($this->mockUser(), true, StateChangeActor::USER));
+	}
+
+	public function testIgnoresForeignEvents(): void {
+		$this->notificationManager->expects($this->never())->method('notify');
+
+		$this->listener->handle(new Event());
+	}
+}

--- a/tests/Unit/Notification/NotifierTest.php
+++ b/tests/Unit/Notification/NotifierTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Test\Unit\Notification;
+
+use OCA\TwoFactorEMail\Notification\Notifier;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\L10N\IFactory;
+use OCP\Notification\INotification;
+use OCP\Notification\UnknownNotificationException;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class NotifierTest extends TestCase {
+	private Notifier $notifier;
+
+	/**
+	 * @throws Exception
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnArgument(0);
+		$l10nFactory = $this->createMock(IFactory::class);
+		$l10nFactory->method('get')->willReturn($l10n);
+		$urlGenerator = $this->createMock(IURLGenerator::class);
+		$urlGenerator->method('imagePath')->willReturn('/path/app-dark.svg');
+		$urlGenerator->method('getAbsoluteURL')->willReturn('https://cloud.example.com/path/app-dark.svg');
+
+		$this->notifier = new Notifier($l10nFactory, $urlGenerator);
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	private function mockNotification(string $app, string $subject): INotification&MockObject {
+		$notification = $this->createMock(INotification::class);
+		$notification->method('getApp')->willReturn($app);
+		$notification->method('getSubject')->willReturn($subject);
+		return $notification;
+	}
+
+	public function testPreparesKnownSubject(): void {
+		$notification = $this->mockNotification('twofactor_email', 'twofactor_email_disabled_no_email');
+		$notification->expects($this->once())
+			->method('setParsedSubject')
+			->with('Email two-factor authentication was disabled because your account has no email address')
+			->willReturnSelf();
+		$notification->expects($this->once())->method('setIcon')->willReturnSelf();
+
+		$this->notifier->prepare($notification, 'en');
+	}
+
+	public function testRejectsForeignApp(): void {
+		$notification = $this->mockNotification('other_app', 'irrelevant');
+
+		$this->expectException(UnknownNotificationException::class);
+
+		$this->notifier->prepare($notification, 'en');
+	}
+
+	public function testRejectsUnknownSubject(): void {
+		$notification = $this->mockNotification('twofactor_email', 'no_such_subject');
+
+		$this->expectException(UnknownNotificationException::class);
+
+		$this->notifier->prepare($notification, 'en');
+	}
+}


### PR DESCRIPTION
Implements the notification item of the roadmap (#7). Based on #101 — merge the stack (#99 → #100 → #101) first.

- New `StateChangeNotification` listener: admin (de)activation and the automatic disable (account lost its email address) send the affected user an immediate Nextcloud notification. Users changing the state themselves see the result in the settings UI and get no notification.
- New `Notifier` renders the notification localized, with the app icon.
- The actor-to-subject mapping moved into the `Notification` enum, shared by the activity and notification listeners.
- 7 new unit tests (96 total).

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.