### PR TITLE
Unify and simplify the "no email address" messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Admins can delete the stored codes of one or all users via occ
 - Notify the user if an admin (de)activated this 2FA provider or the primary email address was deleted
 
+### Changed
+
+- Clearer message when no email address is set
+
 ### Fixed
 
 - Wrong and repeated activity entries for accounts without an email address

--- a/src/LoginChallenge.js
+++ b/src/LoginChallenge.js
@@ -89,7 +89,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				// The cooldown has not elapsed. retryAfter (seconds) comes from our controller.
 				startCountdown((data && data.retryAfter) || cooldown)
 			} else if (data && data.error === 'no-email') {
-				status.textContent = t('twofactor_email', 'No email address is configured for your account.')
+				status.textContent = t('twofactor_email', 'No email address available, please contact your administrator.')
 			} else {
 				Logger.error('failed to resend two-factor email code', error)
 				status.textContent = t('twofactor_email', 'The code could not be sent. Please try again later.')

--- a/src/components/LoginSetup.vue
+++ b/src/components/LoginSetup.vue
@@ -7,7 +7,7 @@
 <template>
 	<div id="twofactor_email-login_setup">
 		<span v-if="store.error === 'no-email'" class="error">
-			{{ t('twofactor_email', 'You cannot enable two-factor authentication via email. You need to set a primary email address (in your personal settings) first.')
+			{{ t('twofactor_email', 'No email address available, please contact your administrator.')
 			}}
 		</span>
 		<span v-else-if="store.error === 'save-failed'" class="error">

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -22,7 +22,7 @@
 		</div>
 		<div v-else>
 			<span class="notice">
-				{{ t('twofactor_email', 'You cannot enable two-factor authentication via email. You need to set a primary email address (in your personal settings) first.')
+				{{ t('twofactor_email', 'No email address available, please set a primary email address in your personal settings first.')
 				}}
 			</span>
 		</div>
@@ -30,7 +30,7 @@
 			{{ t('twofactor_email', 'Password confirmation failed. Please try again.') }}
 		</span>
 		<span v-else-if="store.error === 'no-email'" class="error">
-			{{ t('twofactor_email', 'Apparently your previously configured email address just vanished.') }}
+			{{ t('twofactor_email', 'Your email address was removed in the meantime, please set a primary email address in your personal settings first.') }}
 		</span>
 		<span v-else-if="store.error === 'save-failed'" class="error">
 			{{ t('twofactor_email', 'Could not enable/disable two-factor authentication via email.') }}

--- a/templates/LoginChallenge.php
+++ b/templates/LoginChallenge.php
@@ -35,7 +35,7 @@ $resendAvailableIn = (int)($_['resendAvailableIn'] ?? 0); // seconds left before
 
 <?php if ($error === 'no-email'): ?>
 	<p class="warning">
-		<?php p($l->t('An error occurred: No email address is configured in your personal settings. Please contact your administrator.')); ?>
+		<?php p($l->t('No email address available, please contact your administrator.')); ?>
 	</p>
 <?php elseif ($error === 'send-failed'): ?>
 	<p class="warning">


### PR DESCRIPTION
Implements the "no email address" wording item of the roadmap (#7). Based on #102 — merge the stack (#99 → #100 → #101 → #102) first.

Five different strings become three context-correct ones, phrased like the core hints ("No encryption module loaded, please enable …"):

- Settings contexts (personal settings notice and setup hint): "No email address available, please set a primary email address in your personal settings first."
- Stale-page case (the address existed when the page was loaded but is gone on save): keeps its meaning in simpler words — "Your email address was removed in the meantime, please set a primary email address in your personal settings first." (was: "Apparently your previously configured email address just vanished.")
- Login contexts (challenge dialog, resend, login setup): "No email address available, please contact your administrator." — the user cannot reach the settings mid-login. This also fixes the login setup flow, which previously pointed to the unreachable personal settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.