### PR TITLE
Make activity and notification texts translatable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Wrong and repeated activity entries for accounts without an email address
+- Activity and notification texts could not be translated
 
 ## 3.2.0 (2026-07-05)
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -60,7 +60,7 @@ at the bottom of "Personal Settings/Security").]]></description>
     <repository>https://github.com/datenschutz-individuell/twofactor_email.git</repository>
     <screenshot
             small-thumbnail="https://raw.githubusercontent.com/datenschutz-individuell/twofactor_email/main/screenshots/select-auth_thumb.webp">
-        https://raw.githubusercontent.com/datenschutz-individuell/twofactor_email/master/screenshots/challenge.webp
+        https://raw.githubusercontent.com/datenschutz-individuell/twofactor_email/main/screenshots/challenge.webp
     </screenshot>
     <dependencies>
         <php min-version="8.1" max-version="8.5"/>

--- a/lib/Activity/Notification.php
+++ b/lib/Activity/Notification.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\TwoFactorEMail\Activity;
 
 use OCA\TwoFactorEMail\Event\StateChangeActor;
+use OCP\IL10N;
 
 enum Notification: string {
 	case ENABLED_BY_USER = 'twofactor_email_enabled_by_user';
@@ -27,13 +28,18 @@ enum Notification: string {
 		};
 	}
 
-	public function getSubjectText(): string {
+	/**
+	 * The strings are literal $l->t() calls so the translation tool can
+	 * extract them — passing them through a variable would leave the texts
+	 * untranslatable.
+	 */
+	public function getTranslatedSubject(IL10N $l): string {
 		return match ($this) {
-			Notification::ENABLED_BY_USER => 'You enabled email two-factor authentication for your account',
-			Notification::DISABLED_BY_USER => 'You disabled email two-factor authentication for your account',
-			Notification::ENABLED_BY_ADMIN => 'Email two-factor authentication was enabled by an admin',
-			Notification::DISABLED_BY_ADMIN => 'Email two-factor authentication was disabled by an admin',
-			Notification::DISABLED_NO_EMAIL => 'Email two-factor authentication was disabled because your account has no email address',
+			Notification::ENABLED_BY_USER => $l->t('You enabled email two-factor authentication for your account'),
+			Notification::DISABLED_BY_USER => $l->t('You disabled email two-factor authentication for your account'),
+			Notification::ENABLED_BY_ADMIN => $l->t('Email two-factor authentication was enabled by an admin'),
+			Notification::DISABLED_BY_ADMIN => $l->t('Email two-factor authentication was disabled by an admin'),
+			Notification::DISABLED_NO_EMAIL => $l->t('Email two-factor authentication was disabled because your account has no email address'),
 		};
 	}
 }

--- a/lib/Activity/Provider.php
+++ b/lib/Activity/Provider.php
@@ -37,7 +37,7 @@ final class Provider implements IProvider {
 		$l = $this->l10n->get(Application::APP_ID, $language);
 
 		$event->setIcon($this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('core', 'actions/password.svg')));
-		$event->setSubject($l->t($notification->getSubjectText()));
+		$event->setParsedSubject($notification->getTranslatedSubject($l));
 
 		return $event;
 	}

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -47,7 +47,7 @@ final class Notifier implements INotifier {
 		}
 
 		$l = $this->l10nFactory->get(Application::APP_ID, $languageCode);
-		$notification->setParsedSubject($l->t($subject->getSubjectText()));
+		$notification->setParsedSubject($subject->getTranslatedSubject($l));
 		$notification->setIcon($this->urlGenerator->getAbsoluteURL(
 			$this->urlGenerator->imagePath(Application::APP_ID, 'app-dark.svg'),
 		));

--- a/src/components/LoginSetup.vue
+++ b/src/components/LoginSetup.vue
@@ -18,7 +18,7 @@
 		</span>
 		<div v-else-if="loading" class="loading" style="min-height: 50px" />
 		<div v-else>
-			<p>Successfully enabled</p>
+			<p>{{ t('twofactor_email', 'Two-factor authentication via email was enabled.') }}</p>
 			<p>
 				{{ t('twofactor_email', 'Codes will be sent to your primary email address:') }} <b>{{ store.maskedEmail
 				}}</b>

--- a/tests/Unit/Activity/ProviderTest.php
+++ b/tests/Unit/Activity/ProviderTest.php
@@ -30,6 +30,7 @@ class ProviderTest extends TestCase {
 			[Notification::DISABLED_BY_USER],
 			[Notification::ENABLED_BY_ADMIN],
 			[Notification::DISABLED_BY_ADMIN],
+			[Notification::DISABLED_NO_EMAIL],
 		];
 	}
 
@@ -55,6 +56,7 @@ class ProviderTest extends TestCase {
 		$lang = 'ru';
 		$event = $this->createMock(IEvent::class);
 		$l = $this->createMock(IL10N::class);
+		$l->method('t')->willReturnArgument(0);
 
 		$event->expects($this->once())
 			->method('getApp')
@@ -78,7 +80,8 @@ class ProviderTest extends TestCase {
 			->method('getSubject')
 			->willReturn($subject->value);
 		$event->expects($this->once())
-			->method('setSubject');
+			->method('setParsedSubject')
+			->with($subject->getTranslatedSubject($l));
 
 		$this->provider->parse($lang, $event);
 	}


### PR DESCRIPTION
Fixes three review findings. Based on #105 — merge the stack (#99 → #100 → #101 → #102 → #103 → #105) first, and merge this one before tagging 3.3.0 (its changelog entry sits in the 3.3.0 section).

- **Activity and notification texts were never translatable:** the subject texts were passed to `$l->t()` through a variable, so the translation tool never extracted them — activities (and the new notifications) were always English. The texts are now literal `$l->t()` calls in `Notification::getTranslatedSubject()`, shared by the activity provider and the notifier. The activity provider also sets the parsed subject now instead of overwriting the machine-readable subject, as the Activity API intends.
- Wrap the untranslated "Successfully enabled" in the login setup (now "Two-factor authentication via email was enabled.")
- Point the App Store screenshot URL at the renamed `main` branch (was `master`)

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.