### PR TITLE
Clean up expired codes daily and harden state saving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Admin settings: show and change all app settings via occ
 - Admins can delete the stored codes of one or all users via occ
 - Notify the user if an admin (de)activated this 2FA provider or the primary email address was deleted
+- Expired codes are cleaned up daily by a background job
 
 ### Changed
 
@@ -21,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Wrong and repeated activity entries for accounts without an email address
 - Activity and notification texts could not be translated
+- Saving an unchanged on/off state created duplicate activity entries
 
 ## 3.2.0 (2026-07-05)
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -66,6 +66,9 @@ at the bottom of "Personal Settings/Security").]]></description>
         <php min-version="8.1" max-version="8.5"/>
         <nextcloud min-version="32" max-version="34"/>
     </dependencies>
+    <background-jobs>
+        <job>OCA\TwoFactorEMail\BackgroundJob\CleanUpExpiredCodes</job>
+    </background-jobs>
     <two-factor-providers>
         <provider>OCA\TwoFactorEMail\Provider\TwoFactorEMail</provider>
     </two-factor-providers>

--- a/lib/BackgroundJob/CleanUpExpiredCodes.php
+++ b/lib/BackgroundJob/CleanUpExpiredCodes.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\BackgroundJob;
+
+use OCA\TwoFactorEMail\Service\ICodeStorage;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJob;
+use OCP\BackgroundJob\TimedJob;
+
+/**
+ * Removes expired codes of users who did not return to the login page.
+ * Without this job their hashed codes and timestamps would stay in the
+ * user preferences indefinitely (data minimization).
+ */
+final class CleanUpExpiredCodes extends TimedJob {
+
+	public function __construct(
+		ITimeFactory $time,
+		private readonly ICodeStorage $codeStorage,
+	) {
+		parent::__construct($time);
+		$this->setInterval(24 * 3600);
+		$this->setTimeSensitivity(IJob::TIME_INSENSITIVE);
+	}
+
+	protected function run($argument): void {
+		$this->codeStorage->deleteExpired();
+	}
+}

--- a/lib/Controller/StateController.php
+++ b/lib/Controller/StateController.php
@@ -45,6 +45,14 @@ final class StateController extends ALoginSetupController {
 			], Http::STATUS_UNAUTHORIZED);
 		}
 
+		// Saving an unchanged state must not dispatch another StateChanged
+		// event — each dispatch creates an activity entry.
+		if ($state === $this->stateManager->isEnabled($user)) {
+			return new JSONResponse([
+				'enabled' => $state,
+			]);
+		}
+
 		if ($state) {
 			if ($user->getEMailAddress() === null) {
 				return new JSONResponse([

--- a/lib/Service/EMailSender.php
+++ b/lib/Service/EMailSender.php
@@ -32,7 +32,8 @@ final class EMailSender implements IEMailSender {
 			throw new EMailNotSet($user);
 		}
 
-		$this->logger->debug("sending email message to $email.");
+		// Deliberately logs the UID, not the email address (data minimization)
+		$this->logger->debug('sending email message to user ' . $user->getUID() . '.');
 
 		// For every part an empty admin setting means: use the localized default
 		$subject = $this->appSettings->getEMailSubject() ?: $this->appSettings->getDefaultEMailSubject();

--- a/tests/Unit/BackgroundJob/CleanUpExpiredCodesTest.php
+++ b/tests/Unit/BackgroundJob/CleanUpExpiredCodesTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Test\Unit\BackgroundJob;
+
+use OCA\TwoFactorEMail\BackgroundJob\CleanUpExpiredCodes;
+use OCA\TwoFactorEMail\Service\ICodeStorage;
+use OCP\AppFramework\Utility\ITimeFactory;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+class CleanUpExpiredCodesTest extends TestCase {
+	/**
+	 * @throws Exception
+	 */
+	public function testRunDeletesExpiredCodes(): void {
+		$codeStorage = $this->createMock(ICodeStorage::class);
+		$codeStorage->expects($this->once())->method('deleteExpired');
+		$job = new CleanUpExpiredCodes($this->createMock(ITimeFactory::class), $codeStorage);
+
+		// run() is protected by the TimedJob contract
+		(new ReflectionMethod($job, 'run'))->invoke($job, null);
+	}
+}

--- a/tests/Unit/Controller/StateControllerTest.php
+++ b/tests/Unit/Controller/StateControllerTest.php
@@ -33,9 +33,43 @@ class StateControllerTest extends TestCase {
 		$this->userSession->expects($this->once())
 			->method('getUser')
 			->willReturn($user);
+		$this->stateManager->method('isEnabled')->willReturn(true);
 		$this->stateManager->expects($this->once())
 			->method('disable')
 			->with($user);
+
+		$expected = new JSONResponse([
+			'enabled' => false,
+		]);
+
+		$this->assertEquals($expected, $this->controller->save(false));
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testSavingUnchangedStateDispatchesNothing() {
+		$user = $this->createMock(IUser::class);
+		$this->userSession->method('getUser')->willReturn($user);
+		$this->stateManager->method('isEnabled')->willReturn(true);
+		$this->stateManager->expects($this->never())->method('enable');
+		$this->stateManager->expects($this->never())->method('disable');
+
+		$expected = new JSONResponse([
+			'enabled' => true,
+		]);
+
+		$this->assertEquals($expected, $this->controller->save(true));
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testSavingUnchangedDisabledStateDispatchesNothing() {
+		$user = $this->createMock(IUser::class);
+		$this->userSession->method('getUser')->willReturn($user);
+		$this->stateManager->method('isEnabled')->willReturn(false);
+		$this->stateManager->expects($this->never())->method('disable');
 
 		$expected = new JSONResponse([
 			'enabled' => false,


### PR DESCRIPTION
Supersedes #101 (same fix, plus the state-change notifications and the shared refactor). The more precise occ-coverage docblock from #101 has been ported here and verified against NC 32–34/master.
_____

Implements the remaining review findings. Based on #106 — merge the stack (#99 → #100 → #101 → #102 → #103 → #105 → #106) first, and merge this one before tagging 3.3.0 (its changelog entries sit in the 3.3.0 section).

- **Daily cleanup of expired codes:** a new `TimedJob` runs the existing `deleteExpired()` once a day (time-insensitive), so hashed codes and timestamps of users who never return to the login page no longer stay in the preferences indefinitely (data minimization). The `occ twofactor_email:cleanup` command remains for immediate runs.
- **No duplicate activity entries:** `StateController::save()` now skips dispatching `StateChanged` when the saved state equals the current one (e.g. repeated POSTs).
- **Data minimization in logs:** the email sender logs the UID instead of the email address.
- 3 new unit tests (100 total); `info.xml` validated against the app store schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.