### PR TITLE
Dismiss outdated notifications and polish minor findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Wrong and repeated activity entries for accounts without an email address
 - Activity and notification texts could not be translated
 - Saving an unchanged on/off state created duplicate activity entries
+- Outdated notifications are dismissed when the provider state changes again
 
 ## 3.2.0 (2026-07-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Admin settings: show and change all app settings via occ
 - Admins can delete the stored codes of one or all users via occ
 - Notify the user if an admin (de)activated this 2FA provider or the primary email address was deleted
+- Expired codes are cleaned up daily by a background job
 
 ### Changed
 
@@ -21,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Wrong and repeated activity entries for accounts without an email address
 - Activity and notification texts could not be translated
+- Saving an unchanged on/off state created duplicate activity entries
 
 ## 3.2.0 (2026-07-05)
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -66,6 +66,9 @@ at the bottom of "Personal Settings/Security").]]></description>
         <php min-version="8.1" max-version="8.5"/>
         <nextcloud min-version="32" max-version="34"/>
     </dependencies>
+    <background-jobs>
+        <job>OCA\TwoFactorEMail\BackgroundJob\CleanUpExpiredCodes</job>
+    </background-jobs>
     <two-factor-providers>
         <provider>OCA\TwoFactorEMail\Provider\TwoFactorEMail</provider>
     </two-factor-providers>

--- a/lib/BackgroundJob/CleanUpExpiredCodes.php
+++ b/lib/BackgroundJob/CleanUpExpiredCodes.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\BackgroundJob;
+
+use OCA\TwoFactorEMail\Service\ICodeStorage;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJob;
+use OCP\BackgroundJob\TimedJob;
+
+/**
+ * Removes expired codes of users who did not return to the login page.
+ * Without this job their hashed codes and timestamps would stay in the
+ * user preferences indefinitely (data minimization).
+ */
+final class CleanUpExpiredCodes extends TimedJob {
+
+	public function __construct(
+		ITimeFactory $time,
+		private readonly ICodeStorage $codeStorage,
+	) {
+		parent::__construct($time);
+		$this->setInterval(24 * 3600);
+		$this->setTimeSensitivity(IJob::TIME_INSENSITIVE);
+	}
+
+	protected function run($argument): void {
+		$this->codeStorage->deleteExpired();
+	}
+}

--- a/lib/Command/CleanUp.php
+++ b/lib/Command/CleanUp.php
@@ -34,6 +34,6 @@ final class CleanUp extends Command {
 		$io->title('Removing expired two-factor email codes');
 		$this->codeStorage->deleteExpired();
 		$io->success('Done.');
-		return 0;
+		return Command::SUCCESS;
 	}
 }

--- a/lib/Controller/StateController.php
+++ b/lib/Controller/StateController.php
@@ -45,6 +45,14 @@ final class StateController extends ALoginSetupController {
 			], Http::STATUS_UNAUTHORIZED);
 		}
 
+		// Saving an unchanged state must not dispatch another StateChanged
+		// event — each dispatch creates an activity entry.
+		if ($state === $this->stateManager->isEnabled($user)) {
+			return new JSONResponse([
+				'enabled' => $state,
+			]);
+		}
+
 		if ($state) {
 			if ($user->getEMailAddress() === null) {
 				return new JSONResponse([

--- a/lib/Listener/StateChangeNotification.php
+++ b/lib/Listener/StateChangeNotification.php
@@ -38,12 +38,21 @@ final class StateChangeNotification implements IEventListener {
 		if (!$event instanceof StateChanged) {
 			return;
 		}
+		$uid = $event->getUser()->getUID();
+
+		// An earlier notification about this provider's state is outdated now,
+		// whoever caused the change — dismiss it before possibly adding a new one.
+		$outdated = $this->notificationManager->createNotification();
+		$outdated->setApp(Application::APP_ID)
+			->setUser($uid)
+			->setObject('twofactor_email_state', $uid);
+		$this->notificationManager->dismissNotification($outdated);
+
 		if ($event->getActor() === StateChangeActor::USER) {
 			return;
 		}
 
 		$subject = Notification::fromStateChange($event->getActor(), $event->isEnabled());
-		$uid = $event->getUser()->getUID();
 
 		$notification = $this->notificationManager->createNotification();
 		$notification->setApp(Application::APP_ID)

--- a/lib/Service/EMailSender.php
+++ b/lib/Service/EMailSender.php
@@ -32,7 +32,8 @@ final class EMailSender implements IEMailSender {
 			throw new EMailNotSet($user);
 		}
 
-		$this->logger->debug("sending email message to $email.");
+		// Deliberately logs the UID, not the email address (data minimization)
+		$this->logger->debug('sending email message to user ' . $user->getUID() . '.');
 
 		// For every part an empty admin setting means: use the localized default
 		$subject = $this->appSettings->getEMailSubject() ?: $this->appSettings->getDefaultEMailSubject();

--- a/src/Store.js
+++ b/src/Store.js
@@ -9,29 +9,31 @@ import { persistAdminSettings, persistState, resetAdminSettings } from './servic
 
 export const pinia = createPinia()
 
+/**
+ * Loads the initial state from Nextcloud into the store (shared action).
+ * Only tries to fetch the given keys.
+ * All initial state keys must be the same as in the store.
+ *
+ * @param {string} keys keys to load from initial state
+ */
+function loadInitialState(...keys) {
+	const initialState = {}
+	for (const key of keys) {
+		initialState[key] = loadState('twofactor_email', key)
+	}
+	this.$patch(initialState)
+}
+
 export const usePersonalSettingsStore = defineStore('personalSettings', {
 	state: () => ({
 		enabled: false,
 		hasEmail: false,
-		maskedEmail: 'UNEXPECTED ERROR: no email address set',
-		email: 'UNEXPECTED ERROR: no email address set',
+		maskedEmail: '',
+		email: '',
 		error: false,
 	}),
 	actions: {
-		/**
-		 * Loads the initial state from Nextcloud into the Store.
-		 * Only tries to fetch the given keys.
-		 * All initial state keys must be the same as in the store.
-		 *
-		 * @param {string} keys keys to load from initial state
-		 */
-		loadInitialState(...keys) {
-			const initialState = {}
-			for (const key of keys) {
-				initialState[key] = loadState('twofactor_email', key)
-			}
-			this.$patch(initialState)
-		},
+		loadInitialState,
 		async save() {
 			const previousState = this.enabled
 			const result = await persistState(this.enabled)
@@ -60,20 +62,7 @@ export const useAdminSettingsStore = defineStore('adminSettings', {
 		error: false,
 	}),
 	actions: {
-		/**
-		 * Loads the initial state from Nextcloud into the Store.
-		 * Only tries to fetch the given keys.
-		 * All initial state keys must be the same as in the store.
-		 *
-		 * @param {string} keys keys to load from initial state
-		 */
-		loadInitialState(...keys) {
-			const initialState = {}
-			for (const key of keys) {
-				initialState[key] = loadState('twofactor_email', key)
-			}
-			this.$patch(initialState)
-		},
+		loadInitialState,
 		async save() {
 			const result = await persistAdminSettings({
 				codeLength: this.codeLength,

--- a/tests/Unit/BackgroundJob/CleanUpExpiredCodesTest.php
+++ b/tests/Unit/BackgroundJob/CleanUpExpiredCodesTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Test\Unit\BackgroundJob;
+
+use OCA\TwoFactorEMail\BackgroundJob\CleanUpExpiredCodes;
+use OCA\TwoFactorEMail\Service\ICodeStorage;
+use OCP\AppFramework\Utility\ITimeFactory;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+class CleanUpExpiredCodesTest extends TestCase {
+	/**
+	 * @throws Exception
+	 */
+	public function testRunDeletesExpiredCodes(): void {
+		$codeStorage = $this->createMock(ICodeStorage::class);
+		$codeStorage->expects($this->once())->method('deleteExpired');
+		$job = new CleanUpExpiredCodes($this->createMock(ITimeFactory::class), $codeStorage);
+
+		// run() is protected by the TimedJob contract
+		(new ReflectionMethod($job, 'run'))->invoke($job, null);
+	}
+}

--- a/tests/Unit/Controller/StateControllerTest.php
+++ b/tests/Unit/Controller/StateControllerTest.php
@@ -33,9 +33,43 @@ class StateControllerTest extends TestCase {
 		$this->userSession->expects($this->once())
 			->method('getUser')
 			->willReturn($user);
+		$this->stateManager->method('isEnabled')->willReturn(true);
 		$this->stateManager->expects($this->once())
 			->method('disable')
 			->with($user);
+
+		$expected = new JSONResponse([
+			'enabled' => false,
+		]);
+
+		$this->assertEquals($expected, $this->controller->save(false));
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testSavingUnchangedStateDispatchesNothing() {
+		$user = $this->createMock(IUser::class);
+		$this->userSession->method('getUser')->willReturn($user);
+		$this->stateManager->method('isEnabled')->willReturn(true);
+		$this->stateManager->expects($this->never())->method('enable');
+		$this->stateManager->expects($this->never())->method('disable');
+
+		$expected = new JSONResponse([
+			'enabled' => true,
+		]);
+
+		$this->assertEquals($expected, $this->controller->save(true));
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testSavingUnchangedDisabledStateDispatchesNothing() {
+		$user = $this->createMock(IUser::class);
+		$this->userSession->method('getUser')->willReturn($user);
+		$this->stateManager->method('isEnabled')->willReturn(false);
+		$this->stateManager->expects($this->never())->method('disable');
 
 		$expected = new JSONResponse([
 			'enabled' => false,

--- a/tests/Unit/Listener/StateChangeNotificationTest.php
+++ b/tests/Unit/Listener/StateChangeNotificationTest.php
@@ -52,17 +52,29 @@ class StateChangeNotificationTest extends TestCase {
 	/**
 	 * @throws Exception
 	 */
-	private function expectNotificationWithSubject(string $subject): void {
+	private function mockNotification(): INotification&MockObject {
 		$notification = $this->createMock(INotification::class);
 		$notification->method('setApp')->willReturnSelf();
 		$notification->method('setUser')->with('alice')->willReturnSelf();
 		$notification->method('setDateTime')->willReturnSelf();
 		$notification->method('setObject')->willReturnSelf();
-		$notification->expects($this->once())
+		$notification->method('setSubject')->willReturnSelf();
+		return $notification;
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	private function expectNotificationWithSubject(string $subject): void {
+		// First createNotification() builds the dismiss filter, the second the new notification
+		$newNotification = $this->mockNotification();
+		$newNotification->expects($this->once())
 			->method('setSubject')
 			->with($subject)
 			->willReturnSelf();
-		$this->notificationManager->method('createNotification')->willReturn($notification);
+		$this->notificationManager->method('createNotification')
+			->willReturnOnConsecutiveCalls($this->mockNotification(), $newNotification);
+		$this->notificationManager->expects($this->once())->method('dismissNotification');
 		$this->notificationManager->expects($this->once())->method('notify');
 	}
 
@@ -78,13 +90,19 @@ class StateChangeNotificationTest extends TestCase {
 		$this->listener->handle(new StateChanged($this->mockUser(), false, StateChangeActor::SYSTEM));
 	}
 
-	public function testDoesNotNotifyAboutOwnChanges(): void {
+	/**
+	 * @throws Exception
+	 */
+	public function testDoesNotNotifyAboutOwnChangesButDismissesOutdatedOnes(): void {
+		$this->notificationManager->method('createNotification')->willReturn($this->mockNotification());
+		$this->notificationManager->expects($this->once())->method('dismissNotification');
 		$this->notificationManager->expects($this->never())->method('notify');
 
 		$this->listener->handle(new StateChanged($this->mockUser(), true, StateChangeActor::USER));
 	}
 
 	public function testIgnoresForeignEvents(): void {
+		$this->notificationManager->expects($this->never())->method('dismissNotification');
 		$this->notificationManager->expects($this->never())->method('notify');
 
 		$this->listener->handle(new Event());


### PR DESCRIPTION
Polishes the last review findings. Based on #107 — merge the stack (#99 → #100 → #101 → #102 → #103 → #105 → #106 → #107) first, and merge this one before tagging 3.3.0 (its changelog entry sits in the 3.3.0 section).

- **Dismiss outdated notifications:** a new state change dismisses earlier notifications about the provider state (via `IManager::dismissNotification()`), so after a re-enable the bell no longer shows the outdated "disabled" message. The dismissal also runs for the user's own changes.
- Deduplicate the identical `loadInitialState` action of both Pinia stores
- Replace the `UNEXPECTED ERROR: …` developer fallback strings (which could surface in the UI) with empty strings
- `twofactor_email:cleanup` returns `Command::SUCCESS` instead of a bare `0`, like the other commands

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.