### PR TITLE
Harden the rendered email subject against header injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Saving an unchanged on/off state created duplicate activity entries
 - Outdated notifications are dismissed when the provider state changes again
 
+### Security
+
+- Harden the challenge email subject against header injection (defense in depth)
+
 ## 3.2.0 (2026-07-05)
 
 ### Added

--- a/lib/Mail/TemplateRenderer.php
+++ b/lib/Mail/TemplateRenderer.php
@@ -45,10 +45,14 @@ final class TemplateRenderer {
 
 	/**
 	 * The subject is a single line of plain text — all placeholders are
-	 * inserted bare.
+	 * inserted bare. Line breaks are replaced after the substitution: the
+	 * admin text is validated single-line, but placeholder values like the
+	 * display name are not, and a line break in a mail header must never
+	 * reach the mailer (header injection, defense in depth).
 	 */
 	public function renderSubject(string $subject, IUser $user, string $code): string {
-		return strtr($subject, $this->placeholderValues($user, $code));
+		$rendered = strtr($subject, $this->placeholderValues($user, $code));
+		return str_replace(["\r\n", "\r", "\n"], ' ', $rendered);
 	}
 
 	/**

--- a/tests/Unit/Mail/TemplateRendererTest.php
+++ b/tests/Unit/Mail/TemplateRendererTest.php
@@ -58,6 +58,20 @@ class TemplateRendererTest extends TestCase {
 		);
 	}
 
+	/**
+	 * @throws Exception
+	 */
+	public function testSubjectStaysSingleLineDespiteLineBreaksInDisplayName(): void {
+		// A line break in a mail header must never reach the mailer (header injection)
+		$user = $this->createMock(IUser::class);
+		$user->method('getDisplayName')->willReturn("Jane\r\nBcc: spy@example.com");
+
+		$this->assertSame(
+			'Login of Jane Bcc: spy@example.com',
+			$this->renderer->renderSubject('Login of {user}', $user, '123456'),
+		);
+	}
+
 	public function testBodyStartsWithTheSpacingParagraph(): void {
 		$this->assertSame(
 			[['&nbsp;', false]],


### PR DESCRIPTION
Defense-in-depth finding from a security review of the whole stack. Based on #108 — merge the stack (#99 → #100 → #101 → #102 → #103 → #105 → #106 → #107 → #108) first, and merge this one before tagging 3.3.0.

The admin subject text is validated single-line, but placeholder values like the display name are substituted afterwards, so a display name containing CR/LF would reach `setSubject()`. Nextcloud's mailer already encodes header values (Symfony Mime), so this was **not exploitable** — as defense in depth the renderer now replaces any line break in the rendered subject with a space. One new unit test (101 total).

The review found no exploitable vulnerability in the stack; this hardening was its only actionable outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.