### PR TITLE
Restore the instance logo after upgrades from 3.1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Activity and notification texts could not be translated
 - Saving an unchanged on/off state created duplicate activity entries
 - Outdated notifications are dismissed when the provider state changes again
+- The instance logo returns to the challenge email after upgrades from 3.1.x (#109)
 
 ### Security
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -69,6 +69,11 @@ at the bottom of "Personal Settings/Security").]]></description>
     <background-jobs>
         <job>OCA\TwoFactorEMail\BackgroundJob\CleanUpExpiredCodes</job>
     </background-jobs>
+    <repair-steps>
+        <post-migration>
+            <step>OCA\TwoFactorEMail\Migration\RemovePersistedDefaultTemplate</step>
+        </post-migration>
+    </repair-steps>
     <two-factor-providers>
         <provider>OCA\TwoFactorEMail\Provider\TwoFactorEMail</provider>
     </two-factor-providers>

--- a/lib/Migration/RemovePersistedDefaultTemplate.php
+++ b/lib/Migration/RemovePersistedDefaultTemplate.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Migration;
+
+use OCA\TwoFactorEMail\Service\IAppSettings;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+/**
+ * In 3.1.x the admin UI showed the default email body as the field value and
+ * saving any admin setting persisted it, so most instances stored the 3.1
+ * default text without ever customizing it. Since 3.2.0 a non-empty stored
+ * template suppresses the current default — and with it the {logo} token, so
+ * the instance logo vanished from the challenge emails (issue #109).
+ *
+ * This step deletes the stored template if and only if it is byte-identical
+ * to the 3.1 default text (which was never localized), so the current
+ * default applies again. Real customizations are left untouched.
+ */
+final class RemovePersistedDefaultTemplate implements IRepairStep {
+
+	// The hardcoded default body of twofactor_email 3.1.0 – 3.1.2, verbatim
+	private const OLD_DEFAULT_TEMPLATE
+		= "Your two-factor authentication code is: {code}\n\n"
+		. 'If you tried to login, please enter that code on {cloud}. '
+		. 'If you did not, somebody else did and knows your email address '
+		. 'or username – and your password!';
+
+	public function __construct(
+		private readonly IAppSettings $appSettings,
+	) {
+	}
+
+	public function getName(): string {
+		return 'Remove the email template that 3.1.x persisted without customization';
+	}
+
+	public function run(IOutput $output): void {
+		if ($this->appSettings->getEMailTemplate() !== self::OLD_DEFAULT_TEMPLATE) {
+			return;
+		}
+		// Empty means: use the localized default (which contains {logo})
+		$this->appSettings->setEMailTemplate('');
+		$output->info('Removed the persisted 3.1 default email template; the current default (with {logo}) applies again.');
+	}
+}

--- a/tests/Unit/Migration/RemovePersistedDefaultTemplateTest.php
+++ b/tests/Unit/Migration/RemovePersistedDefaultTemplateTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Test\Unit\Migration;
+
+use OCA\TwoFactorEMail\Migration\RemovePersistedDefaultTemplate;
+use OCA\TwoFactorEMail\Service\IAppSettings;
+use OCP\Migration\IOutput;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class RemovePersistedDefaultTemplateTest extends TestCase {
+	private const OLD_DEFAULT_TEMPLATE
+		= "Your two-factor authentication code is: {code}\n\n"
+		. 'If you tried to login, please enter that code on {cloud}. '
+		. 'If you did not, somebody else did and knows your email address '
+		. 'or username – and your password!';
+
+	private IAppSettings&MockObject $appSettings;
+
+	private RemovePersistedDefaultTemplate $step;
+
+	/**
+	 * @throws Exception
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->appSettings = $this->createMock(IAppSettings::class);
+
+		$this->step = new RemovePersistedDefaultTemplate($this->appSettings);
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testRemovesThePersistedOldDefault(): void {
+		$this->appSettings->method('getEMailTemplate')->willReturn(self::OLD_DEFAULT_TEMPLATE);
+		$this->appSettings->expects($this->once())->method('setEMailTemplate')->with('');
+
+		$this->step->run($this->createMock(IOutput::class));
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testKeepsCustomizedTemplates(): void {
+		$this->appSettings->method('getEMailTemplate')->willReturn('My custom text with {code}');
+		$this->appSettings->expects($this->never())->method('setEMailTemplate');
+
+		$this->step->run($this->createMock(IOutput::class));
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testKeepsEmptyTemplates(): void {
+		$this->appSettings->method('getEMailTemplate')->willReturn('');
+		$this->appSettings->expects($this->never())->method('setEMailTemplate');
+
+		$this->step->run($this->createMock(IOutput::class));
+	}
+}


### PR DESCRIPTION
Fixes the logo half of #109. Based on #110 — merge the stack (#99 → #100 → #101 → #102 → #103 → #105 → #106 → #107 → #108 → #110) first, and merge this one before tagging 3.3.0.

**Root cause:** In 3.1.x the admin UI showed the default email body as the field value, and saving *any* admin setting persisted it — so most instances stored the 3.1 default text without ever customizing it. Since 3.2.0 a non-empty stored template suppresses the current default, and with it the `{logo}` token: the instance logo (previously rendered by the removed `addHeader()`) vanished from the challenge emails.

**Fix:** a post-migration repair step deletes the stored template if and only if it is byte-identical to the (never localized) 3.1 default text — verified byte-identical against the 3.1.2 source. The current default with `{logo}` applies again. Real customizations are left untouched; those admins can add `{logo}` to their template (release-note-worthy).

Deliberately *not* restoring an automatic logo header: a template without `{logo}` remains a valid way to send logo-free emails.

3 new unit tests (104 total); `info.xml` validated against the app store schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.