### PR TITLE
Ignore .envrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,12 +11,10 @@ css/
 
 /.php-cs-fixer.cache
 
-# Ignore NetBeans project
 /nbproject/
-# Ignore JetBrains project
 /.idea/
-# Ignore Claude preferences
 /.claude/
+/.envrc
 
 tests/clover.xml
 tests/.phpunit.result.cache


### PR DESCRIPTION
The direnv file holds the per-repo GH_TOKEN lookup and must never be committed, on no machine and by no contributor — the global git ignore only protects a single machine. Independent of the open stack (no conflict possible).

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.