### PR TITLE
Do not silently disable 2FA on third-party email removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - Harden the challenge email subject against header injection (defense in depth)
+- Keep 2FA enabled instead of dropping to password-only when a user's only email address is removed
 
 ## 3.2.0 (2026-07-05)
 

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -29,7 +29,6 @@ use OCA\TwoFactorEMail\Service\IStateManager;
 use OCA\TwoFactorEMail\Service\LoginChallenge;
 use OCA\TwoFactorEMail\Service\NumericalCodeGenerator;
 use OCA\TwoFactorEMail\Service\StateManager;
-use OCP\Accounts\UserUpdatedEvent;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
@@ -60,7 +59,6 @@ final class Application extends App implements IBootstrap {
 		$context->registerEventListener(StateChanged::class, StateChangeRegistryUpdater::class);
 		$context->registerEventListener(StateChanged::class, StateChangeActivity::class);
 		$context->registerEventListener(StateChanged::class, StateChangeNotification::class);
-		$context->registerEventListener(UserUpdatedEvent::class, EMailDeleted::class);
 		$context->registerEventListener(UserChangedEvent::class, EMailDeleted::class);
 
 		$context->registerNotifierService(Notifier::class);

--- a/lib/Listener/EMailDeleted.php
+++ b/lib/Listener/EMailDeleted.php
@@ -11,51 +11,58 @@ namespace OCA\TwoFactorEMail\Listener;
 
 use OCA\TwoFactorEMail\Event\StateChangeActor;
 use OCA\TwoFactorEMail\Service\IStateManager;
-use OCP\Accounts\UserUpdatedEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
-use OCP\IUser;
 use OCP\User\Events\UserChangedEvent;
 
 /**
- * Disables the provider when an account loses its email address — codes
- * could no longer be delivered. Listens on both events that cover the two
- * UI paths: profile/account updates (UserUpdatedEvent) and direct email
- * changes, e.g. by an admin via the users page (UserChangedEvent).
+ * Disables email 2FA when an account loses its email address, but only when
+ * that removes no protection — it never silently downgrades an account to
+ * password-only.
  *
- * Not covered (Nextcloud fires no event): raw preference edits like
- * `occ user:setting <uid> settings email --delete`.
+ * Trigger: UserChangedEvent for the 'eMailAddress' feature. Every path that
+ * clears the address used for delivery goes through IUser::setSystemEMailAddress()
+ * (personal settings, the users page, the provisioning API, `occ user:setting`),
+ * which fires this event. Account-only changes (additional emails,
+ * `occ user:profile`) leave getEMailAddress() intact and are correctly ignored.
  *
- * @template-implements IEventListener<UserUpdatedEvent|UserChangedEvent>
+ * Once the address is gone and the provider is still enabled:
+ *   - another active provider remains → disable, no protection is lost;
+ *   - email was the sole factor → keep it enabled (fail-closed), whoever
+ *     cleared the address.
+ *
+ * Disabling the sole factor would drop the account to password-only. That would
+ * skip the password confirmation which turning 2FA off directly requires
+ * (StateController), and it would let anyone who may edit a user's email — a
+ * group subadmin, a directory sync, or someone on an unlocked session — remove
+ * a second factor without it. So the provider stays enabled and the challenge
+ * fails until the address is restored or an admin runs
+ * `occ twofactorauth:disable <uid> email`.
+ *
+ * @template-implements IEventListener<UserChangedEvent>
  */
 final class EMailDeleted implements IEventListener {
 
 	public function __construct(
-		private readonly IStateManager $service,
+		private readonly IStateManager $stateManager,
 	) {
 	}
 
 	public function handle(Event $event): void {
-		$user = $this->affectedUser($event);
-		if ($user === null || $user->getEMailAddress() !== null) {
+		if (!$event instanceof UserChangedEvent || $event->getFeature() !== 'eMailAddress') {
 			return;
 		}
-		// Only disable an enabled provider: without this guard, every profile
-		// update of a user without an email address would dispatch another
-		// StateChanged event and create a bogus activity entry.
-		if (!$this->service->isEnabled($user)) {
+		$user = $event->getUser();
+		if ($user->getEMailAddress() !== null) {
+			return; // still deliverable (e.g. the address was changed, not cleared)
+		}
+		if (!$this->stateManager->isEnabled($user)) {
 			return;
 		}
-		$this->service->disable($user, StateChangeActor::SYSTEM);
-	}
-
-	private function affectedUser(Event $event): ?IUser {
-		if ($event instanceof UserUpdatedEvent) {
-			return $event->getUser();
+		// Disable only when another factor remains; keep the sole factor enabled
+		// (fail-closed) — see the class docblock.
+		if ($this->stateManager->hasOtherActiveProvider($user)) {
+			$this->stateManager->disable($user, StateChangeActor::SYSTEM);
 		}
-		if ($event instanceof UserChangedEvent && $event->getFeature() === 'eMailAddress') {
-			return $event->getUser();
-		}
-		return null;
 	}
 }

--- a/lib/Service/IStateManager.php
+++ b/lib/Service/IStateManager.php
@@ -18,4 +18,10 @@ interface IStateManager {
 	public function disable(IUser $user, StateChangeActor $actor = StateChangeActor::USER): void;
 
 	public function isEnabled(IUser $user): bool;
+
+	/**
+	 * Whether the user has another active 2FA provider besides email, i.e.
+	 * disabling email would not leave the account without a second factor.
+	 */
+	public function hasOtherActiveProvider(IUser $user): bool;
 }

--- a/lib/Service/StateManager.php
+++ b/lib/Service/StateManager.php
@@ -21,6 +21,9 @@ use OCP\IUser;
  * updating it here would create a circular dependency with the provider.
  */
 final class StateManager implements IStateManager {
+
+	private const PROVIDER_ID = 'email';
+
 	public function __construct(
 		private readonly IEventDispatcher $eventDispatcher,
 		private readonly IRegistry $registry,
@@ -36,6 +39,15 @@ final class StateManager implements IStateManager {
 	}
 
 	public function isEnabled(IUser $user): bool {
-		return $this->registry->getProviderStates($user)['email'] ?? false;
+		return $this->registry->getProviderStates($user)[self::PROVIDER_ID] ?? false;
+	}
+
+	public function hasOtherActiveProvider(IUser $user): bool {
+		foreach ($this->registry->getProviderStates($user) as $providerId => $enabled) {
+			if ($enabled && $providerId !== self::PROVIDER_ID) {
+				return true;
+			}
+		}
+		return false;
 	}
 }

--- a/tests/Unit/Listener/EMailDeletedTest.php
+++ b/tests/Unit/Listener/EMailDeletedTest.php
@@ -45,37 +45,43 @@ class EMailDeletedTest extends TestCase {
 		return $user;
 	}
 
-	public function testDisablesEnabledProviderOnAccountUpdateWithoutEmail(): void {
-		$user = $this->mockUser(null);
-		$this->stateManager->method('isEnabled')->with($user)->willReturn(true);
-		$this->stateManager->expects($this->once())->method('disable')->with($user, StateChangeActor::SYSTEM);
-
-		$this->listener->handle(new UserUpdatedEvent($user, []));
+	private function emailCleared(IUser $user): UserChangedEvent {
+		return new UserChangedEvent($user, 'eMailAddress', '', 'old@example.com');
 	}
 
-	public function testDisablesEnabledProviderWhenEmailFeatureIsCleared(): void {
+	public function testDisablesWhenAnotherProviderRemains(): void {
 		$user = $this->mockUser(null);
-		$this->stateManager->method('isEnabled')->with($user)->willReturn(true);
+		$this->stateManager->method('isEnabled')->willReturn(true);
+		$this->stateManager->method('hasOtherActiveProvider')->willReturn(true);
 		$this->stateManager->expects($this->once())->method('disable')->with($user, StateChangeActor::SYSTEM);
 
-		$this->listener->handle(new UserChangedEvent($user, 'eMailAddress', '', 'old@example.com'));
+		$this->listener->handle($this->emailCleared($user));
 	}
 
-	public function testKeepsProviderWhenEmailIsPresent(): void {
-		$user = $this->mockUser('alice@example.com');
+	public function testKeepsSoleFactorEnabledWhoeverRemovedTheEmail(): void {
+		// Fail-closed: the only second factor is never auto-disabled
+		$user = $this->mockUser(null);
+		$this->stateManager->method('isEnabled')->willReturn(true);
+		$this->stateManager->method('hasOtherActiveProvider')->willReturn(false);
 		$this->stateManager->expects($this->never())->method('disable');
 
-		$this->listener->handle(new UserUpdatedEvent($user, []));
+		$this->listener->handle($this->emailCleared($user));
+	}
+
+	public function testKeepsProviderWhenAddressStillPresent(): void {
+		// The address was changed, not cleared
+		$user = $this->mockUser('new@example.com');
+		$this->stateManager->expects($this->never())->method('disable');
+
+		$this->listener->handle(new UserChangedEvent($user, 'eMailAddress', 'new@example.com', 'old@example.com'));
 	}
 
 	public function testDoesNotDisableAnAlreadyDisabledProvider(): void {
-		// Guards against bogus activity entries on every profile update
-		// of users without an email address
 		$user = $this->mockUser(null);
-		$this->stateManager->method('isEnabled')->with($user)->willReturn(false);
+		$this->stateManager->method('isEnabled')->willReturn(false);
 		$this->stateManager->expects($this->never())->method('disable');
 
-		$this->listener->handle(new UserUpdatedEvent($user, []));
+		$this->listener->handle($this->emailCleared($user));
 	}
 
 	public function testIgnoresOtherChangedFeatures(): void {
@@ -83,6 +89,19 @@ class EMailDeletedTest extends TestCase {
 		$this->stateManager->expects($this->never())->method('disable');
 
 		$this->listener->handle(new UserChangedEvent($user, 'displayName', 'Alice'));
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testIgnoresUnrelatedProfileUpdate(): void {
+		// Regression: a UserUpdatedEvent (any profile change) must not trigger a
+		// disable — even for a user who currently has no email address. Only a
+		// genuine email-change event (UserChangedEvent) is a trigger.
+		$user = $this->mockUser(null);
+		$this->stateManager->expects($this->never())->method('disable');
+
+		$this->listener->handle(new UserUpdatedEvent($user, []));
 	}
 
 	public function testIgnoresForeignEvents(): void {

--- a/tests/Unit/Service/StateManagerTest.php
+++ b/tests/Unit/Service/StateManagerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Test\Unit\Service;
+
+use OCA\TwoFactorEMail\Service\StateManager;
+use OCP\Authentication\TwoFactorAuth\IRegistry;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IUser;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class StateManagerTest extends TestCase {
+	private IRegistry&MockObject $registry;
+
+	private StateManager $stateManager;
+
+	/**
+	 * @throws Exception
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->registry = $this->createMock(IRegistry::class);
+		$this->stateManager = new StateManager($this->createMock(IEventDispatcher::class), $this->registry);
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	private function withProviderStates(array $states): IUser&MockObject {
+		$user = $this->createMock(IUser::class);
+		$this->registry->method('getProviderStates')->with($user)->willReturn($states);
+		return $user;
+	}
+
+	public function testHasOtherActiveProviderIsTrueForAnEnabledNonEmailProvider(): void {
+		$user = $this->withProviderStates(['email' => true, 'totp' => true]);
+
+		$this->assertTrue($this->stateManager->hasOtherActiveProvider($user));
+	}
+
+	public function testHasOtherActiveProviderIsFalseWhenEmailIsTheOnlyEnabledOne(): void {
+		$user = $this->withProviderStates(['email' => true, 'totp' => false]);
+
+		$this->assertFalse($this->stateManager->hasOtherActiveProvider($user));
+	}
+
+	public function testHasOtherActiveProviderIgnoresEmailItself(): void {
+		$user = $this->withProviderStates(['email' => true]);
+
+		$this->assertFalse($this->stateManager->hasOtherActiveProvider($user));
+	}
+
+	public function testHasOtherActiveProviderIsFalseWithoutAnyProviders(): void {
+		$user = $this->withProviderStates([]);
+
+		$this->assertFalse($this->stateManager->hasOtherActiveProvider($user));
+	}
+}


### PR DESCRIPTION
**Edit (after review):** Tightened to fully fail-closed following @seyfahni's and Copilot's feedback. The sole second factor is now **never** auto-disabled (the earlier "user removed their own address → disable" branch is gone), and the trigger is narrowed to the actual email-change event. Details in the discussion below.

---

Security fix from the stack review (Finding 1).

## What it does

When an account loses its email address, email 2FA can no longer send codes. Until now the app switched email 2FA off whenever that happened — no matter who removed the address.

That is fine, unless email is the user's **only** second factor. Then switching it off leaves the account protected by the password alone. That is a downgrade — and it could be triggered by people who shouldn't be able to weaken a login:

- an admin or a group subadmin who edits the user's email;
- an automatic directory sync (LDAP/SAML) clearing addresses in bulk;
- someone on the user's own unlocked session.

None of them can turn 2FA off directly — that needs a password confirmation. Removing the email was a way around it.

The app now switches email 2FA off **only when another active second factor remains** (so no protection is lost). If email is the sole factor it stays enabled ("fail closed"), no matter who removed the address. The email login then simply can't be completed until the address is restored or an admin turns the provider off on purpose (`occ twofactorauth:disable <uid> email`). A locked-out user is a visible, fixable problem; a silently weakened account is not.

## How it decides

- "Is another second factor active?" — from Nextcloud's provider registry (`IStateManager::hasOtherActiveProvider()`).
- Trigger: `UserChangedEvent` for the `eMailAddress` feature (a genuine email change), not any profile update — so an unrelated later change can't disable the provider.

## Availability trade-off (on purpose)

A user who removes their own only email address ends up locked out until they re-add it or an admin steps in. That is acceptable for a security provider, and it avoids the far worse "email removed by someone else silently drops 2FA".

## Why no self-service exception

Removing the email is not password-protected, but turning 2FA off directly is (StateController). A "user removed it themselves → disable" branch would still bypass that gate from an unlocked session, and — as Copilot noted — a later unrelated profile update could re-trigger it. Telling apart "should be re-set up at next login" (enforced 2FA) from "must not be downgraded" (voluntary) would need the enforcement status, for which Nextcloud exposes no public API. So the app fails closed for everyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.