### PR TITLE
Attribute activity to the actor, and persist before notifying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Wrong and repeated activity entries for accounts without an email address
+- Admin and automatic changes are no longer attributed to the affected user in the activity stream
 - Activity and notification texts could not be translated
 - Saving an unchanged on/off state created duplicate activity entries
 - Outdated notifications are dismissed when the provider state changes again

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -54,9 +54,12 @@ final class Application extends App implements IBootstrap {
 		$context->registerServiceAlias(IEMailSender::class, EMailSender::class);
 		$context->registerServiceAlias(IStateManager::class, StateManager::class);
 
+		// Persist the state first: if the registry write fails, the activity and
+		// notification listeners (which run afterwards) do not record a change
+		// that did not happen.
+		$context->registerEventListener(StateChanged::class, StateChangeRegistryUpdater::class);
 		$context->registerEventListener(StateChanged::class, StateChangeActivity::class);
 		$context->registerEventListener(StateChanged::class, StateChangeNotification::class);
-		$context->registerEventListener(StateChanged::class, StateChangeRegistryUpdater::class);
 		$context->registerEventListener(UserUpdatedEvent::class, EMailDeleted::class);
 		$context->registerEventListener(UserChangedEvent::class, EMailDeleted::class);
 

--- a/lib/Listener/StateChangeActivity.php
+++ b/lib/Listener/StateChangeActivity.php
@@ -11,10 +11,12 @@ namespace OCA\TwoFactorEMail\Listener;
 
 use OCA\TwoFactorEMail\Activity\Notification;
 use OCA\TwoFactorEMail\AppInfo\Application;
+use OCA\TwoFactorEMail\Event\StateChangeActor;
 use OCA\TwoFactorEMail\Event\StateChanged;
 use OCP\Activity\IManager as ActivityManager;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
+use OCP\IUserSession;
 
 /**
  * @template-implements IEventListener<StateChanged>
@@ -23,6 +25,7 @@ final class StateChangeActivity implements IEventListener {
 
 	public function __construct(
 		private readonly ActivityManager $activityManager,
+		private readonly IUserSession $userSession,
 	) {
 	}
 
@@ -36,9 +39,22 @@ final class StateChangeActivity implements IEventListener {
 		$activity = $this->activityManager->generateEvent();
 		$activity->setApp(Application::APP_ID)
 			->setType('security')
-			->setAuthor($user->getUID())
+			->setAuthor($this->author($event))
 			->setAffectedUser($user->getUID())
 			->setSubject($notification->value);
 		$this->activityManager->publish($activity);
+	}
+
+	/**
+	 * The author is who caused the change, not who it affects. An admin action
+	 * is attributed to the acting admin (empty if none is in the session, e.g.
+	 * an occ command), and an automatic change to no one.
+	 */
+	private function author(StateChanged $event): string {
+		return match ($event->getActor()) {
+			StateChangeActor::USER => $event->getUser()->getUID(),
+			StateChangeActor::ADMIN => $this->userSession->getUser()?->getUID() ?? '',
+			StateChangeActor::SYSTEM => '',
+		};
 	}
 }

--- a/tests/Unit/Listener/StateChangeActivityTest.php
+++ b/tests/Unit/Listener/StateChangeActivityTest.php
@@ -17,6 +17,7 @@ use OCP\Activity\IEvent;
 use OCP\Activity\IManager;
 use OCP\EventDispatcher\Event;
 use OCP\IUser;
+use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -24,63 +25,94 @@ class StateChangeActivityTest extends TestCase {
 
 	private StateChangeActivity $listener;
 
-	private IManager|MockObject $activityManager;
+	private IManager&MockObject $activityManager;
+
+	private IUserSession&MockObject $userSession;
 
 	/**
 	 * @throws Exception
 	 */
-	public function testHandleStateEvent() {
-		$uid = 'user234';
-		$user = $this->createMock(IUser::class);
-		$user->method('getUID')->willReturn($uid);
-		$event = new StateChanged($user, true);
-		$activityEvent = $this->createMock(IEvent::class);
-		$this->activityManager->expects($this->once())
-			->method('generateEvent')
-			->willReturn($activityEvent);
-		$activityEvent->expects($this->once())
-			->method('setApp')
-			->with('twofactor_email')
-			->willReturnSelf();
-		$activityEvent->expects($this->once())
-			->method('setType')
-			->with('security')
-			->willReturnSelf();
-		$activityEvent->expects($this->once())
-			->method('setAuthor')
-			->with($uid)
-			->willReturnSelf();
-		$activityEvent->expects($this->once())
-			->method('setAffectedUser')
-			->with($uid)
-			->willReturnSelf();
-		$this->activityManager->expects($this->once())
-			->method('publish')
-			->with($activityEvent);
-
-		$this->listener->handle($event);
-	}
-
-	/**
-	 * @throws Exception
-	 */
-	public function testSystemDisableCreatesNoEmailActivity(): void {
-		$user = $this->createMock(IUser::class);
-		$user->method('getUID')->willReturn('user234');
-		$event = new StateChanged($user, false, StateChangeActor::SYSTEM);
+	private function mockActivityEvent(): IEvent&MockObject {
 		$activityEvent = $this->createMock(IEvent::class);
 		$activityEvent->method('setApp')->willReturnSelf();
 		$activityEvent->method('setType')->willReturnSelf();
 		$activityEvent->method('setAuthor')->willReturnSelf();
 		$activityEvent->method('setAffectedUser')->willReturnSelf();
+		$activityEvent->method('setSubject')->willReturnSelf();
+		$this->activityManager->method('generateEvent')->willReturn($activityEvent);
+		return $activityEvent;
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	private function loginAs(?string $uid): void {
+		$actor = null;
+		if ($uid !== null) {
+			$actor = $this->createMock(IUser::class);
+			$actor->method('getUID')->willReturn($uid);
+		}
+		$this->userSession->method('getUser')->willReturn($actor);
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testUserChangeIsAuthoredByTheUser(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$activityEvent = $this->mockActivityEvent();
+		$this->loginAs('alice');
+		$activityEvent->expects($this->once())->method('setAuthor')->with('alice')->willReturnSelf();
+		$activityEvent->expects($this->once())->method('setAffectedUser')->with('alice')->willReturnSelf();
+		$this->activityManager->expects($this->once())->method('publish');
+
+		$this->listener->handle(new StateChanged($user, true, StateChangeActor::USER));
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testAdminChangeIsAuthoredByTheActingAdmin(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$activityEvent = $this->mockActivityEvent();
+		$this->loginAs('admin');
+		$activityEvent->expects($this->once())->method('setAuthor')->with('admin')->willReturnSelf();
+		$activityEvent->expects($this->once())->method('setAffectedUser')->with('alice')->willReturnSelf();
+
+		$this->listener->handle(new StateChanged($user, false, StateChangeActor::ADMIN));
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testAdminChangeWithoutSessionHasNoAuthor(): void {
+		// e.g. `occ twofactorauth:disable` — no user in the session
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$activityEvent = $this->mockActivityEvent();
+		$this->loginAs(null);
+		$activityEvent->expects($this->once())->method('setAuthor')->with('')->willReturnSelf();
+
+		$this->listener->handle(new StateChanged($user, false, StateChangeActor::ADMIN));
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testSystemChangeHasNoAuthorAndTheNoEmailSubject(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$activityEvent = $this->mockActivityEvent();
+		$this->loginAs('alice'); // even with a session, a SYSTEM change stays authorless
+		$activityEvent->expects($this->once())->method('setAuthor')->with('')->willReturnSelf();
 		$activityEvent->expects($this->once())
 			->method('setSubject')
 			->with('twofactor_email_disabled_no_email')
 			->willReturnSelf();
-		$this->activityManager->method('generateEvent')->willReturn($activityEvent);
-		$this->activityManager->expects($this->once())->method('publish');
 
-		$this->listener->handle($event);
+		$this->listener->handle(new StateChanged($user, false, StateChangeActor::SYSTEM));
 	}
 
 	public function testIgnoresForeignEvents(): void {
@@ -96,7 +128,8 @@ class StateChangeActivityTest extends TestCase {
 		parent::setUp();
 
 		$this->activityManager = $this->createMock(IManager::class);
+		$this->userSession = $this->createMock(IUserSession::class);
 
-		$this->listener = new StateChangeActivity($this->activityManager);
+		$this->listener = new StateChangeActivity($this->activityManager, $this->userSession);
 	}
 }


### PR DESCRIPTION
Two small follow-ups from the security review (Findings 2 and 3, both low severity). Based on #113 — merge the stack in order first.

## Finding 2 — activity author

The activity stream recorded every state change under the **affected** user, even when an admin or the app itself made the change. For an audit log — whose whole purpose (added in #102) is to make third-party changes visible — that misattributes the action.

The author is now the party that caused the change:

- the user's own change → the user;
- an admin change → the acting admin (empty if there is no session, e.g. an `occ` command);
- an automatic change (email removed) → no one.

The affected user stays the subject of the entry, so the text still reads correctly.

## Finding 3 — persist before notifying

The `StateChanged` listeners ran in the order activity → notification → registry write. If the registry write failed, the user had already received a notification and an activity entry for a change that never persisted.

They now run registry write → activity → notification. A failing write stops the chain (the exception propagates), so nothing is recorded for a change that did not happen.

Covered by updated unit tests (112 total). The listener order itself is a one-line registration change with an explaining comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
