### PR TITLE
Admin settings: name validation limits, keep fields flagged, cap validity

### DIFF
--- a/lib/Service/SettingsValidator.php
+++ b/lib/Service/SettingsValidator.php
@@ -21,7 +21,7 @@ final class SettingsValidator {
 
 	// Allowed range for code validity in minutes
 	public const MIN_CODE_VALID_MINUTES = 1;
-	public const MAX_CODE_VALID_MINUTES = 44640; // 1 month
+	public const MAX_CODE_VALID_MINUTES = 1440; // 1 day
 
 	// Allowed range for the resend cooldown in minutes
 	public const MIN_RESEND_MINUTES = 1;

--- a/lib/Service/SettingsValidator.php
+++ b/lib/Service/SettingsValidator.php
@@ -32,6 +32,22 @@ final class SettingsValidator {
 	public const MAX_EMAIL_TEMPLATE_LENGTH = 10000;
 
 	/**
+	 * Returns the numeric limits per settings field, so the web UI can name
+	 * them in its validation messages without duplicating the values.
+	 *
+	 * @return array<string, array{min?: int, max: int}>
+	 */
+	public static function getLimits(): array {
+		return [
+			'codeLength' => ['min' => self::MIN_CODE_LENGTH, 'max' => self::MAX_CODE_LENGTH],
+			'codeValidMinutes' => ['min' => self::MIN_CODE_VALID_MINUTES, 'max' => self::MAX_CODE_VALID_MINUTES],
+			'codeResendMinutes' => ['min' => self::MIN_RESEND_MINUTES, 'max' => self::MAX_RESEND_MINUTES],
+			'eMailSubject' => ['max' => self::MAX_EMAIL_SUBJECT_LENGTH],
+			'eMailTemplate' => ['max' => self::MAX_EMAIL_TEMPLATE_LENGTH],
+		];
+	}
+
+	/**
 	 * Validates the given admin settings.
 	 * Returns a map of field name to error code, or an empty array if all
 	 * values are valid. The field names match the settings keys used by the

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -11,6 +11,7 @@ namespace OCA\TwoFactorEMail\Settings;
 
 use OCA\TwoFactorEMail\AppInfo\Application;
 use OCA\TwoFactorEMail\Service\IAppSettings;
+use OCA\TwoFactorEMail\Service\SettingsValidator;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\IL10N;
@@ -33,6 +34,8 @@ final class AdminSettings implements IDelegatedSettings {
 		// Localized default texts, shown as placeholders in the empty form fields
 		$this->initialState->provideInitialState('eMailSubjectDefault', $this->appSettings->getDefaultEMailSubject());
 		$this->initialState->provideInitialState('eMailTemplateDefault', $this->appSettings->getDefaultEMailBody());
+		// Numeric limits, so validation messages can name the allowed range
+		$this->initialState->provideInitialState('limits', SettingsValidator::getLimits());
 
 		return new TemplateResponse(Application::APP_ID, 'AdminSettings', renderAs: TemplateResponse::RENDER_AS_BLANK);
 	}

--- a/src/composables/useAdminSettings.js
+++ b/src/composables/useAdminSettings.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { loadState } from '@nextcloud/initial-state'
 import { t } from '@nextcloud/l10n'
 import { nextTick, reactive, ref, watch } from 'vue'
 import Logger from '../Logger.js'
@@ -32,15 +33,19 @@ export function useAdminSettings(store, fieldKeys, debounceMs = 1500, successMs 
 	const errorMessages = reactive(Object.fromEntries(fieldKeys.map((key) => [key, ''])))
 	const successTimers = Object.fromEntries(fieldKeys.map((key) => [key, null]))
 
+	// Numeric limits per field, provided by the server, so the messages below
+	// can name the allowed range instead of duplicating the values.
+	const limits = loadState('twofactor_email', 'limits', {})
+
 	// User-facing message per validation error code. Built here (not at module
 	// load) so t() runs once l10n is available.
 	const errorMessageByCode = {
-		'code-length-out-of-range': t('twofactor_email', 'The code length is outside the allowed range.'),
-		'code-valid-minutes-out-of-range': t('twofactor_email', 'The validity is outside the allowed range.'),
-		'resend-minutes-out-of-range': t('twofactor_email', 'The resend cooldown is outside the allowed range.'),
-		'email-subject-too-long': t('twofactor_email', 'The subject is too long.'),
+		'code-length-out-of-range': t('twofactor_email', 'The code length must be between {min} and {max} characters.', { min: limits.codeLength?.min, max: limits.codeLength?.max }),
+		'code-valid-minutes-out-of-range': t('twofactor_email', 'The validity must be between {min} and {max} minutes.', { min: limits.codeValidMinutes?.min, max: limits.codeValidMinutes?.max }),
+		'resend-minutes-out-of-range': t('twofactor_email', 'The resend cooldown must be between {min} and {max} minutes.', { min: limits.codeResendMinutes?.min, max: limits.codeResendMinutes?.max }),
+		'email-subject-too-long': t('twofactor_email', 'The subject must not exceed {max} characters.', { max: limits.eMailSubject?.max }),
 		'email-subject-must-be-single-line': t('twofactor_email', 'The subject must be a single line.'),
-		'email-template-too-long': t('twofactor_email', 'The body is too long.'),
+		'email-template-too-long': t('twofactor_email', 'The body must not exceed {max} characters.', { max: limits.eMailTemplate?.max }),
 		'email-code-placeholder-missing': t('twofactor_email', 'The body must contain the {code} placeholder.'),
 	}
 

--- a/src/composables/useAdminSettings.js
+++ b/src/composables/useAdminSettings.js
@@ -118,47 +118,18 @@ export function useAdminSettings(store, fieldKeys, debounceMs = 1500, successMs 
 		}, debounceMs)
 	}
 
-	/**
-	 * Validates all input values before saving.
-	 * Returns a field->code map (same vocabulary as the backend), or an empty
-	 * object if all values are valid.
-	 *
-	 * @return {Object<string, string>} field name to validation error code
-	 */
-	function validate() {
-		const errors = {}
-		// The code must reach the user: an empty body falls back to the default
-		// which contains {code}, so only a customized body can lose it.
-		const body = inputValues.eMailTemplate ?? ''
-		if (body !== '' && !body.includes('{code}')) {
-			errors.eMailTemplate = 'email-code-placeholder-missing'
-			Logger.warn('Email body does not contain the {code} placeholder')
-		}
-		// The subject must stay a single line (email header)
-		if (/[\r\n]/.test(inputValues.eMailSubject ?? '')) {
-			errors.eMailSubject = 'email-subject-must-be-single-line'
-			Logger.warn('Email subject must not contain line breaks')
-		}
-		return errors
-	}
-
 	async function scheduleAndSave() {
 		loading.value = true
 		store.$patch({ error: null })
-
-		// Validate before saving — flag failing fields and abort
-		const invalidFields = validate()
-		if (Object.keys(invalidFields).length > 0) {
-			applyErrors(invalidFields)
-			loading.value = false
-			return
-		}
 
 		try {
 			// Write all current inputValues into the store before saving
 			for (const key of fieldKeys) {
 				store[key] = inputValues[key]
 			}
+			// The backend validates every field and returns the full field->code
+			// map, so all currently invalid fields stay flagged (not just the
+			// one last edited).
 			const result = await store.save()
 			if (result?.errors && typeof result.errors === 'object') {
 				// Backend rejected specific fields — flag only those


### PR DESCRIPTION
Follow-up polish for the (still unreleased) admin settings validation added in 3.3.0. Three independent commits:

- **Name the allowed range** in each validation message, e.g. "The code length must be between 4 and 16 characters" instead of a vague "out of range". The limits come from the validator constants via initial state, so they stay a single source of truth.
- **Keep every invalid field flagged**: the client-side pre-check aborted before the server save and reset all fields, so a field flagged by the server (a range it cannot check itself) lost its mark as soon as another field became invalid. The backend now always validates and returns the full field→code map.
- **Cap code validity at one day** (1440 min) instead of one month (44640) — a month-long one-time code made no sense as an upper bound.

No CHANGELOG entry: all of this refines the 3.3.0 admin settings that have not been released yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
