### PR TITLE
Report whether occ code deletion removed anything

### DIFF
--- a/lib/Command/CleanUp.php
+++ b/lib/Command/CleanUp.php
@@ -32,8 +32,8 @@ final class CleanUp extends Command {
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$io = new SymfonyStyle($input, $output);
 		$io->title('Removing expired two-factor email codes');
-		$this->codeStorage->deleteExpired();
-		$io->success('Done.');
+		$count = $this->codeStorage->deleteExpired();
+		$io->success(sprintf('Removed %d expired code(s).', $count));
 		return Command::SUCCESS;
 	}
 }

--- a/lib/Command/DeleteCodes.php
+++ b/lib/Command/DeleteCodes.php
@@ -53,7 +53,11 @@ final class DeleteCodes extends Command {
 
 		if ($all) {
 			$count = $this->codeStorage->deleteAllCodes();
-			$io->success(sprintf('Deleted the stored codes of %d user(s).', $count));
+			if ($count === 0) {
+				$io->info('No stored codes to delete.');
+			} else {
+				$io->success(sprintf('Deleted the stored codes of %d user(s).', $count));
+			}
 			return Command::SUCCESS;
 		}
 
@@ -62,8 +66,11 @@ final class DeleteCodes extends Command {
 		if ($this->userManager->get($uid) === null) {
 			$io->warning('No user with id "' . $uid . '" exists — deleting leftover codes anyway.');
 		}
-		$this->codeStorage->deleteCode($uid);
-		$io->success('Deleted the stored code of "' . $uid . '".');
+		if ($this->codeStorage->deleteCode($uid)) {
+			$io->success('Deleted the stored code of "' . $uid . '".');
+		} else {
+			$io->info('No code was stored for "' . $uid . '".');
+		}
 		return Command::SUCCESS;
 	}
 }

--- a/lib/Service/CodeStorage.php
+++ b/lib/Service/CodeStorage.php
@@ -47,9 +47,11 @@ final class CodeStorage implements ICodeStorage {
 		return max(0, time() - $createdAt);
 	}
 
-	public function deleteCode(string $userId): void {
+	public function deleteCode(string $userId): bool {
+		$existed = $this->config->getValueString($userId, Application::APP_ID, self::KEY_CODE) !== '';
 		$this->config->deleteUserConfig($userId, Application::APP_ID, self::KEY_CODE);
 		$this->config->deleteUserConfig($userId, Application::APP_ID, self::KEY_CREATED_AT);
+		return $existed;
 	}
 
 	public function writeCode(string $userId, string $code, ?int $createdAt = null): void {
@@ -65,14 +67,17 @@ final class CodeStorage implements ICodeStorage {
 		return $count;
 	}
 
-	public function deleteExpired(): void {
+	public function deleteExpired(): int {
 		$expiresBefore = time() - $this->settings->getCodeValidMinutes() * 60;
 		$creationTime = $this->config->getValuesByUsers(Application::APP_ID, self::KEY_CREATED_AT, ValueType::INT);
 
+		$count = 0;
 		foreach ($creationTime as $userId => $createdAt) {
 			if ($createdAt < $expiresBefore) {
 				$this->deleteCode($userId);
+				$count++;
 			}
 		}
+		return $count;
 	}
 }

--- a/lib/Service/ICodeStorage.php
+++ b/lib/Service/ICodeStorage.php
@@ -20,7 +20,12 @@ interface ICodeStorage {
 
 	public function writeCode(string $userId, string $code, ?int $createdAt = null): void;
 
-	public function deleteCode(string $userId): void;
+	/**
+	 * Deletes the user's stored code.
+	 *
+	 * @return bool whether a code was stored (an expired one still counts)
+	 */
+	public function deleteCode(string $userId): bool;
 
 	/**
 	 * Deletes the stored codes of all users.
@@ -29,5 +34,10 @@ interface ICodeStorage {
 	 */
 	public function deleteAllCodes(): int;
 
-	public function deleteExpired(): void;
+	/**
+	 * Deletes all codes whose validity has elapsed.
+	 *
+	 * @return int the number of expired codes removed
+	 */
+	public function deleteExpired(): int;
 }

--- a/tests/Unit/BackgroundJob/CleanUpExpiredCodesTest.php
+++ b/tests/Unit/BackgroundJob/CleanUpExpiredCodesTest.php
@@ -22,7 +22,7 @@ class CleanUpExpiredCodesTest extends TestCase {
 	 */
 	public function testRunDeletesExpiredCodes(): void {
 		$codeStorage = $this->createMock(ICodeStorage::class);
-		$codeStorage->expects($this->once())->method('deleteExpired');
+		$codeStorage->expects($this->once())->method('deleteExpired')->willReturn(0);
 		$job = new CleanUpExpiredCodes($this->createMock(ITimeFactory::class), $codeStorage);
 
 		// run() is protected by the TimedJob contract

--- a/tests/Unit/Command/DeleteCodesTest.php
+++ b/tests/Unit/Command/DeleteCodesTest.php
@@ -42,17 +42,28 @@ class DeleteCodesTest extends TestCase {
 	 */
 	public function testDeletesCodeOfSingleUser(): void {
 		$this->userManager->method('get')->with('alice')->willReturn($this->createMock(IUser::class));
-		$this->codeStorage->expects($this->once())->method('deleteCode')->with('alice');
+		$this->codeStorage->expects($this->once())->method('deleteCode')->with('alice')->willReturn(true);
 		$this->codeStorage->expects($this->never())->method('deleteAllCodes');
 
 		$exitCode = $this->tester->execute(['uid' => 'alice']);
 
 		$this->assertSame(Command::SUCCESS, $exitCode);
+		$this->assertStringContainsString('Deleted the stored code of "alice"', $this->tester->getDisplay());
+	}
+
+	public function testReportsWhenNoCodeWasStored(): void {
+		$this->userManager->method('get')->with('alice')->willReturn($this->createMock(IUser::class));
+		$this->codeStorage->expects($this->once())->method('deleteCode')->with('alice')->willReturn(false);
+
+		$exitCode = $this->tester->execute(['uid' => 'alice']);
+
+		$this->assertSame(Command::SUCCESS, $exitCode);
+		$this->assertStringContainsString('No code was stored for "alice"', $this->tester->getDisplay());
 	}
 
 	public function testWarnsAboutUnknownUserButStillDeletes(): void {
 		$this->userManager->method('get')->with('ghost')->willReturn(null);
-		$this->codeStorage->expects($this->once())->method('deleteCode')->with('ghost');
+		$this->codeStorage->expects($this->once())->method('deleteCode')->with('ghost')->willReturn(true);
 
 		$exitCode = $this->tester->execute(['uid' => 'ghost']);
 
@@ -68,6 +79,16 @@ class DeleteCodesTest extends TestCase {
 
 		$this->assertSame(Command::SUCCESS, $exitCode);
 		$this->assertStringContainsString('3 user(s)', $this->tester->getDisplay());
+	}
+
+	public function testAllReportsWhenNothingToDelete(): void {
+		$this->codeStorage->expects($this->once())->method('deleteAllCodes')->willReturn(0);
+		$this->codeStorage->expects($this->never())->method('deleteCode');
+
+		$exitCode = $this->tester->execute(['--all' => true]);
+
+		$this->assertSame(Command::SUCCESS, $exitCode);
+		$this->assertStringContainsString('No stored codes to delete', $this->tester->getDisplay());
 	}
 
 	public function testRejectsMissingUserIdAndAll(): void {

--- a/tests/Unit/Service/CodeStorageTest.php
+++ b/tests/Unit/Service/CodeStorageTest.php
@@ -52,6 +52,26 @@ class CodeStorageTest extends TestCase {
 		$this->assertSame(['code', 'code_created_at'], $deletedKeys);
 	}
 
+	public function testDeleteCodeReturnsTrueWhenCodeWasStored(): void {
+		$this->config->method('getValueString')->willReturn('hashed-code');
+
+		$this->assertTrue($this->storage->deleteCode('alice'));
+	}
+
+	public function testDeleteCodeReturnsFalseWhenNoCodeWasStored(): void {
+		$this->config->method('getValueString')->willReturn('');
+
+		$this->assertFalse($this->storage->deleteCode('alice'));
+	}
+
+	public function testDeleteExpiredReturnsRemovedCount(): void {
+		// validity is 10 minutes: created_at 0 is expired, a fresh one is not
+		$this->config->method('getValuesByUsers')->willReturn(['old' => 0, 'fresh' => time()]);
+		$this->config->method('getValueString')->willReturn('hashed-code');
+
+		$this->assertSame(1, $this->storage->deleteExpired());
+	}
+
 	public function testSecondsSinceLastCodeForFreshCode(): void {
 		$this->config->method('getValueInt')->willReturn(time());
 		$this->config->method('getValueString')->willReturn('hashed-code');


### PR DESCRIPTION
The occ commands now tell the caller whether anything was actually removed:

- `twofactor_email:delete-codes <user>`: reports "No code was stored for …" instead of always claiming a deletion.
- `twofactor_email:delete-codes --all`: reports when there was nothing to delete.
- `twofactor_email:cleanup`: names how many expired codes were removed.

`deleteCode()` now returns whether a code was stored (an expired one still counts) and `deleteExpired()` returns the removed count. The background job and the other internal callers ignore the return value and are unaffected.

No CHANGELOG entry: these occ commands are new in the unreleased 3.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
