### PR TITLE
Drop the non-working notification dismissal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Admin and automatic changes are no longer attributed to the affected user in the activity stream
 - Activity and notification texts could not be translated
 - Saving an unchanged on/off state created duplicate activity entries
-- Outdated notifications are dismissed when the provider state changes again
 - The instance logo returns to the challenge email after upgrades from 3.1.x (#109)
 
 ### Security

--- a/lib/Listener/StateChangeNotification.php
+++ b/lib/Listener/StateChangeNotification.php
@@ -38,20 +38,13 @@ final class StateChangeNotification implements IEventListener {
 		if (!$event instanceof StateChanged) {
 			return;
 		}
-		$uid = $event->getUser()->getUID();
-
-		// An earlier notification about this provider's state is outdated now,
-		// whoever caused the change — dismiss it before possibly adding a new one.
-		$outdated = $this->notificationManager->createNotification();
-		$outdated->setApp(Application::APP_ID)
-			->setUser($uid)
-			->setObject('twofactor_email_state', $uid);
-		$this->notificationManager->dismissNotification($outdated);
-
 		if ($event->getActor() === StateChangeActor::USER) {
+			// The user changed the state themselves and sees the result in the
+			// settings UI, so no notification is needed.
 			return;
 		}
 
+		$uid = $event->getUser()->getUID();
 		$subject = Notification::fromStateChange($event->getActor(), $event->isEnabled());
 
 		$notification = $this->notificationManager->createNotification();

--- a/tests/Unit/Listener/StateChangeNotificationTest.php
+++ b/tests/Unit/Listener/StateChangeNotificationTest.php
@@ -66,15 +66,12 @@ class StateChangeNotificationTest extends TestCase {
 	 * @throws Exception
 	 */
 	private function expectNotificationWithSubject(string $subject): void {
-		// First createNotification() builds the dismiss filter, the second the new notification
-		$newNotification = $this->mockNotification();
-		$newNotification->expects($this->once())
+		$notification = $this->mockNotification();
+		$notification->expects($this->once())
 			->method('setSubject')
 			->with($subject)
 			->willReturnSelf();
-		$this->notificationManager->method('createNotification')
-			->willReturnOnConsecutiveCalls($this->mockNotification(), $newNotification);
-		$this->notificationManager->expects($this->once())->method('dismissNotification');
+		$this->notificationManager->method('createNotification')->willReturn($notification);
 		$this->notificationManager->expects($this->once())->method('notify');
 	}
 
@@ -90,19 +87,13 @@ class StateChangeNotificationTest extends TestCase {
 		$this->listener->handle(new StateChanged($this->mockUser(), false, StateChangeActor::SYSTEM));
 	}
 
-	/**
-	 * @throws Exception
-	 */
-	public function testDoesNotNotifyAboutOwnChangesButDismissesOutdatedOnes(): void {
-		$this->notificationManager->method('createNotification')->willReturn($this->mockNotification());
-		$this->notificationManager->expects($this->once())->method('dismissNotification');
+	public function testDoesNotNotifyAboutOwnChanges(): void {
 		$this->notificationManager->expects($this->never())->method('notify');
 
 		$this->listener->handle(new StateChanged($this->mockUser(), true, StateChangeActor::USER));
 	}
 
 	public function testIgnoresForeignEvents(): void {
-		$this->notificationManager->expects($this->never())->method('dismissNotification');
 		$this->notificationManager->expects($this->never())->method('notify');
 
 		$this->listener->handle(new Event());


### PR DESCRIPTION
`StateChangeNotification` tried to withdraw an outdated notification via `dismissNotification()`, but that method only invokes notifiers implementing `IDismissableNotifier` (a hook for user-initiated dismissals) — it never removed the app's own stored notification. So an admin enable after a disable left both notifications standing (and `markProcessed()`, which would remove them, is no longer in the public `IManager` in NC 34).

Showing both state-change notifications is fine, and every change is still recorded in the activity log, so this drops the dead code and simplifies the listener. It also removes the CHANGELOG line that claimed the never-working dismissal.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
