### PR TITLE
Flag the stored code hash as sensitive

### DIFF
--- a/lib/Service/CodeStorage.php
+++ b/lib/Service/CodeStorage.php
@@ -56,7 +56,9 @@ final class CodeStorage implements ICodeStorage {
 
 	public function writeCode(string $userId, string $code, ?int $createdAt = null): void {
 		$createdAt ??= time();
-		$this->config->setValueString($userId, Application::APP_ID, self::KEY_CODE, $code);
+		// The stored value is a hash, but flag it sensitive so it is masked in
+		// occ config:list and system/support reports.
+		$this->config->setValueString($userId, Application::APP_ID, self::KEY_CODE, $code, flags: IUserConfig::FLAG_SENSITIVE);
 		$this->config->setValueInt($userId, Application::APP_ID, self::KEY_CREATED_AT, $createdAt);
 	}
 


### PR DESCRIPTION
The 2FA code is stored as a hash, but `writeCode()` persisted it without the sensitive flag, so it appeared verbatim in `occ config:list` and system/support reports. Given the small code space (6 digits by default), a hash exported during a live login could be brute-forced offline within the code's validity window. Store the value with `IUserConfig::FLAG_SENSITIVE` so it is masked in listings.

Defense-in-depth hardening — the value was already a hash, and the change is a one-liner.

Found by an independent review of main. Independent of the test-coverage PR (this touches lib/, not tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
