### PR TITLE
Cover the core code lifecycle and email masking with unit tests

### DIFF
--- a/tests/Unit/Service/CodeStorageTest.php
+++ b/tests/Unit/Service/CodeStorageTest.php
@@ -82,4 +82,26 @@ class CodeStorageTest extends TestCase {
 		$this->assertGreaterThanOrEqual(0, $elapsed);
 		$this->assertLessThan(60, $elapsed);
 	}
+
+	public function testReadCodeReturnsTheStoredCodeWhenFresh(): void {
+		$this->config->method('getValueInt')->willReturn(time());
+		$this->config->method('getValueString')->willReturn('stored-hash');
+
+		$this->assertSame('stored-hash', $this->storage->readCode('alice'));
+	}
+
+	public function testReadCodeReturnsNullAndClearsAnExpiredCode(): void {
+		// created_at 0 is far older than the validity window → expired
+		$this->config->method('getValueInt')->willReturn(0);
+		$this->config->expects($this->atLeastOnce())->method('deleteUserConfig');
+
+		$this->assertNull($this->storage->readCode('alice'));
+	}
+
+	public function testReadCodeReturnsNullWhenTheStoredCodeIsEmpty(): void {
+		$this->config->method('getValueInt')->willReturn(time());
+		$this->config->method('getValueString')->willReturn('');
+
+		$this->assertNull($this->storage->readCode('alice'));
+	}
 }

--- a/tests/Unit/Service/EMailAddressMaskerTest.php
+++ b/tests/Unit/Service/EMailAddressMaskerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Test\Unit\Service;
+
+use OCA\TwoFactorEMail\Service\EMailAddressMasker;
+use PHPUnit\Framework\TestCase;
+
+class EMailAddressMaskerTest extends TestCase {
+	private EMailAddressMasker $masker;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->masker = new EMailAddressMasker();
+	}
+
+	public function testMasksATypicalAddress(): void {
+		$this->assertSame('a*@*.com', $this->masker->maskForUI('alice@example.com'));
+	}
+
+	public function testKeepsOnlyTheTopLevelDomainOfAMultiLabelDomain(): void {
+		$this->assertSame('b*@*.uk', $this->masker->maskForUI('bob@mail.example.co.uk'));
+	}
+
+	public function testSingleLabelDomainHasNoTld(): void {
+		$this->assertSame('u*@*', $this->masker->maskForUI('user@localhost'));
+	}
+
+	public function testReturnsInputWithoutAnAtSignUnchanged(): void {
+		$this->assertSame('notanemail', $this->masker->maskForUI('notanemail'));
+	}
+
+	public function testReturnsInputWithMultipleAtSignsUnchanged(): void {
+		$this->assertSame('a@b@c', $this->masker->maskForUI('a@b@c'));
+	}
+
+	public function testReturnsEmptyInputUnchanged(): void {
+		$this->assertSame('', $this->masker->maskForUI(''));
+	}
+}

--- a/tests/Unit/Service/LoginChallengeTest.php
+++ b/tests/Unit/Service/LoginChallengeTest.php
@@ -163,4 +163,82 @@ class LoginChallengeTest extends TestCase {
 		// min(1800, 600) - 60 = 540
 		$this->assertSame(540, $this->challenge->secondsUntilResendAllowed($this->mockUser()));
 	}
+
+	/**
+	 * @throws SendEMailFailed
+	 * @throws EMailNotSet
+	 * @throws Exception
+	 */
+	public function testSendChallengeIssuesAndStoresACodeWhenNoneIsStored(): void {
+		$user = $this->mockUser();
+		$this->codeStorage->method('readCode')->with('alice')->willReturn(null);
+		$this->codeGenerator->method('generateChallengeCode')->willReturn('123456');
+		$this->emailSender->expects($this->once())->method('sendChallengeEMail')->with($user, '123456');
+		$this->hasher->method('hash')->with('123456')->willReturn('hashed');
+		$this->codeStorage->expects($this->once())->method('writeCode')->with('alice', 'hashed');
+
+		$this->assertTrue($this->challenge->sendChallenge($user));
+	}
+
+	/**
+	 * @throws SendEMailFailed
+	 * @throws EMailNotSet
+	 * @throws Exception
+	 */
+	public function testSendChallengeSkipsWhileAValidCodeStillExists(): void {
+		$user = $this->mockUser();
+		$this->codeStorage->method('readCode')->with('alice')->willReturn('existing-hash');
+		$this->emailSender->expects($this->never())->method('sendChallengeEMail');
+		$this->codeStorage->expects($this->never())->method('writeCode');
+
+		$this->assertFalse($this->challenge->sendChallenge($user));
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testVerifyChallengeAcceptsAValidCodeAndDeletesIt(): void {
+		$user = $this->mockUser();
+		$this->codeStorage->method('readCode')->with('alice')->willReturn('stored-hash');
+		$this->hasher->method('verify')->with('123456', 'stored-hash')->willReturn(true);
+		$this->codeStorage->expects($this->once())->method('deleteCode')->with('alice');
+
+		$this->assertTrue($this->challenge->verifyChallenge($user, '123456'));
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testVerifyChallengeRejectsAWrongCodeAndKeepsItForRetry(): void {
+		$user = $this->mockUser();
+		$this->codeStorage->method('readCode')->with('alice')->willReturn('stored-hash');
+		$this->hasher->method('verify')->with('123456', 'stored-hash')->willReturn(false);
+		$this->codeStorage->expects($this->never())->method('deleteCode');
+
+		$this->assertFalse($this->challenge->verifyChallenge($user, '123456'));
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testVerifyChallengeRejectsWhenNoCodeIsStored(): void {
+		$user = $this->mockUser();
+		$this->codeStorage->method('readCode')->with('alice')->willReturn(null);
+		$this->hasher->expects($this->never())->method('verify');
+		$this->codeStorage->expects($this->never())->method('deleteCode');
+
+		$this->assertFalse($this->challenge->verifyChallenge($user, '123456'));
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testVerifyChallengeTrimsTheSubmittedCode(): void {
+		$user = $this->mockUser();
+		$this->codeStorage->method('readCode')->with('alice')->willReturn('stored-hash');
+		// Surrounding whitespace must be stripped before verifying
+		$this->hasher->expects($this->once())->method('verify')->with('123456', 'stored-hash')->willReturn(true);
+
+		$this->assertTrue($this->challenge->verifyChallenge($user, "  123456\n"));
+	}
 }


### PR DESCRIPTION
Adds direct unit tests for security-relevant logic that an independent review of main found to be covered only indirectly or not at all. Tests only, no production code change.

- **LoginChallenge::sendChallenge()/verifyChallenge()** — the methods that decide whether to (re)issue a code and that verify + hash-check a submitted one: a valid stored code blocks a new send; hash verify success/failure; delete-on-success but keep-on-failure; no code stored; input trimming.
- **EMailAddressMasker::maskForUI()** — the privacy masking regex, previously always mocked away: typical / multi-label domain / single-label domain / malformed / empty input.
- **CodeStorage::readCode()** — fresh / expired (clears the code) / empty-value branches.

131 tests, all green (psalm/cs clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
