### PR TITLE
Close two coverage gaps and add a lenient coverage gate

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+# SPDX-License-Identifier: MIT
+
+# Turns the existing Codecov upload into a light gate: a noticeable drop in
+# overall coverage fails the check, while per-PR (patch) coverage is only
+# reported, not enforced — so PRs touching code without a natural unit test
+# (e.g. plumbing or the untested frontend) are not blocked.
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        informational: true

--- a/tests/Unit/Activity/NotificationTest.php
+++ b/tests/Unit/Activity/NotificationTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Test\Unit\Activity;
+
+use OCA\TwoFactorEMail\Activity\Notification;
+use OCA\TwoFactorEMail\Event\StateChangeActor;
+use PHPUnit\Framework\TestCase;
+
+class NotificationTest extends TestCase {
+	public function testUserEnableMapsToEnabledByUser(): void {
+		$this->assertSame(Notification::ENABLED_BY_USER, Notification::fromStateChange(StateChangeActor::USER, true));
+	}
+
+	public function testUserDisableMapsToDisabledByUser(): void {
+		$this->assertSame(Notification::DISABLED_BY_USER, Notification::fromStateChange(StateChangeActor::USER, false));
+	}
+
+	public function testAdminEnableMapsToEnabledByAdmin(): void {
+		$this->assertSame(Notification::ENABLED_BY_ADMIN, Notification::fromStateChange(StateChangeActor::ADMIN, true));
+	}
+
+	public function testAdminDisableMapsToDisabledByAdmin(): void {
+		$this->assertSame(Notification::DISABLED_BY_ADMIN, Notification::fromStateChange(StateChangeActor::ADMIN, false));
+	}
+
+	public function testSystemAlwaysMapsToNoEmailRegardlessOfFlag(): void {
+		// The system only ever disables, so the enabled flag is irrelevant.
+		$this->assertSame(Notification::DISABLED_NO_EMAIL, Notification::fromStateChange(StateChangeActor::SYSTEM, false));
+		$this->assertSame(Notification::DISABLED_NO_EMAIL, Notification::fromStateChange(StateChangeActor::SYSTEM, true));
+	}
+}

--- a/tests/Unit/Command/CleanUpTest.php
+++ b/tests/Unit/Command/CleanUpTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Test\Unit\Command;
+
+use OCA\TwoFactorEMail\Command\CleanUp;
+use OCA\TwoFactorEMail\Service\ICodeStorage;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class CleanUpTest extends TestCase {
+	private ICodeStorage&MockObject $codeStorage;
+
+	private CommandTester $tester;
+
+	/**
+	 * @throws Exception
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->codeStorage = $this->createMock(ICodeStorage::class);
+		$this->tester = new CommandTester(new CleanUp($this->codeStorage));
+	}
+
+	public function testRemovesExpiredCodesAndReportsTheCount(): void {
+		$this->codeStorage->expects($this->once())->method('deleteExpired')->willReturn(3);
+
+		$exitCode = $this->tester->execute([]);
+
+		$this->assertSame(Command::SUCCESS, $exitCode);
+		$this->assertStringContainsString('Removed 3 expired code(s)', $this->tester->getDisplay());
+	}
+
+	public function testReportsZeroWhenNothingWasExpired(): void {
+		$this->codeStorage->expects($this->once())->method('deleteExpired')->willReturn(0);
+
+		$exitCode = $this->tester->execute([]);
+
+		$this->assertSame(Command::SUCCESS, $exitCode);
+		$this->assertStringContainsString('Removed 0 expired code(s)', $this->tester->getDisplay());
+	}
+}


### PR DESCRIPTION
Two small, independent follow-ups from the review of main. Tests + CI config only, no production code change.

**Coverage gaps**
- `CleanUpTest`: covers the `occ twofactor_email:cleanup` command (count reporting), matching the per-command test pattern the other commands already follow.
- `NotificationTest`: asserts `Notification::fromStateChange()`'s actor→case mapping directly (previously only covered indirectly), including that SYSTEM always maps to the no-email case.

**Coverage gate**
- `codecov.yml`: coverage was uploaded but nothing enforced it. This adds a lenient gate — the project status fails on a >1% overall drop while patch coverage stays informational, so regressions are caught without blocking PRs that touch code with no natural unit test.

138 tests, all green (psalm/cs clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
