### PR TITLE
Cover the provider's decision logic with unit tests

### DIFF
--- a/tests/Unit/Provider/TwoFactorEMailTest.php
+++ b/tests/Unit/Provider/TwoFactorEMailTest.php
@@ -10,6 +10,9 @@ declare(strict_types=1);
 namespace OCA\TwoFactorEMail\Test\Unit\Provider;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\TwoFactorEMail\Exception\EMailNotSet;
+use OCA\TwoFactorEMail\Exception\SendEMailFailed;
+use OCA\TwoFactorEMail\Provider\LoginSetup;
 use OCA\TwoFactorEMail\Provider\TwoFactorEMail;
 use OCA\TwoFactorEMail\Service\IAppSettings;
 use OCA\TwoFactorEMail\Service\IEMailAddressMasker;
@@ -17,9 +20,11 @@ use OCA\TwoFactorEMail\Service\ILoginChallenge;
 use OCA\TwoFactorEMail\Service\IStateManager;
 use OCA\TwoFactorEMail\Settings\PersonalSettings;
 use OCP\AppFramework\Services\IInitialState;
+use OCP\Authentication\TwoFactorAuth\ILoginSetupProvider;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUser;
+use OCP\Template\ITemplate;
 use OCP\Template\ITemplateManager;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -31,6 +36,10 @@ class TwoFactorEMailTest extends TestCase {
 	private IInitialState&MockObject $initialState;
 	private IURLGenerator&MockObject $urlGenerator;
 	private IStateManager&MockObject $stateManager;
+	private IEMailAddressMasker&MockObject $masker;
+	private ContainerInterface&MockObject $container;
+	private ILoginChallenge&MockObject $challengeService;
+	private IAppSettings&MockObject $settings;
 
 	private TwoFactorEMail $provider;
 
@@ -141,29 +150,148 @@ class TwoFactorEMailTest extends TestCase {
 	/**
 	 * @throws Exception
 	 */
+	public function testActivate(): void {
+		$user = $this->createMock(IUser::class);
+		$this->stateManager->expects($this->once())->method('enable')->with($user);
+
+		$this->provider->enableFor($user);
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testIsTwoFactorAuthEnabledReflectsTheStateManager(): void {
+		$user = $this->createMock(IUser::class);
+		$this->stateManager->method('isEnabled')->with($user)->willReturn(true);
+
+		self::assertTrue($this->provider->isTwoFactorAuthEnabledForUser($user));
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testGetTemplateSendsACodeAndReportsNoError(): void {
+		$assigns = [];
+		$user = $this->createMock(IUser::class);
+		$this->templateManager->method('getTemplate')->willReturn($this->templateCapturing($assigns));
+		$this->settings->method('getCodeLength')->willReturn(6);
+		$this->challengeService->method('sendChallenge')->with($user)->willReturn(true);
+
+		$this->provider->getTemplate($user);
+
+		self::assertTrue($assigns['newCodeWasSent']);
+		self::assertNull($assigns['error']);
+		self::assertSame(6, $assigns['codeLength']);
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testGetTemplateDoesNotResendWhileAValidCodeExists(): void {
+		$assigns = [];
+		$user = $this->createMock(IUser::class);
+		$this->templateManager->method('getTemplate')->willReturn($this->templateCapturing($assigns));
+		$this->challengeService->method('sendChallenge')->with($user)->willReturn(false);
+
+		$this->provider->getTemplate($user);
+
+		self::assertFalse($assigns['newCodeWasSent']);
+		self::assertNull($assigns['error']);
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testGetTemplateReportsNoEmailWhenTheAddressIsMissing(): void {
+		$assigns = [];
+		$user = $this->createMock(IUser::class);
+		$this->templateManager->method('getTemplate')->willReturn($this->templateCapturing($assigns));
+		$this->challengeService->method('sendChallenge')->willThrowException(new EMailNotSet($user));
+
+		$this->provider->getTemplate($user);
+
+		self::assertSame('no-email', $assigns['error']);
+		self::assertFalse($assigns['newCodeWasSent']);
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testGetTemplateReportsSendFailure(): void {
+		$assigns = [];
+		$user = $this->createMock(IUser::class);
+		$this->templateManager->method('getTemplate')->willReturn($this->templateCapturing($assigns));
+		$this->challengeService->method('sendChallenge')->willThrowException(new SendEMailFailed());
+
+		$this->provider->getTemplate($user);
+
+		self::assertSame('send-failed', $assigns['error']);
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testGetLoginSetupMasksTheEmailAndProvidesIt(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getEMailAddress')->willReturn('alice@example.com');
+		$this->masker->expects($this->once())->method('maskForUI')->with('alice@example.com')->willReturn('a*@*.com');
+		$this->initialState->expects($this->once())->method('provideInitialState')->with('maskedEmail', 'a*@*.com');
+		$loginSetup = $this->createMock(ILoginSetupProvider::class);
+		$this->container->method('get')->with(LoginSetup::class)->willReturn($loginSetup);
+
+		self::assertSame($loginSetup, $this->provider->getLoginSetup($user));
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testGetLoginSetupHandlesAMissingEmail(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getEMailAddress')->willReturn(null);
+		$this->masker->expects($this->once())->method('maskForUI')->with('')->willReturn('');
+		$this->initialState->expects($this->once())->method('provideInitialState')->with('maskedEmail', '');
+		$this->container->method('get')->willReturn($this->createMock(ILoginSetupProvider::class));
+
+		$this->provider->getLoginSetup($user);
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	private function templateCapturing(array &$assigns): ITemplate&MockObject {
+		$template = $this->createMock(ITemplate::class);
+		$template->method('assign')->willReturnCallback(function (string $key, $value) use (&$assigns): void {
+			$assigns[$key] = $value;
+		});
+		return $template;
+	}
+
+	/**
+	 * @throws Exception
+	 */
 	protected function setUp(): void {
 		parent::setUp();
 
-		$masker = $this->createMock(IEMailAddressMasker::class);
+		$this->masker = $this->createMock(IEMailAddressMasker::class);
 		$this->templateManager = $this->createMock(ITemplateManager::class);
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->initialState = $this->createMock(IInitialState::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
-		$container = $this->createMock(ContainerInterface::class);
-		$challengeService = $this->createMock(ILoginChallenge::class);
+		$this->container = $this->createMock(ContainerInterface::class);
+		$this->challengeService = $this->createMock(ILoginChallenge::class);
 		$this->stateManager = $this->createMock(IStateManager::class);
-		$settings = $this->createMock(IAppSettings::class);
+		$this->settings = $this->createMock(IAppSettings::class);
 
 		$this->provider = new TwoFactorEMail(
-			$masker,
+			$this->masker,
 			$this->templateManager,
 			$this->l10n,
 			$this->initialState,
 			$this->urlGenerator,
-			$container,
-			$challengeService,
+			$this->container,
+			$this->challengeService,
 			$this->stateManager,
-			$settings,
+			$this->settings,
 		);
 	}
 }


### PR DESCRIPTION
Adds unit tests for the `TwoFactorEMail` provider's decision logic, previously untested (the existing test covered id/name/icons/personal-settings/disable only). These pin the branches that decide what a user actually sees — the edge cases that are easy to miss in manual testing:

- `getTemplate()` (the login-challenge view): a new code is sent; a still-valid code exists (no resend); the account has no email address (`error='no-email'`); a send failure (`error='send-failed'`).
- `getLoginSetup()` (the enforced-2FA setup entry): masks the address and provides it, including the missing-email case.
- `enableFor()` (symmetry with the existing `disableFor` test) and `isTwoFactorAuthEnabledForUser()`.

Tests only, no production code change. What the app itself decides is now covered by fast unit tests; the surrounding 2FA enforcement flow and provider-selection UI remain Nextcloud core's responsibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
