### PR TITLE
Add CodeQL analysis for JavaScript and workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+# SPDX-License-Identifier: MIT
+
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '30 4 * * 1'
+
+concurrency:
+  group: codeql-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # CodeQL does not support PHP; only the JS/TS frontend and the
+        # workflows are analysable here.
+        language: [javascript-typescript, actions]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3.37.1
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3.37.1
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Adds a CodeQL advanced-setup workflow. **CodeQL does not support PHP**, so it scans only what it can here — the Vue/JS frontend and the GitHub Actions workflows — as defense-in-depth. The PHP backend stays covered by psalm + review + `roave/security-advisories`.

- Languages: `javascript-typescript`, `actions` (`build-mode: none`).
- Triggers: push/PR to `main` + weekly schedule.
- Actions SHA-pinned per the repo convention (`actions/checkout` v6.0.3, `github/codeql-action` v3.37.1).

**Caveat:** if CodeQL **default setup** is already enabled under repo Settings → Code security & analysis, an advanced-setup workflow conflicts and errors. I couldn't verify the current setting — the CI token has no code-scanning scope (403). If default setup is on, disable it before merging (or don't merge this).

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
