### PR TITLE
Name the resend setting consistently (codeResendMinutes)

### DIFF
--- a/lib/Command/Settings.php
+++ b/lib/Command/Settings.php
@@ -83,7 +83,7 @@ final class Settings extends Command {
 		$io->table(['Setting', 'Value', 'Default'], [
 			['code_length', $this->appSettings->getCodeLength(), AppSettings::DEFAULT_CODE_LENGTH],
 			['code_valid_minutes', $this->appSettings->getCodeValidMinutes(), AppSettings::DEFAULT_CODE_VALID_MINUTES],
-			['resend_min_minutes', $this->appSettings->getResendMinMinutes(), AppSettings::DEFAULT_RESEND_MIN_MINUTES],
+			['resend_min_minutes', $this->appSettings->getCodeResendMinutes(), AppSettings::DEFAULT_RESEND_MIN_MINUTES],
 			['email_subject', $this->appSettings->getEMailSubject() ?: $emptyMeansDefault, $this->preview($this->appSettings->getDefaultEMailSubject())],
 			['email_template', $this->preview($this->appSettings->getEMailTemplate()) ?: $emptyMeansDefault, $this->preview($this->appSettings->getDefaultEMailBody())],
 		]);
@@ -104,7 +104,7 @@ final class Settings extends Command {
 		return match ($key) {
 			'code_length' => $this->appSettings->getCodeLength(),
 			'code_valid_minutes' => $this->appSettings->getCodeValidMinutes(),
-			'resend_min_minutes' => $this->appSettings->getResendMinMinutes(),
+			'resend_min_minutes' => $this->appSettings->getCodeResendMinutes(),
 			'email_subject' => $this->appSettings->getEMailSubject(),
 			'email_template' => $this->appSettings->getEMailTemplate(),
 		};
@@ -120,18 +120,18 @@ final class Settings extends Command {
 		// rules stay in one place (SettingsValidator, shared with the web UI).
 		$codeLength = $this->appSettings->getCodeLength();
 		$codeValidMinutes = $this->appSettings->getCodeValidMinutes();
-		$resendMinutes = $this->appSettings->getResendMinMinutes();
+		$codeResendMinutes = $this->appSettings->getCodeResendMinutes();
 		$eMailSubject = $this->appSettings->getEMailSubject();
 		$eMailTemplate = $this->appSettings->getEMailTemplate();
 		match ($key) {
 			'code_length' => $codeLength = (int)$value,
 			'code_valid_minutes' => $codeValidMinutes = (int)$value,
-			'resend_min_minutes' => $resendMinutes = (int)$value,
+			'resend_min_minutes' => $codeResendMinutes = (int)$value,
 			'email_subject' => $eMailSubject = $value,
 			'email_template' => $eMailTemplate = $value,
 		};
 
-		$errors = $this->validator->validate($codeLength, $codeValidMinutes, $resendMinutes, $eMailSubject, $eMailTemplate);
+		$errors = $this->validator->validate($codeLength, $codeValidMinutes, $codeResendMinutes, $eMailSubject, $eMailTemplate);
 		if (!empty($errors)) {
 			foreach ($errors as $error) {
 				$io->error($this->errorMessage($error));
@@ -142,7 +142,7 @@ final class Settings extends Command {
 		match ($key) {
 			'code_length' => $this->appSettings->setCodeLength((int)$value),
 			'code_valid_minutes' => $this->appSettings->setCodeValidMinutes((int)$value),
-			'resend_min_minutes' => $this->appSettings->setResendMinMinutes((int)$value),
+			'resend_min_minutes' => $this->appSettings->setCodeResendMinutes((int)$value),
 			'email_subject' => $this->appSettings->setEMailSubject($value),
 			'email_template' => $this->appSettings->setEMailTemplate($value),
 		};

--- a/lib/Controller/AdminSettingsController.php
+++ b/lib/Controller/AdminSettingsController.php
@@ -40,16 +40,16 @@ final class AdminSettingsController extends ALoginSetupController {
 		int $codeValidMinutes,
 		string $eMailTemplate,
 		string $eMailSubject,
-		int $resendMinutes,
+		int $codeResendMinutes,
 	): JSONResponse {
-		$errors = $this->validator->validate($codeLength, $codeValidMinutes, $resendMinutes, $eMailSubject, $eMailTemplate);
+		$errors = $this->validator->validate($codeLength, $codeValidMinutes, $codeResendMinutes, $eMailSubject, $eMailTemplate);
 		if (!empty($errors)) {
 			return new JSONResponse(['errors' => $errors], Http::STATUS_BAD_REQUEST);
 		}
 
 		$this->appSettings->setCodeLength($codeLength);
 		$this->appSettings->setCodeValidMinutes($codeValidMinutes);
-		$this->appSettings->setResendMinMinutes($resendMinutes);
+		$this->appSettings->setCodeResendMinutes($codeResendMinutes);
 		$this->appSettings->setEMailSubject($eMailSubject);
 		$this->appSettings->setEMailTemplate($eMailTemplate);
 
@@ -67,7 +67,7 @@ final class AdminSettingsController extends ALoginSetupController {
 		return new JSONResponse([
 			'codeLength' => $this->appSettings->getCodeLength(),
 			'codeValidMinutes' => $this->appSettings->getCodeValidMinutes(),
-			'codeResendMinutes' => $this->appSettings->getResendMinMinutes(),
+			'codeResendMinutes' => $this->appSettings->getCodeResendMinutes(),
 			'eMailSubject' => $this->appSettings->getEMailSubject(),
 			'eMailTemplate' => $this->appSettings->getEMailTemplate(),
 		]);

--- a/lib/Service/AppSettings.php
+++ b/lib/Service/AppSettings.php
@@ -46,12 +46,12 @@ final class AppSettings implements IAppSettings {
 		return $this->appConfig->getValueInt(Application::APP_ID, self::KEY_CODE_VALID_MINUTES, self::DEFAULT_CODE_VALID_MINUTES);
 	}
 
-	public function getResendMinMinutes(): int {
+	public function getCodeResendMinutes(): int {
 		return $this->appConfig->getValueInt(Application::APP_ID, self::KEY_RESEND_MIN_MINUTES, self::DEFAULT_RESEND_MIN_MINUTES);
 	}
 
 	public function getResendCooldownSeconds(): int {
-		return $this->getResendMinMinutes() * 60;
+		return $this->getCodeResendMinutes() * 60;
 	}
 
 	public function getEMailSubject(): string {
@@ -86,8 +86,8 @@ final class AppSettings implements IAppSettings {
 		$this->appConfig->setValueInt(Application::APP_ID, self::KEY_CODE_VALID_MINUTES, $codeValidMinutes);
 	}
 
-	public function setResendMinMinutes(int $resendMinutes): void {
-		$this->appConfig->setValueInt(Application::APP_ID, self::KEY_RESEND_MIN_MINUTES, $resendMinutes);
+	public function setCodeResendMinutes(int $codeResendMinutes): void {
+		$this->appConfig->setValueInt(Application::APP_ID, self::KEY_RESEND_MIN_MINUTES, $codeResendMinutes);
 	}
 
 	public function setEMailSubject(string $subject): void {

--- a/lib/Service/IAppSettings.php
+++ b/lib/Service/IAppSettings.php
@@ -28,7 +28,7 @@ interface IAppSettings {
 	 *
 	 * @return int minutes
 	 */
-	public function getResendMinMinutes(): int;
+	public function getCodeResendMinutes(): int;
 
 	/**
 	 * The resend cooldown in seconds. The setting is stored in minutes and
@@ -73,7 +73,7 @@ interface IAppSettings {
 
 	public function setCodeValidMinutes(int $codeValidMinutes): void;
 
-	public function setResendMinMinutes(int $resendMinutes): void;
+	public function setCodeResendMinutes(int $codeResendMinutes): void;
 
 	public function setEMailSubject(string $subject): void;
 

--- a/lib/Service/SettingsValidator.php
+++ b/lib/Service/SettingsValidator.php
@@ -60,7 +60,7 @@ final class SettingsValidator {
 	public function validate(
 		int $codeLength,
 		int $codeValidMinutes,
-		int $resendMinutes,
+		int $codeResendMinutes,
 		string $eMailSubject,
 		string $eMailTemplate,
 	): array {
@@ -71,7 +71,7 @@ final class SettingsValidator {
 		if ($codeValidMinutes < self::MIN_CODE_VALID_MINUTES || $codeValidMinutes > self::MAX_CODE_VALID_MINUTES) {
 			$errors['codeValidMinutes'] = 'code-valid-minutes-out-of-range';
 		}
-		if ($resendMinutes < self::MIN_RESEND_MINUTES || $resendMinutes > self::MAX_RESEND_MINUTES) {
+		if ($codeResendMinutes < self::MIN_RESEND_MINUTES || $codeResendMinutes > self::MAX_RESEND_MINUTES) {
 			$errors['codeResendMinutes'] = 'resend-minutes-out-of-range';
 		}
 		if (strlen($eMailSubject) > self::MAX_EMAIL_SUBJECT_LENGTH) {

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -28,7 +28,7 @@ final class AdminSettings implements IDelegatedSettings {
 	public function getForm(): TemplateResponse {
 		$this->initialState->provideInitialState('codeLength', $this->appSettings->getCodeLength());
 		$this->initialState->provideInitialState('codeValidMinutes', $this->appSettings->getCodeValidMinutes());
-		$this->initialState->provideInitialState('codeResendMinutes', $this->appSettings->getResendMinMinutes());
+		$this->initialState->provideInitialState('codeResendMinutes', $this->appSettings->getCodeResendMinutes());
 		$this->initialState->provideInitialState('eMailSubject', $this->appSettings->getEMailSubject());
 		$this->initialState->provideInitialState('eMailTemplate', $this->appSettings->getEMailTemplate());
 		// Localized default texts, shown as placeholders in the empty form fields

--- a/src/Store.js
+++ b/src/Store.js
@@ -67,7 +67,7 @@ export const useAdminSettingsStore = defineStore('adminSettings', {
 			const result = await persistAdminSettings({
 				codeLength: this.codeLength,
 				codeValidMinutes: this.codeValidMinutes,
-				resendMinutes: this.codeResendMinutes,
+				codeResendMinutes: this.codeResendMinutes,
 				eMailSubject: this.eMailSubject,
 				eMailTemplate: this.eMailTemplate,
 			})

--- a/tests/Unit/Command/SettingsTest.php
+++ b/tests/Unit/Command/SettingsTest.php
@@ -31,7 +31,7 @@ class SettingsTest extends TestCase {
 		// Valid current values; single tests override where needed
 		$this->appSettings->method('getCodeLength')->willReturn(6);
 		$this->appSettings->method('getCodeValidMinutes')->willReturn(10);
-		$this->appSettings->method('getResendMinMinutes')->willReturn(1);
+		$this->appSettings->method('getCodeResendMinutes')->willReturn(1);
 		$this->appSettings->method('getEMailSubject')->willReturn('');
 		$this->appSettings->method('getEMailTemplate')->willReturn('');
 		$this->appSettings->method('getDefaultEMailSubject')->willReturn('Login attempt for {user} @ {cloud}');

--- a/tests/Unit/Controller/AdminSettingsControllerTest.php
+++ b/tests/Unit/Controller/AdminSettingsControllerTest.php
@@ -41,7 +41,7 @@ class AdminSettingsControllerTest extends TestCase {
 	public function testSavePersistsAllSettings(): void {
 		$this->appSettings->expects($this->once())->method('setCodeLength')->with(6);
 		$this->appSettings->expects($this->once())->method('setCodeValidMinutes')->with(10);
-		$this->appSettings->expects($this->once())->method('setResendMinMinutes')->with(30);
+		$this->appSettings->expects($this->once())->method('setCodeResendMinutes')->with(30);
 		$this->appSettings->expects($this->once())->method('setEMailSubject')->with('Subject');
 		$this->appSettings->expects($this->once())->method('setEMailTemplate')->with('Use {code}');
 

--- a/tests/Unit/Service/AppSettingsTest.php
+++ b/tests/Unit/Service/AppSettingsTest.php
@@ -88,12 +88,12 @@ class AppSettingsTest extends TestCase {
 		$this->settings->setCodeLength(8);
 	}
 
-	public function testGetResendMinMinutesDefaultsToOne(): void {
+	public function testGetCodeResendMinutesDefaultsToOne(): void {
 		$this->appConfig->method('getValueInt')
 			->with(Application::APP_ID, 'resend_min_minutes', 1)
 			->willReturn(1);
 
-		$this->assertSame(1, $this->settings->getResendMinMinutes());
+		$this->assertSame(1, $this->settings->getCodeResendMinutes());
 	}
 
 	public function testGetResendCooldownSecondsConvertsMinutes(): void {
@@ -104,12 +104,12 @@ class AppSettingsTest extends TestCase {
 		$this->assertSame(120, $this->settings->getResendCooldownSeconds());
 	}
 
-	public function testSetResendMinMinutesWritesToAppConfig(): void {
+	public function testSetCodeResendMinutesWritesToAppConfig(): void {
 		$this->appConfig->expects($this->once())
 			->method('setValueInt')
 			->with(Application::APP_ID, 'resend_min_minutes', 30);
 
-		$this->settings->setResendMinMinutes(30);
+		$this->settings->setCodeResendMinutes(30);
 	}
 
 	public function testResetToDefaultsDeletesAllKeys(): void {


### PR DESCRIPTION
Aligns the resend-cooldown setting's naming with its siblings — it was the odd one out. PHP used `getResendMinMinutes()` / `$resendMinutes` and the save **request** key was `resendMinutes`, while the response, initial state and the whole JS side already used `codeResendMinutes` (matching `codeLength` / `codeValidMinutes`).

- Renames the PHP methods (`getResendMinMinutes`→`getCodeResendMinutes`, `setResendMinMinutes`→`setCodeResendMinutes`), the parameters (`$resendMinutes`→`$codeResendMinutes`), and the save **request** key in `Store.js` (`resendMinutes`→`codeResendMinutes`). The controller binds body params by name, so the request key and the parameter are renamed together — request/response keys are now symmetric.
- **Unchanged, deliberately:** the persisted app-config key and the occ setting name stay `resend_min_minutes` — renaming those would need a DB migration and break admin scripts/muscle memory.

No behaviour change; cs/psalm/tests/eslint/build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
