### PR TITLE
Document the accepted timing side channel in verifyChallenge

### DIFF
--- a/lib/Service/LoginChallenge.php
+++ b/lib/Service/LoginChallenge.php
@@ -86,6 +86,12 @@ final class LoginChallenge implements ILoginChallenge {
 	public function verifyChallenge(IUser $user, string $submittedCode): bool {
 		$submittedCode = trim($submittedCode);
 		$storedCodeHash = $this->codeStorage->readCode($user->getUID());
+		// Accepted residual timing side channel: returning early when no code is
+		// stored is measurably faster than the hash verify, so the response time
+		// reveals whether an unexpired code currently exists — but only to someone
+		// who already passed the first factor, and the comparison itself stays
+		// constant-time (IHasher::verify). A dummy verify on the miss path was
+		// deliberately left out; the leak does not justify it.
 		if (is_null($storedCodeHash)) {
 			$isValid = false;
 		} else {

--- a/src/components/LoginSetup.vue
+++ b/src/components/LoginSetup.vue
@@ -7,8 +7,7 @@
 <template>
 	<div id="twofactor_email-login_setup">
 		<span v-if="store.error === 'no-email'" class="error">
-			{{ t('twofactor_email', 'No email address available, please contact your administrator.')
-			}}
+			{{ t('twofactor_email', 'No email address available, please contact your administrator.') }}
 		</span>
 		<span v-else-if="store.error === 'save-failed'" class="error">
 			{{ t('twofactor_email', 'Could not enable/disable two-factor authentication via email.') }}
@@ -20,8 +19,7 @@
 		<div v-else>
 			<p>{{ t('twofactor_email', 'Two-factor authentication via email was enabled.') }}</p>
 			<p>
-				{{ t('twofactor_email', 'Codes will be sent to your primary email address:') }} <b>{{ store.maskedEmail
-				}}</b>
+				{{ t('twofactor_email', 'Codes will be sent to your primary email address:') }} <b>{{ store.maskedEmail }}</b>
 			</p>
 			<form method="POST">
 				<button>{{ t('twofactor_email', 'Proceed') }}</button>


### PR DESCRIPTION
Adds a code comment recording an accepted security trade-off in `LoginChallenge::verifyChallenge()`, so it is not mistaken for a bug or "fixed" wrongly later.

When no code is stored, the method returns early instead of running the (deliberately slow) hash verify, which makes that path measurably faster — a residual timing side channel that reveals only whether an unexpired code currently exists, and only to someone who already passed the first factor. The comparison itself stays constant-time (`IHasher::verify`). A dummy verify on the miss path was deliberately left out; the leak's value does not justify it.

Comment only, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
