### PR TITLE
Set up vitest and cover the admin-settings service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ build/
 vendor/
 js/
 css/
+/coverage/
 
 /.php-cs-fixer.cache
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,6 +9,9 @@ import { recommendedJavascript } from '@nextcloud/eslint-config'
 export default [
 	...recommendedJavascript,
 	{
+		// Test files are handled by @nextcloud/eslint-config without the jsdoc
+		// plugin, so scoping this rule out of them keeps its plugin reference valid.
+		ignores: ['**/*.test.js', '**/*.spec.js'],
 		rules: {
 			'jsdoc/require-jsdoc': [
 				'warn',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,7 +11,7 @@ export default [
 	{
 		// Test files are handled by @nextcloud/eslint-config without the jsdoc
 		// plugin, so scoping this rule out of them keeps its plugin reference valid.
-		ignores: ['**/*.test.js', '**/*.spec.js'],
+		ignores: ['**/*.test.js'],
 		rules: {
 			'jsdoc/require-jsdoc': [
 				'warn',

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,10 @@
         "@nextcloud/stylelint-config": "^3.1.0",
         "@nextcloud/typings": "^1.10.0",
         "@nextcloud/vite-config": "^2.5.1",
+        "@vitest/coverage-v8": "^4.1.10",
         "eslint": "^10.0.1",
-        "vite": "^7.1.9"
+        "vite": "^7.1.9",
+        "vitest": "^4.1.10"
       },
       "engines": {
         "node": "^24.0.0",
@@ -175,6 +177,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@buttercup/fetch": {
@@ -481,7 +493,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -498,7 +509,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -515,7 +525,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -532,7 +541,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -549,7 +557,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -566,7 +573,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -583,7 +589,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -600,7 +605,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -617,7 +621,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -634,7 +637,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -651,7 +653,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -668,7 +669,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -685,7 +685,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -702,7 +701,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -719,7 +717,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -736,7 +733,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -753,7 +749,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -770,7 +765,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -787,7 +781,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -804,7 +797,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -821,7 +813,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -838,7 +829,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -855,7 +845,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -872,7 +861,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -889,7 +877,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -906,7 +893,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1818,7 +1804,6 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1859,7 +1844,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1881,7 +1865,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1903,7 +1886,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1925,7 +1907,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1947,7 +1928,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1969,7 +1949,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1991,7 +1970,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2013,7 +1991,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2035,7 +2012,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2057,7 +2033,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2079,7 +2054,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2101,7 +2075,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2123,7 +2096,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2220,7 +2192,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2234,7 +2205,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2248,7 +2218,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2262,7 +2231,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2276,7 +2244,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2290,7 +2257,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2304,7 +2270,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2318,7 +2283,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2332,7 +2296,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2346,7 +2309,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2360,7 +2322,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2374,7 +2335,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2388,7 +2348,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2402,7 +2361,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2416,7 +2374,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2430,7 +2387,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2444,7 +2400,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2458,7 +2413,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2472,7 +2426,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2486,7 +2439,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2500,7 +2452,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2514,7 +2465,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2528,7 +2478,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2542,7 +2491,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2556,7 +2504,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2762,6 +2709,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@stylistic/eslint-plugin": {
       "version": "5.10.0",
       "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
@@ -2796,6 +2750,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -2804,6 +2769,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/escape-html": {
       "version": "1.0.4",
@@ -3174,6 +3146,160 @@
       "peerDependencies": {
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@volar/language-core": {
@@ -3709,6 +3835,16 @@
         "util": "^0.12.5"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-kit": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.2.0.tgz",
@@ -3724,6 +3860,35 @@
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ast-walker-scope": {
       "version": "0.9.0",
@@ -4277,6 +4442,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/character-entities": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
@@ -4458,6 +4633,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4830,7 +5012,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -5096,6 +5277,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
@@ -5573,6 +5761,16 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
@@ -5945,7 +6143,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6409,6 +6606,13 @@
       ],
       "license": "MIT"
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-tags": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-5.1.0.tgz",
@@ -6499,7 +6703,7 @@
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
       "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true
     },
@@ -6685,7 +6889,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6726,7 +6930,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -6895,6 +7099,68 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jju": {
@@ -7178,6 +7444,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/material-colors": {
@@ -8112,7 +8406,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true
@@ -8309,6 +8602,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/optionator": {
@@ -9487,7 +9794,7 @@
       "version": "1.101.0",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.101.0.tgz",
       "integrity": "sha512-OL3GoQyoUdDt843DpVmDO6y2k1sc5IhUDSpu8XucEI+35neq5QivZ1iuegnpraEVTJXlQGK1gl27zKcTLEPbQw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -9676,6 +9983,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
@@ -9899,6 +10213,20 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stream-browserify": {
       "version": "3.0.0",
@@ -10473,6 +10801,23 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -10487,6 +10832,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-buffer": {
@@ -11139,6 +11494,96 @@
         "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/vm-browserify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
@@ -11382,6 +11827,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "stylelint": "stylelint src/**/*.{css,vue}",
-    "stylelint:fix": "stylelint src/**/*.{css,vue} --fix"
+    "stylelint:fix": "stylelint src/**/*.{css,vue} --fix",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@nextcloud/auth": "^2.6.0",
@@ -76,7 +78,9 @@
     "@nextcloud/stylelint-config": "^3.1.0",
     "@nextcloud/typings": "^1.10.0",
     "@nextcloud/vite-config": "^2.5.1",
+    "@vitest/coverage-v8": "^4.1.10",
     "eslint": "^10.0.1",
-    "vite": "^7.1.9"
+    "vite": "^7.1.9",
+    "vitest": "^4.1.10"
   }
 }

--- a/src/services/StateManager.test.js
+++ b/src/services/StateManager.test.js
@@ -11,12 +11,6 @@ vi.mock('@nextcloud/router', () => ({ generateUrl: (path) => path }))
 vi.mock('@nextcloud/axios', () => ({ default: { post: vi.fn() } }))
 vi.mock('../Logger.js', () => ({ default: { debug: vi.fn(), error: vi.fn() } }))
 
-const garbageBodies = [
-	{ case: 'null', body: null },
-	{ case: 'a string', body: 'unexpected' },
-	{ case: 'an unexpected object', body: { totallyWrong: true } },
-]
-
 beforeEach(() => {
 	vi.clearAllMocks()
 })
@@ -28,10 +22,10 @@ describe('persistAdminSettings', () => {
 		await expect(persistAdminSettings({})).resolves.toEqual({ codeLength: 6 })
 	})
 
-	it.each(garbageBodies)('returns a 200 body verbatim ($case)', async ({ body }) => {
-		Axios.post.mockResolvedValue({ status: 200, data: body })
+	it('returns an unexpected 200 body verbatim', async () => {
+		Axios.post.mockResolvedValue({ status: 200, data: { unexpected: true } })
 
-		await expect(persistAdminSettings({})).resolves.toEqual(body)
+		await expect(persistAdminSettings({})).resolves.toEqual({ unexpected: true })
 	})
 
 	it('maps a 400 field-to-code map to { errors }', async () => {
@@ -41,16 +35,21 @@ describe('persistAdminSettings', () => {
 	})
 
 	it.each([
-		{ case: 'an array errors payload', arm: () => Axios.post.mockRejectedValue({ response: { data: { errors: ['code-length-out-of-range'] } } }) },
-		{ case: 'a string errors payload', arm: () => Axios.post.mockRejectedValue({ response: { data: { errors: 'code-length-out-of-range' } } }) },
-		{ case: 'a numeric errors payload', arm: () => Axios.post.mockRejectedValue({ response: { data: { errors: 42 } } }) },
-		{ case: 'a boolean errors payload', arm: () => Axios.post.mockRejectedValue({ response: { data: { errors: true } } }) },
-		{ case: 'a null errors payload', arm: () => Axios.post.mockRejectedValue({ response: { data: { errors: null } } }) },
-		{ case: 'a missing errors payload', arm: () => Axios.post.mockRejectedValue({ response: { data: {} } }) },
-		{ case: 'a non-200 response', arm: () => Axios.post.mockResolvedValue({ status: 500, data: {} }) },
-		{ case: 'a network error without a response', arm: () => Axios.post.mockRejectedValue(new Error('network down')) },
-	])('reports save-failed for $case', async ({ arm }) => {
-		arm()
+		{ case: 'an array errors payload', rejection: { response: { data: { errors: ['code-length-out-of-range'] } } } },
+		{ case: 'a string errors payload', rejection: { response: { data: { errors: 'code-length-out-of-range' } } } },
+		{ case: 'a numeric errors payload', rejection: { response: { data: { errors: 42 } } } },
+		{ case: 'a boolean errors payload', rejection: { response: { data: { errors: true } } } },
+		{ case: 'a null errors payload', rejection: { response: { data: { errors: null } } } },
+		{ case: 'a missing errors payload', rejection: { response: { data: {} } } },
+		{ case: 'a network error without a response', rejection: new Error('network down') },
+	])('reports save-failed for $case', async ({ rejection }) => {
+		Axios.post.mockRejectedValue(rejection)
+
+		await expect(persistAdminSettings({})).resolves.toEqual({ error: 'save-failed' })
+	})
+
+	it('reports save-failed on a non-200 response', async () => {
+		Axios.post.mockResolvedValue({ status: 500, data: {} })
 
 		await expect(persistAdminSettings({})).resolves.toEqual({ error: 'save-failed' })
 	})
@@ -63,19 +62,22 @@ describe('persistState', () => {
 		await expect(persistState(true)).resolves.toEqual({ enabled: true })
 	})
 
-	it.each(garbageBodies)('returns a 200 body verbatim ($case)', async ({ body }) => {
-		Axios.post.mockResolvedValue({ status: 200, data: body })
+	it('returns an unexpected 200 body verbatim', async () => {
+		Axios.post.mockResolvedValue({ status: 200, data: { unexpected: true } })
 
-		await expect(persistState(true)).resolves.toEqual(body)
+		await expect(persistState(true)).resolves.toEqual({ unexpected: true })
 	})
 
-	it.each([
-		{ case: 'a known code', error: 'no-email' },
-		{ case: 'a garbage value', error: { weird: 1 } },
-	])('surfaces the backend error verbatim ($case)', async ({ error }) => {
-		Axios.post.mockRejectedValue({ response: { data: { error } } })
+	it('surfaces a specific backend error', async () => {
+		Axios.post.mockRejectedValue({ response: { data: { error: 'no-email' } } })
 
-		await expect(persistState(true)).resolves.toEqual({ enabled: false, error })
+		await expect(persistState(true)).resolves.toEqual({ enabled: false, error: 'no-email' })
+	})
+
+	it('surfaces a garbage backend error verbatim', async () => {
+		Axios.post.mockRejectedValue({ response: { data: { error: { weird: 1 } } } })
+
+		await expect(persistState(true)).resolves.toEqual({ enabled: false, error: { weird: 1 } })
 	})
 
 	it.each([
@@ -97,18 +99,23 @@ describe('resetAdminSettings', () => {
 		await expect(resetAdminSettings()).resolves.toEqual({ codeLength: 6 })
 	})
 
-	it.each(garbageBodies)('returns a 200 body verbatim ($case)', async ({ body }) => {
-		Axios.post.mockResolvedValue({ status: 200, data: body })
+	it('returns an unexpected 200 body verbatim', async () => {
+		Axios.post.mockResolvedValue({ status: 200, data: { unexpected: true } })
 
-		await expect(resetAdminSettings()).resolves.toEqual(body)
+		await expect(resetAdminSettings()).resolves.toEqual({ unexpected: true })
 	})
 
 	it.each([
-		{ case: 'a rejected request', arm: () => Axios.post.mockRejectedValue(new Error('boom')) },
-		{ case: 'a garbage 4xx payload', arm: () => Axios.post.mockRejectedValue({ response: { status: 418, data: 'nonsense' } }) },
-		{ case: 'a non-200 response', arm: () => Axios.post.mockResolvedValue({ status: 500, data: {} }) },
-	])('reports reset-failed for $case', async ({ arm }) => {
-		arm()
+		{ case: 'a rejected request', rejection: new Error('boom') },
+		{ case: 'a garbage 4xx payload', rejection: { response: { status: 418, data: 'nonsense' } } },
+	])('reports reset-failed for $case', async ({ rejection }) => {
+		Axios.post.mockRejectedValue(rejection)
+
+		await expect(resetAdminSettings()).resolves.toEqual({ error: 'reset-failed' })
+	})
+
+	it('reports reset-failed on a non-200 response', async () => {
+		Axios.post.mockResolvedValue({ status: 500, data: {} })
 
 		await expect(resetAdminSettings()).resolves.toEqual({ error: 'reset-failed' })
 	})

--- a/src/services/StateManager.test.js
+++ b/src/services/StateManager.test.js
@@ -41,15 +41,16 @@ describe('persistAdminSettings', () => {
 	})
 
 	it.each([
-		{ case: 'an array errors payload', rejection: { response: { data: { errors: ['code-length-out-of-range'] } } } },
-		{ case: 'a string errors payload', rejection: { response: { data: { errors: 'code-length-out-of-range' } } } },
-		{ case: 'a numeric errors payload', rejection: { response: { data: { errors: 42 } } } },
-		{ case: 'a boolean errors payload', rejection: { response: { data: { errors: true } } } },
-		{ case: 'a null errors payload', rejection: { response: { data: { errors: null } } } },
-		{ case: 'a missing errors payload', rejection: { response: { data: {} } } },
-		{ case: 'a network error without a response', rejection: new Error('network down') },
-	])('reports save-failed for $case', async ({ rejection }) => {
-		Axios.post.mockRejectedValue(rejection)
+		{ case: 'an array errors payload', arm: () => Axios.post.mockRejectedValue({ response: { data: { errors: ['code-length-out-of-range'] } } }) },
+		{ case: 'a string errors payload', arm: () => Axios.post.mockRejectedValue({ response: { data: { errors: 'code-length-out-of-range' } } }) },
+		{ case: 'a numeric errors payload', arm: () => Axios.post.mockRejectedValue({ response: { data: { errors: 42 } } }) },
+		{ case: 'a boolean errors payload', arm: () => Axios.post.mockRejectedValue({ response: { data: { errors: true } } }) },
+		{ case: 'a null errors payload', arm: () => Axios.post.mockRejectedValue({ response: { data: { errors: null } } }) },
+		{ case: 'a missing errors payload', arm: () => Axios.post.mockRejectedValue({ response: { data: {} } }) },
+		{ case: 'a non-200 response', arm: () => Axios.post.mockResolvedValue({ status: 500, data: {} }) },
+		{ case: 'a network error without a response', arm: () => Axios.post.mockRejectedValue(new Error('network down')) },
+	])('reports save-failed for $case', async ({ arm }) => {
+		arm()
 
 		await expect(persistAdminSettings({})).resolves.toEqual({ error: 'save-failed' })
 	})

--- a/src/services/StateManager.test.js
+++ b/src/services/StateManager.test.js
@@ -1,0 +1,76 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import Axios from '@nextcloud/axios'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { persistAdminSettings, persistState, resetAdminSettings } from './StateManager.js'
+
+vi.mock('@nextcloud/router', () => ({ generateUrl: (path) => path }))
+vi.mock('@nextcloud/axios', () => ({ default: { post: vi.fn() } }))
+vi.mock('../Logger.js', () => ({ default: { debug: vi.fn(), error: vi.fn() } }))
+
+beforeEach(() => {
+	vi.clearAllMocks()
+})
+
+describe('persistAdminSettings', () => {
+	it('returns the saved settings on success', async () => {
+		Axios.post.mockResolvedValue({ status: 200, data: { codeLength: 6 } })
+
+		await expect(persistAdminSettings({})).resolves.toEqual({ codeLength: 6 })
+	})
+
+	it('maps a 400 field-to-code map to { errors }', async () => {
+		Axios.post.mockRejectedValue({ response: { data: { errors: { codeLength: 'code-length-out-of-range' } } } })
+
+		await expect(persistAdminSettings({})).resolves.toEqual({ errors: { codeLength: 'code-length-out-of-range' } })
+	})
+
+	it('ignores an array errors payload and reports save-failed', async () => {
+		Axios.post.mockRejectedValue({ response: { data: { errors: ['code-length-out-of-range'] } } })
+
+		await expect(persistAdminSettings({})).resolves.toEqual({ error: 'save-failed' })
+	})
+
+	it('reports save-failed on a network error', async () => {
+		Axios.post.mockRejectedValue(new Error('network down'))
+
+		await expect(persistAdminSettings({})).resolves.toEqual({ error: 'save-failed' })
+	})
+})
+
+describe('persistState', () => {
+	it('returns the backend state on success', async () => {
+		Axios.post.mockResolvedValue({ status: 200, data: { enabled: true } })
+
+		await expect(persistState(true)).resolves.toEqual({ enabled: true })
+	})
+
+	it('surfaces a specific backend error', async () => {
+		Axios.post.mockRejectedValue({ response: { data: { error: 'no-email' } } })
+
+		await expect(persistState(true)).resolves.toEqual({ enabled: false, error: 'no-email' })
+	})
+
+	it('reports save-failed on a network error', async () => {
+		Axios.post.mockRejectedValue(new Error('network down'))
+
+		await expect(persistState(true)).resolves.toEqual({ enabled: false, error: 'save-failed' })
+	})
+})
+
+describe('resetAdminSettings', () => {
+	it('returns the defaults on success', async () => {
+		Axios.post.mockResolvedValue({ status: 200, data: { codeLength: 6 } })
+
+		await expect(resetAdminSettings()).resolves.toEqual({ codeLength: 6 })
+	})
+
+	it('reports reset-failed on error', async () => {
+		Axios.post.mockRejectedValue(new Error('boom'))
+
+		await expect(resetAdminSettings()).resolves.toEqual({ error: 'reset-failed' })
+	})
+})

--- a/src/services/StateManager.test.js
+++ b/src/services/StateManager.test.js
@@ -49,7 +49,7 @@ describe('persistAdminSettings', () => {
 	})
 
 	it('reports save-failed on a non-200 response', async () => {
-		Axios.post.mockResolvedValue({ status: 500, data: {} })
+		Axios.post.mockResolvedValue({ status: 204, data: '' })
 
 		await expect(persistAdminSettings({})).resolves.toEqual({ error: 'save-failed' })
 	})
@@ -115,7 +115,7 @@ describe('resetAdminSettings', () => {
 	})
 
 	it('reports reset-failed on a non-200 response', async () => {
-		Axios.post.mockResolvedValue({ status: 500, data: {} })
+		Axios.post.mockResolvedValue({ status: 204, data: '' })
 
 		await expect(resetAdminSettings()).resolves.toEqual({ error: 'reset-failed' })
 	})

--- a/src/services/StateManager.test.js
+++ b/src/services/StateManager.test.js
@@ -11,6 +11,12 @@ vi.mock('@nextcloud/router', () => ({ generateUrl: (path) => path }))
 vi.mock('@nextcloud/axios', () => ({ default: { post: vi.fn() } }))
 vi.mock('../Logger.js', () => ({ default: { debug: vi.fn(), error: vi.fn() } }))
 
+const garbageBodies = [
+	{ case: 'null', body: null },
+	{ case: 'a string', body: 'unexpected' },
+	{ case: 'an unexpected object', body: { totallyWrong: true } },
+]
+
 beforeEach(() => {
 	vi.clearAllMocks()
 })
@@ -22,20 +28,28 @@ describe('persistAdminSettings', () => {
 		await expect(persistAdminSettings({})).resolves.toEqual({ codeLength: 6 })
 	})
 
+	it.each(garbageBodies)('returns a 200 body verbatim ($case)', async ({ body }) => {
+		Axios.post.mockResolvedValue({ status: 200, data: body })
+
+		await expect(persistAdminSettings({})).resolves.toEqual(body)
+	})
+
 	it('maps a 400 field-to-code map to { errors }', async () => {
 		Axios.post.mockRejectedValue({ response: { data: { errors: { codeLength: 'code-length-out-of-range' } } } })
 
 		await expect(persistAdminSettings({})).resolves.toEqual({ errors: { codeLength: 'code-length-out-of-range' } })
 	})
 
-	it('ignores an array errors payload and reports save-failed', async () => {
-		Axios.post.mockRejectedValue({ response: { data: { errors: ['code-length-out-of-range'] } } })
-
-		await expect(persistAdminSettings({})).resolves.toEqual({ error: 'save-failed' })
-	})
-
-	it('reports save-failed on a network error', async () => {
-		Axios.post.mockRejectedValue(new Error('network down'))
+	it.each([
+		{ case: 'an array errors payload', rejection: { response: { data: { errors: ['code-length-out-of-range'] } } } },
+		{ case: 'a string errors payload', rejection: { response: { data: { errors: 'code-length-out-of-range' } } } },
+		{ case: 'a numeric errors payload', rejection: { response: { data: { errors: 42 } } } },
+		{ case: 'a boolean errors payload', rejection: { response: { data: { errors: true } } } },
+		{ case: 'a null errors payload', rejection: { response: { data: { errors: null } } } },
+		{ case: 'a missing errors payload', rejection: { response: { data: {} } } },
+		{ case: 'a network error without a response', rejection: new Error('network down') },
+	])('reports save-failed for $case', async ({ rejection }) => {
+		Axios.post.mockRejectedValue(rejection)
 
 		await expect(persistAdminSettings({})).resolves.toEqual({ error: 'save-failed' })
 	})
@@ -48,14 +62,28 @@ describe('persistState', () => {
 		await expect(persistState(true)).resolves.toEqual({ enabled: true })
 	})
 
-	it('surfaces a specific backend error', async () => {
-		Axios.post.mockRejectedValue({ response: { data: { error: 'no-email' } } })
+	it.each(garbageBodies)('returns a 200 body verbatim ($case)', async ({ body }) => {
+		Axios.post.mockResolvedValue({ status: 200, data: body })
 
-		await expect(persistState(true)).resolves.toEqual({ enabled: false, error: 'no-email' })
+		await expect(persistState(true)).resolves.toEqual(body)
 	})
 
-	it('reports save-failed on a network error', async () => {
-		Axios.post.mockRejectedValue(new Error('network down'))
+	it.each([
+		{ case: 'a known code', error: 'no-email' },
+		{ case: 'a garbage value', error: { weird: 1 } },
+	])('surfaces the backend error verbatim ($case)', async ({ error }) => {
+		Axios.post.mockRejectedValue({ response: { data: { error } } })
+
+		await expect(persistState(true)).resolves.toEqual({ enabled: false, error })
+	})
+
+	it.each([
+		{ case: 'a response without a data body', rejection: { response: {} } },
+		{ case: 'a data body without an error', rejection: { response: { data: {} } } },
+		{ case: 'an empty error string', rejection: { response: { data: { error: '' } } } },
+		{ case: 'a network error without a response', rejection: new Error('network down') },
+	])('reports save-failed for $case', async ({ rejection }) => {
+		Axios.post.mockRejectedValue(rejection)
 
 		await expect(persistState(true)).resolves.toEqual({ enabled: false, error: 'save-failed' })
 	})
@@ -68,8 +96,18 @@ describe('resetAdminSettings', () => {
 		await expect(resetAdminSettings()).resolves.toEqual({ codeLength: 6 })
 	})
 
-	it('reports reset-failed on error', async () => {
-		Axios.post.mockRejectedValue(new Error('boom'))
+	it.each(garbageBodies)('returns a 200 body verbatim ($case)', async ({ body }) => {
+		Axios.post.mockResolvedValue({ status: 200, data: body })
+
+		await expect(resetAdminSettings()).resolves.toEqual(body)
+	})
+
+	it.each([
+		{ case: 'a rejected request', arm: () => Axios.post.mockRejectedValue(new Error('boom')) },
+		{ case: 'a garbage 4xx payload', arm: () => Axios.post.mockRejectedValue({ response: { status: 418, data: 'nonsense' } }) },
+		{ case: 'a non-200 response', arm: () => Axios.post.mockResolvedValue({ status: 500, data: {} }) },
+	])('reports reset-failed for $case', async ({ arm }) => {
+		arm()
 
 		await expect(resetAdminSettings()).resolves.toEqual({ error: 'reset-failed' })
 	})

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { defineConfig } from 'vitest/config'
+
+// noinspection JSUnusedGlobalSymbols
+export default defineConfig({
+	test: {
+		environment: 'node',
+		include: ['src/**/*.test.js'],
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'lcov'],
+			reportsDirectory: './coverage',
+		},
+	},
+})


### PR DESCRIPTION
Sets up a frontend test harness (finding from the review — the JS/Vue logic had no automated coverage, and `node-test.yml` was calling `npm run test --if-present` into the void).

- Adds `vitest` + `@vitest/coverage-v8` and `test` / `test:coverage` scripts (node environment, lcov coverage to `./coverage`). The existing node-test workflow already invokes both via `--if-present`, so CI starts running the frontend tests and uploading JS coverage to Codecov.
- First tests cover `src/services/StateManager.js` end to end — the response/error mapping that #120 fixed: success, the 400 field→code map, the array-payload guard, and the network fallback of `persistAdminSettings` / `persistState` / `resetAdminSettings`. ~92% line coverage of that file.

This is a starting point; the composable (`useAdminSettings`) and store can follow now that the harness exists.

Note: I could not run `eslint` locally to check the new test file (the dev machine is on node 26, which breaks eslint's flat-config plugin resolution repo-wide — unrelated to this PR); the PR's lint-eslint job is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
