### PR TITLE
Cover the store, composable and resend logic with vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@nextcloud/vite-config": "^2.5.1",
         "@vitest/coverage-v8": "^4.1.10",
         "eslint": "^10.0.1",
+        "happy-dom": "^20.10.6",
         "vite": "^7.1.9",
         "vitest": "^4.1.10"
       },
@@ -2851,6 +2852,16 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@types/semver": {
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
@@ -2881,6 +2892,23 @@
       "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
       "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
       "license": "MIT"
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.64.0",
@@ -4295,6 +4323,19 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/buffer-xor": {
@@ -6362,6 +6403,38 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/happy-dom": {
+      "version": "20.10.6",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.6.tgz",
+      "integrity": "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/has-flag": {
       "version": "5.0.1",
@@ -11025,6 +11098,13 @@
       "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
       "license": "MIT"
     },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/unicorn-magic": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
@@ -11791,6 +11871,16 @@
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "license": "MIT"
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -11868,6 +11958,28 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@nextcloud/vite-config": "^2.5.1",
     "@vitest/coverage-v8": "^4.1.10",
     "eslint": "^10.0.1",
+    "happy-dom": "^20.10.6",
     "vite": "^7.1.9",
     "vitest": "^4.1.10"
   }

--- a/src/LoginChallenge.test.js
+++ b/src/LoginChallenge.test.js
@@ -1,0 +1,106 @@
+// @vitest-environment happy-dom
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import Axios from '@nextcloud/axios'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import './LoginChallenge.js'
+
+vi.mock('./LoginChallenge.css', () => ({}))
+vi.mock('@nextcloud/axios', () => ({ default: { post: vi.fn() } }))
+vi.mock('@nextcloud/router', () => ({ generateUrl: (path) => path }))
+vi.mock('@nextcloud/l10n', () => ({
+	t: (app, text) => text,
+	n: (app, singular, plural, count) => plural.replace('%n', String(count)),
+}))
+vi.mock('./Logger.js', () => ({ default: { error: vi.fn() } }))
+
+function render({ cooldown = 60, availableIn = 0 } = {}) {
+	document.body.innerHTML = `
+		<div class="twofactor_email-resend-line" data-cooldown="${cooldown}" data-available-in="${availableIn}">
+			<a class="twofactor_email-resend" href="#">Send a new code</a>
+			<span class="twofactor_email-resend-status"></span>
+		</div>
+		<form class="twofactor_email-challenge-form">
+			<input name="challenge" value="123456">
+		</form>
+	`
+	document.dispatchEvent(new Event('DOMContentLoaded'))
+	return {
+		link: document.querySelector('.twofactor_email-resend'),
+		status: document.querySelector('.twofactor_email-resend-status'),
+		input: document.querySelector('input[name="challenge"]'),
+	}
+}
+
+beforeEach(() => {
+	vi.useFakeTimers()
+	vi.clearAllMocks()
+})
+
+afterEach(() => {
+	vi.useRealTimers()
+})
+
+describe('LoginChallenge resend', () => {
+	it('offers the resend link when no cooldown is pending', () => {
+		const { link } = render({ availableIn: 0 })
+
+		expect(link.hidden).toBe(false)
+	})
+
+	it('hides the link and shows a countdown when a cooldown is pending', () => {
+		const { link, status } = render({ availableIn: 30 })
+
+		expect(link.hidden).toBe(true)
+		expect(status.textContent).toContain('1 minute')
+	})
+
+	it('sends a new code, clears the input and starts the cooldown on click', async () => {
+		Axios.post.mockResolvedValue({})
+		const { link, status, input } = render({ availableIn: 0 })
+
+		link.click()
+		await vi.advanceTimersByTimeAsync(0)
+
+		expect(Axios.post).toHaveBeenCalledWith('/apps/twofactor_email/challenge/resend')
+		expect(input.value).toBe('')
+		expect(link.hidden).toBe(true)
+		expect(status.textContent).toContain('new code was sent')
+	})
+
+	it('shows a countdown when the server reports the cooldown (429)', async () => {
+		Axios.post.mockRejectedValue({ response: { status: 429, data: { retryAfter: 30 } } })
+		const { link, status } = render({ availableIn: 0 })
+
+		link.click()
+		await vi.advanceTimersByTimeAsync(0)
+
+		expect(link.hidden).toBe(true)
+		expect(status.textContent).toContain('1 minute')
+	})
+
+	it('reports a missing email address', async () => {
+		Axios.post.mockRejectedValue({ response: { status: 400, data: { error: 'no-email' } } })
+		const { status } = render({ availableIn: 0 })
+
+		document.querySelector('.twofactor_email-resend').click()
+		await vi.advanceTimersByTimeAsync(0)
+
+		expect(status.textContent).toContain('contact your administrator')
+	})
+
+	it('reports a generic failure and offers the link again', async () => {
+		Axios.post.mockRejectedValue(new Error('boom'))
+		const { link, status } = render({ availableIn: 0 })
+
+		link.click()
+		await vi.advanceTimersByTimeAsync(0)
+
+		expect(status.textContent).toContain('could not be sent')
+		expect(link.hidden).toBe(false)
+	})
+})

--- a/src/Store.test.js
+++ b/src/Store.test.js
@@ -1,0 +1,91 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { persistAdminSettings, persistState, resetAdminSettings } from './services/StateManager.js'
+import { useAdminSettingsStore, usePersonalSettingsStore } from './Store.js'
+
+vi.mock('@nextcloud/initial-state', () => ({ loadState: vi.fn() }))
+vi.mock('./services/StateManager.js', () => ({
+	persistState: vi.fn(),
+	persistAdminSettings: vi.fn(),
+	resetAdminSettings: vi.fn(),
+}))
+
+beforeEach(() => {
+	setActivePinia(createPinia())
+	vi.clearAllMocks()
+})
+
+describe('usePersonalSettingsStore.save', () => {
+	it('keeps the new state on success', async () => {
+		persistState.mockResolvedValue({ enabled: true })
+		const store = usePersonalSettingsStore()
+		store.enabled = true
+
+		await store.save()
+
+		expect(store.enabled).toBe(true)
+		expect(store.error).toBeFalsy()
+	})
+
+	it('reverts the switch and keeps the error on failure', async () => {
+		persistState.mockResolvedValue({ enabled: false, error: 'no-email' })
+		const store = usePersonalSettingsStore()
+		store.enabled = true
+
+		await store.save()
+
+		expect(store.enabled).toBe(false)
+		expect(store.error).toBe('no-email')
+	})
+})
+
+describe('useAdminSettingsStore.save', () => {
+	it('maps the saved settings into the state', async () => {
+		const saved = { codeLength: 8, codeValidMinutes: 10, codeResendMinutes: 30, eMailSubject: 'S', eMailTemplate: 'T' }
+		persistAdminSettings.mockResolvedValue(saved)
+		const store = useAdminSettingsStore()
+
+		const result = await store.save()
+
+		expect(store.codeLength).toBe(8)
+		expect(result).toEqual(saved)
+	})
+
+	it('keeps the current values and returns the errors on a validation error', async () => {
+		persistAdminSettings.mockResolvedValue({ errors: { codeLength: 'code-length-out-of-range' } })
+		const store = useAdminSettingsStore()
+		store.codeLength = 6
+
+		const result = await store.save()
+
+		expect(store.codeLength).toBe(6)
+		expect(result.errors).toEqual({ codeLength: 'code-length-out-of-range' })
+	})
+})
+
+describe('useAdminSettingsStore.reset', () => {
+	it('applies the defaults on success', async () => {
+		resetAdminSettings.mockResolvedValue({ codeLength: 6, codeValidMinutes: 10, codeResendMinutes: 30, eMailSubject: '', eMailTemplate: '' })
+		const store = useAdminSettingsStore()
+
+		await store.reset()
+
+		expect(store.codeLength).toBe(6)
+	})
+
+	it('does not touch the state on error', async () => {
+		resetAdminSettings.mockResolvedValue({ error: 'reset-failed' })
+		const store = useAdminSettingsStore()
+		store.codeLength = 8
+
+		const result = await store.reset()
+
+		expect(store.codeLength).toBe(8)
+		expect(result.error).toBe('reset-failed')
+	})
+})

--- a/src/composables/useAdminSettings.test.js
+++ b/src/composables/useAdminSettings.test.js
@@ -1,0 +1,104 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, reactive } from 'vue'
+import { useAdminSettings } from './useAdminSettings.js'
+
+vi.mock('@nextcloud/initial-state', () => ({ loadState: () => ({}) }))
+vi.mock('@nextcloud/l10n', () => ({ t: (app, text) => text }))
+vi.mock('../Logger.js', () => ({ default: { error: vi.fn(), warn: vi.fn() } }))
+
+const FIELDS = ['codeLength', 'codeValidMinutes', 'codeResendMinutes', 'eMailSubject', 'eMailTemplate']
+
+function makeStore() {
+	const store = reactive({
+		codeLength: 6,
+		codeValidMinutes: 10,
+		codeResendMinutes: 30,
+		eMailSubject: 'Subject',
+		eMailTemplate: 'Body {code}',
+	})
+	store.$patch = (patch) => Object.assign(store, patch)
+	store.save = vi.fn()
+	return store
+}
+
+/**
+ * Starts the composable, waits for its deferred watchers to register, edits one
+ * field and drives the debounced save to completion.
+ */
+async function editAndSave(store, key, value) {
+	const composable = useAdminSettings(store, FIELDS)
+	await nextTick()
+	await nextTick()
+	composable.inputValues[key] = value
+	await nextTick()
+	await vi.advanceTimersByTimeAsync(1500)
+	return composable
+}
+
+beforeEach(() => {
+	vi.useFakeTimers()
+})
+
+afterEach(() => {
+	vi.useRealTimers()
+})
+
+describe('useAdminSettings', () => {
+	it('flags only the field the backend rejected', async () => {
+		const store = makeStore()
+		store.save.mockResolvedValue({ errors: { codeLength: 'code-length-out-of-range' } })
+
+		const { successRefs, errorMessages } = await editAndSave(store, 'codeLength', 2)
+
+		expect(successRefs.codeLength).toBe(false)
+		expect(errorMessages.codeLength).toContain('code length')
+		expect(successRefs.codeValidMinutes).toBeNull()
+		expect(errorMessages.codeValidMinutes).toBe('')
+	})
+
+	it('marks every field as saved on success, then clears it', async () => {
+		const store = makeStore()
+		store.save.mockResolvedValue({ codeLength: 8 })
+
+		const { successRefs } = await editAndSave(store, 'codeLength', 8)
+
+		expect(successRefs.codeLength).toBe(true)
+		expect(successRefs.eMailSubject).toBe(true)
+
+		await vi.advanceTimersByTimeAsync(1200)
+		expect(successRefs.codeLength).toBeNull()
+	})
+
+	it('flags all fields without a message on an unexpected failure', async () => {
+		const store = makeStore()
+		store.save.mockResolvedValue({ error: 'save-failed' })
+
+		const { successRefs, errorMessages } = await editAndSave(store, 'codeLength', 8)
+
+		expect(successRefs.codeLength).toBe(false)
+		expect(successRefs.eMailSubject).toBe(false)
+		expect(errorMessages.codeLength).toBe('')
+	})
+
+	it('coalesces rapid edits into a single save', async () => {
+		const store = makeStore()
+		store.save.mockResolvedValue({ codeLength: 9 })
+		const { inputValues } = useAdminSettings(store, FIELDS)
+		await nextTick()
+		await nextTick()
+
+		inputValues.codeLength = 7
+		await nextTick()
+		await vi.advanceTimersByTimeAsync(500)
+		inputValues.codeLength = 9
+		await nextTick()
+		await vi.advanceTimersByTimeAsync(1500)
+
+		expect(store.save).toHaveBeenCalledTimes(1)
+	})
+})


### PR DESCRIPTION
Priority 1 of the frontend test plan — covers the JS/Vue **logic** layer with fast unit tests (no component mounting yet):

- **`Store.js`** (pinia): `save()`/`reset()` map the service result into state, the personal toggle reverts on error, and `reset()` skips the patch on error.
- **`useAdminSettings` composable**: the debounced save flags only the backend-rejected fields, marks every field saved on success (then clears after the timeout), flags all fields on an unexpected failure, and coalesces rapid edits into a single save — i.e. exactly the field-flagging logic that carried bugs earlier.
- **`LoginChallenge.js`**: the resend flow — offering the link, the cooldown countdown, sending a code, and the 429 / no-email / generic-error paths (runs under `happy-dom` since it manipulates the DOM directly).

25 frontend tests total (with the service tests from the base PR), all green; lint + build clean. Coverage of the touched files is uploaded to Codecov via the existing node-test workflow.

Based on #136 (the vitest harness); GitHub will retarget this to `main` once #136 merges. Component tests (`@vue/test-utils`) remain a later Priority 2 round.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
