### PR TITLE
Guarantee a well-formed result shape at the StateManager boundary

### DIFF
--- a/src/services/StateManager.js
+++ b/src/services/StateManager.js
@@ -12,6 +12,10 @@ import Logger from '../Logger.js'
  * 2xx response (null, an empty 204 body, an array, a primitive) breaks the
  * contract and must not be handed to the store, which dereferences it.
  *
+ * This only guards the shape: an object with unexpected keys still passes
+ * through, as validating the values would duplicate the backend
+ * SettingsValidator for a trusted first-party endpoint.
+ *
  * @param {unknown} data The response body to check
  * @return {boolean} Whether the body is a usable result object
  */

--- a/src/services/StateManager.js
+++ b/src/services/StateManager.js
@@ -8,6 +8,18 @@ import { generateUrl } from '@nextcloud/router'
 import Logger from '../Logger.js'
 
 /**
+ * A well-formed backend result is always a plain object. Anything else on a
+ * 2xx response (null, an empty 204 body, an array, a primitive) breaks the
+ * contract and must not be handed to the store, which dereferences it.
+ *
+ * @param {unknown} data The response body to check
+ * @return {boolean} Whether the body is a usable result object
+ */
+function isResultObject(data) {
+	return !!data && typeof data === 'object' && !Array.isArray(data)
+}
+
+/**
  * @typedef {{
  *   enabled: boolean,
  *   error: string|boolean
@@ -30,6 +42,9 @@ export function persistState(enabled) {
 	return Axios.post(url, data)
 		.then((resp) => {
 			// here HTTP 2xx only, HTTP 4xx error codes go to catch
+			if (!isResultObject(resp.data)) {
+				return { enabled: false, error: 'save-failed' }
+			}
 			return resp.data
 		}).catch((error) => {
 			Logger.error('failed to save two-factor email state', error)
@@ -75,11 +90,10 @@ export function persistAdminSettings(settings) {
 	Logger.debug('sending two-factor email admin settings', settings)
 	return Axios.post(url, settings)
 		.then((resp) => {
-			if (resp.status !== 200) {
+			if (resp.status !== 200 || !isResultObject(resp.data)) {
 				return { error: 'save-failed' }
-			} else {
-				return resp.data
 			}
+			return resp.data
 		}).catch((error) => {
 			// A 400 carries a field->code map of the failed validation checks so
 			// the UI can flag the offending fields; anything else is unexpected.
@@ -103,11 +117,10 @@ export function resetAdminSettings() {
 	Logger.debug('resetting two-factor email admin settings to defaults')
 	return Axios.post(url)
 		.then((resp) => {
-			if (resp.status !== 200) {
+			if (resp.status !== 200 || !isResultObject(resp.data)) {
 				return { error: 'reset-failed' }
-			} else {
-				return resp.data
 			}
+			return resp.data
 		}).catch(() => {
 			return { error: 'reset-failed' }
 		})

--- a/src/services/StateManager.test.js
+++ b/src/services/StateManager.test.js
@@ -11,6 +11,16 @@ vi.mock('@nextcloud/router', () => ({ generateUrl: (path) => path }))
 vi.mock('@nextcloud/axios', () => ({ default: { post: vi.fn() } }))
 vi.mock('../Logger.js', () => ({ default: { debug: vi.fn(), error: vi.fn() } }))
 
+// 2xx responses whose body is not a usable result object; the store would
+// crash or misbehave on these, so they must collapse to the failure shape.
+const malformedBodies = [
+	{ case: 'a null body', body: null },
+	{ case: 'an empty body', body: '' },
+	{ case: 'an array body', body: [] },
+	{ case: 'a numeric body', body: 42 },
+	{ case: 'a boolean body', body: true },
+]
+
 beforeEach(() => {
 	vi.clearAllMocks()
 })
@@ -22,7 +32,7 @@ describe('persistAdminSettings', () => {
 		await expect(persistAdminSettings({})).resolves.toEqual({ codeLength: 6 })
 	})
 
-	it('returns an unexpected 200 body verbatim', async () => {
+	it('passes an unexpected object body through unchanged', async () => {
 		Axios.post.mockResolvedValue({ status: 200, data: { unexpected: true } })
 
 		await expect(persistAdminSettings({})).resolves.toEqual({ unexpected: true })
@@ -48,8 +58,14 @@ describe('persistAdminSettings', () => {
 		await expect(persistAdminSettings({})).resolves.toEqual({ error: 'save-failed' })
 	})
 
-	it('reports save-failed on a non-200 response', async () => {
-		Axios.post.mockResolvedValue({ status: 204, data: '' })
+	it.each(malformedBodies)('reports save-failed for $case on a 200', async ({ body }) => {
+		Axios.post.mockResolvedValue({ status: 200, data: body })
+
+		await expect(persistAdminSettings({})).resolves.toEqual({ error: 'save-failed' })
+	})
+
+	it('reports save-failed on a non-200 response even with a valid body', async () => {
+		Axios.post.mockResolvedValue({ status: 201, data: { codeLength: 6 } })
 
 		await expect(persistAdminSettings({})).resolves.toEqual({ error: 'save-failed' })
 	})
@@ -62,7 +78,7 @@ describe('persistState', () => {
 		await expect(persistState(true)).resolves.toEqual({ enabled: true })
 	})
 
-	it('returns an unexpected 200 body verbatim', async () => {
+	it('passes an unexpected object body through unchanged', async () => {
 		Axios.post.mockResolvedValue({ status: 200, data: { unexpected: true } })
 
 		await expect(persistState(true)).resolves.toEqual({ unexpected: true })
@@ -90,6 +106,12 @@ describe('persistState', () => {
 
 		await expect(persistState(true)).resolves.toEqual({ enabled: false, error: 'save-failed' })
 	})
+
+	it.each(malformedBodies)('reports save-failed for $case on a 200', async ({ body }) => {
+		Axios.post.mockResolvedValue({ status: 200, data: body })
+
+		await expect(persistState(true)).resolves.toEqual({ enabled: false, error: 'save-failed' })
+	})
 })
 
 describe('resetAdminSettings', () => {
@@ -99,7 +121,7 @@ describe('resetAdminSettings', () => {
 		await expect(resetAdminSettings()).resolves.toEqual({ codeLength: 6 })
 	})
 
-	it('returns an unexpected 200 body verbatim', async () => {
+	it('passes an unexpected object body through unchanged', async () => {
 		Axios.post.mockResolvedValue({ status: 200, data: { unexpected: true } })
 
 		await expect(resetAdminSettings()).resolves.toEqual({ unexpected: true })
@@ -114,8 +136,14 @@ describe('resetAdminSettings', () => {
 		await expect(resetAdminSettings()).resolves.toEqual({ error: 'reset-failed' })
 	})
 
-	it('reports reset-failed on a non-200 response', async () => {
-		Axios.post.mockResolvedValue({ status: 204, data: '' })
+	it.each(malformedBodies)('reports reset-failed for $case on a 200', async ({ body }) => {
+		Axios.post.mockResolvedValue({ status: 200, data: body })
+
+		await expect(resetAdminSettings()).resolves.toEqual({ error: 'reset-failed' })
+	})
+
+	it('reports reset-failed on a non-200 response even with a valid body', async () => {
+		Axios.post.mockResolvedValue({ status: 201, data: { codeLength: 6 } })
 
 		await expect(resetAdminSettings()).resolves.toEqual({ error: 'reset-failed' })
 	})


### PR DESCRIPTION
## What

Hardens the `StateManager` service so it always hands the store a well-formed result object, never a raw contract-breaking body.

## Why

All three service functions returned `resp.data` verbatim on a 2xx response. The store dereferences that result (`result.error`, `result.enabled ?? …`, `result.codeLength ?? …`), so a broken 2xx body would:

- **crash** on a `null`/`undefined` body (`null.error`),
- **blank the fields** in `reset()` for a wrong-shape body (`typeof undefined !== 'string'` → patches `undefined`).

The first-party backend never sends such bodies today, so this is defense-in-depth against a contract violation (proxy, future change), guarded at the trust boundary where the HTTP data first enters.

## How

Each success branch now requires a plain result object before returning it, reusing the exact idiom already used for the 400 errors map (`x && typeof x === 'object' && !Array.isArray(x)`, extracted as a small `isResultObject` helper). Anything else collapses to the `save-failed` / `reset-failed` shape the store already handles — so **no store change is needed**, and the empty-204 case is subsumed as a failure.

A non-null object with unexpected keys still passes through unchanged: full schema validation would be speculative for a trusted first-party backend (and range validation already lives in the backend `SettingsValidator`).

## Tests

`StateManager.test.js`: added parametrized coverage for malformed 200 bodies (null, empty, array, numeric, boolean) per function, plus a non-200-with-valid-body case; kept the "unexpected object body passes through" characterization. StateManager.js stays at 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
