### PR TITLE
Exclude vitest/codecov config from the package, date 3.3.0

### DIFF
--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -12,6 +12,7 @@
 /.tx
 /build
 /.claude
+/codecov.yml
 /composer.*
 /krankerl.toml
 /node_modules
@@ -25,3 +26,4 @@
 /vendor/bin
 /vendor-bin
 /vite.config.js
+/vitest.config.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 3.3.0 (2026-07-16)
+## 3.3.0 (2026-07-20)
 
 ### Added
 


### PR DESCRIPTION
Final release hygiene for 3.3.0:

- Add `/vitest.config.js` and `/codecov.yml` to `.nextcloudignore` so the release package ships only runtime files (analogous to the already-excluded `eslint.config.js`).
- Set the 3.3.0 CHANGELOG date to the actual release day (2026-07-20).

No production code touched. Merging without review per maintainer instruction (CI is behind a GitHub Actions incident).

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.