### PR TITLE
Require PHP 8.2 and add psalm taint analysis

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -55,3 +55,6 @@ jobs:
 
       - name: Run coding standards check
         run: composer run psalm -- --threads=1 --monochrome --no-progress --output-format=github
+
+      - name: Run taint analysis
+        run: composer run psalm:taint -- --threads=1 --monochrome --no-progress --output-format=github

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.4.0 (2026-07-20)
+
+### Changed
+
+- Require PHP 8.2 or newer
+
 ## 3.3.0 (2026-07-20)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Require PHP 8.2 or newer
+- Drop support for Nextcloud 32 (which still allows PHP 8.1)
 
 ## 3.3.0 (2026-07-20)
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -63,7 +63,7 @@ at the bottom of "Personal Settings/Security").]]></description>
         https://raw.githubusercontent.com/datenschutz-individuell/twofactor_email/main/screenshots/challenge.webp
     </screenshot>
     <dependencies>
-        <php min-version="8.1" max-version="8.5"/>
+        <php min-version="8.2" max-version="8.5"/>
         <nextcloud min-version="32" max-version="34"/>
     </dependencies>
     <background-jobs>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -42,7 +42,7 @@ Mind that, once a user enabled any 2FA provider, they can no longer use their
 password in applications that don't support the web-based 2FA login flow. For
 such applications, the user needs to create and use app passwords (to be found
 at the bottom of "Personal Settings/Security").]]></description>
-    <version>3.3.0</version>
+    <version>3.4.0</version>
     <licence>agpl</licence>
     <author mail="twofactor-email@datenschutz-individuell.de">
         Olav Seyfarth (datenschutz-individuell) [see CONTRIBUTORS.md for more]

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -64,7 +64,7 @@ at the bottom of "Personal Settings/Security").]]></description>
     </screenshot>
     <dependencies>
         <php min-version="8.2" max-version="8.5"/>
-        <nextcloud min-version="32" max-version="34"/>
+        <nextcloud min-version="33" max-version="34"/>
     </dependencies>
     <background-jobs>
         <job>OCA\TwoFactorEMail\BackgroundJob\CleanUpExpiredCodes</job>

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   },
   "require": {
-    "php": ">=8.1 <8.6"
+    "php": ">=8.2 <8.6"
   },
   "require-dev": {
     "bamarni/composer-bin-plugin": "^1.9.1",
@@ -30,6 +30,7 @@
     "cs:check": "php-cs-fixer fix --dry-run --diff",
     "cs:fix": "php-cs-fixer fix",
     "psalm": "psalm.phar --threads=1",
+    "psalm:taint": "psalm.phar --threads=1 --taint-analysis",
     "psalm:update-baseline": "psalm.phar --threads=1 --update-baseline --set-baseline=tests/psalm-baseline.xml",
     "psalm:clear": "psalm.phar --clear-cache && psalm.phar --clear-global-cache",
     "psalm:fix": "psalm.phar --alter --issues=InvalidReturnType,InvalidNullableReturnType,MissingParamType,InvalidFalsableReturnType",
@@ -45,7 +46,7 @@
     "optimize-autoloader": true,
     "classmap-authoritative": false,
     "platform": {
-      "php": "8.1"
+      "php": "8.2"
     },
     "sort-packages": true,
     "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "require-dev": {
     "bamarni/composer-bin-plugin": "^1.9.1",
     "christophwurst/nextcloud_testing": "^2.0",
-    "nextcloud/ocp": "^32 || ^33 || ^34",
+    "nextcloud/ocp": "^33 || ^34",
     "psalm/phar": "^6.8",
     "roave/security-advisories": "dev-latest",
     "symfony/console": "^6.4.12"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "967ab776f7211de4ef0fbd74567f870f",
+    "content-hash": "c596a3c2d437fc99e6c3eb9093975098",
     "packages": [],
     "packages-dev": [
         {
@@ -872,20 +872,20 @@
         },
         {
             "name": "psalm/phar",
-            "version": "6.8.2",
+            "version": "6.16.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/psalm/phar.git",
-                "reference": "333a7a0d7805b699860262e1b4ea8cf14e1cd118"
+                "reference": "11c6b55449667837fc07bb2a456c45a137c05ecd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/psalm/phar/zipball/333a7a0d7805b699860262e1b4ea8cf14e1cd118",
-                "reference": "333a7a0d7805b699860262e1b4ea8cf14e1cd118",
+                "url": "https://api.github.com/repos/psalm/phar/zipball/11c6b55449667837fc07bb2a456c45a137c05ecd",
+                "reference": "11c6b55449667837fc07bb2a456c45a137c05ecd",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.2"
             },
             "conflict": {
                 "vimeo/psalm": "*"
@@ -901,9 +901,9 @@
             "description": "Composer-based Psalm Phar",
             "support": {
                 "issues": "https://github.com/psalm/phar/issues",
-                "source": "https://github.com/psalm/phar/tree/6.8.2"
+                "source": "https://github.com/psalm/phar/tree/6.16.1"
             },
-            "time": "2025-02-20T08:23:26+00:00"
+            "time": "2026-03-19T11:11:23+00:00"
         },
         {
             "name": "psr/clock",
@@ -4090,11 +4090,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.1 <8.6"
+        "php": ">=8.2 <8.6"
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.1"
+        "php": "8.2"
     },
     "plugin-api-version": "2.9.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c596a3c2d437fc99e6c3eb9093975098",
+    "content-hash": "1f107300da16b39294f9f5283aea66dd",
     "packages": [],
     "packages-dev": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "twofactor_email",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "twofactor_email",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "twofactor_email",
   "description": "Two-Factor Email Provider",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "type": "module",
   "author": {
     "name": "Christoph Wurst",

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <psalm
         errorLevel="3"
-        phpVersion="8.1"
+        phpVersion="8.2"
         findUnusedCode="false"
         ensureOverrideAttribute="false"
         autoloader="tests/bootstrap.php"


### PR DESCRIPTION
## What

Raises the PHP floor to 8.2 and adds Psalm taint (security) analysis — the latter was blocked by the former (Psalm ≥ 6.8.3 requires PHP 8.2).

## Changes

- **PHP 8.2 floor:** `composer.json` require (`>=8.2 <8.6`) + `config.platform.php`, `appinfo/info.xml` `<php min-version="8.2">`, `psalm.xml` `phpVersion="8.2"`. The CI PHP matrix is derived from `info.xml` via `nextcloud-version-matrix`, so 8.1 drops out automatically.
- **Psalm 6.8.2 → 6.16.1** (unblocked by the platform bump; also fixes the earlier taint-run crash).
- **Taint analysis wired up:** new `psalm:taint` composer script (`--taint-analysis`) and a CI step in `psalm.yml` next to the existing static run.

## Result

Taint analysis reports **no source-to-sink findings** on the current code. Full local pass (php-legacy 8.3): cs-fixer, psalm, psalm:taint, phpunit (146). npm side unaffected (lint/stylelint/vitest 77/vitalbuild green).

## Release

- Bumped to **3.4.0** (package.json + info.xml) with a CHANGELOG entry. Kept as a minor despite the raised floor by maintainer decision: admins on NC 32 with PHP 8.1 are offered the update but get a clear "PHP 8.2 required" message on the attempt.
- **Nextcloud range kept at 32–34.** Dropping PHP 8.1 does *not* drop NC 32 — the app now just requires an NC instance running PHP ≥ 8.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
