### PR TITLE
Add user, admin and developer documentation

### DIFF
--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -13,6 +13,7 @@
 /build
 /.claude
 /codecov.yml
+/doc
 /composer.*
 /krankerl.toml
 /node_modules

--- a/README.md
+++ b/README.md
@@ -1,87 +1,46 @@
 # Two-Factor Email Provider for Nextcloud
 
-[Nextcloud](https://nextcloud.com/) supports web logins with a second factor
-([two-factor authentication](https://en.wikipedia.org/wiki/Multi-factor_authentication#Factors),
-2FA). To support a certain type of 2FA, a "2FA provider" (server-)app must be
-installed. 2FA kicks in after the primary authentication stage (typically
-username and password) were successful. This provider challenges the user to
-enter a randomly generated authentication code (aka one-time password, OTP,
-currently six digits). It sends that code to the user's primary email address
-and expects the user to enter it on an additional second step web login page.
+[Nextcloud](https://nextcloud.com/) supports web logins with a second factor ([two-factor authentication](https://en.wikipedia.org/wiki/Multi-factor_authentication#Factors), 2FA). To support a certain type of 2FA, a "2FA provider" (server-)app must be installed. 2FA kicks in after the primary authentication stage (typically username and password) were successful. This provider challenges the user to enter a randomly generated authentication code (aka one-time password, OTP, currently six digits). It sends that code to the user's primary email address and expects the user to enter it on an additional second step web login page.
 
 ## Installation, activation and usage
 
-As with any 2FA provider, two-factor email must be installed from the
-[Nextcloud app store](https://apps.nextcloud.com/apps/twofactor_email) and
-enabled by a Nextcloud server admin. Additionally, the Nextcloud must have a
-working email server configured.
+As with any 2FA provider, two-factor email must be installed from the [Nextcloud app store](https://apps.nextcloud.com/apps/twofactor_email) and enabled by a Nextcloud server admin. Additionally, the Nextcloud must have a working email server configured.
 
-The user may set up any of the installed providers or even multiple. This
-provider uses email to send the code and thus can only be enabled if an email
-address is set in 'Personal info'. Mind that a user may not be able to log in
-if that email address is invalid (or email server setup of the Nextcloud is
-not working properly).
+The user may set up any of the installed providers or even multiple. This provider uses email to send the code and thus can only be enabled if an email address is set in 'Personal info'. Mind that a user may not be able to log in if that email address is invalid (or email server setup of the Nextcloud is not working properly).
 
-Admins with console access may enable and disable this provider for specified
-users via OCC command. Admins may also enforce 2FA for all users (or specific
-groups) via Admin Settings. This is a Nextcloud feature and not specific to
-this provider. If enforced, users with no 2FA are prompted to enable any
-installed provider (that supports AtLogin setup – this provider supports it
-since v3). If the admin installs this provider and enforces 2FA, it should be
-ensured that each user does have a valid email address.
+Admins with console access may enable and disable this provider for specified users via OCC command. Admins may also enforce 2FA for all users (or specific groups) via Admin Settings. This is a Nextcloud feature and not specific to this provider. If enforced, users with no 2FA are prompted to enable any installed provider (that supports AtLogin setup – this provider supports it since v3). If the admin installs this provider and enforces 2FA, it should be ensured that each user does have a valid email address.
 
-Mind that, once a user enabled any 2FA provider, they can no longer use their
-password in applications that don't support the web-based 2FA login flow. For
-such applications, the user needs to create and use
-[app passwords](https://docs.nextcloud.com/server/stable/user_manual/en/session_management.html#managing-devices)
-(to be found at the bottom of Personal Settings/Security).
+Mind that, once a user enabled any 2FA provider, they can no longer use their password in applications that don't support the web-based 2FA login flow. For such applications, the user needs to create and use [app passwords](https://docs.nextcloud.com/server/stable/user_manual/en/session_management.html#managing-devices) (to be found at the bottom of Personal Settings/Security).
+
+## Documentation
+
+- Guides [for users](doc/users.md), [for administrators](doc/admins.md), and [for developers](doc/developers.md)
+- The [architecture](doc/architecture.md) and the [threat model](doc/threat-model.md)
+
+To report a security vulnerability, see [SECURITY.md](SECURITY.md).
 
 ## State of the app
 
-This version 3.x.x ("v3") is the successor of the
-deprecated [twofactor_email](https://github.com/nursoda/twofactor_email/)
-app 2.x.x ("v2"). v2 will remain in the [Nextcloud App Store](https://apps.nextcloud.com/apps/twofactor_email) alongside
-v3 as
-long as upcoming security issues may be fixed with reasonable effort. After
-that, or after all supported Nextcloud versions may use v3, it will be pulled
-from the App Store. v3 is based on [twofactor_totp](https://github.com/nextcloud/twofactor_totp/) but has been
-refactored.
-v2 is installable on NC ≤33, v3 on NC ≥32.
+This version 3.x.x ("v3") is the successor of the deprecated [twofactor_email](https://github.com/nursoda/twofactor_email/) app 2.x.x ("v2"). v2 will remain in the [Nextcloud App Store](https://apps.nextcloud.com/apps/twofactor_email) alongside v3 as long as upcoming security issues may be fixed with reasonable effort. After that, or after all supported Nextcloud versions may use v3, it will be pulled from the App Store. v3 is based on [twofactor_totp](https://github.com/nextcloud/twofactor_totp/) but has been refactored. v2 is installable on NC ≤33, v3 on NC ≥32.
 
-The code is stable now. There are plans for further enhancements. See open tasks in the
-[roadmap](https://github.com/datenschutz-individuell/twofactor_email/issues/7). It keeps the status of whether this
-provider is enabled for a specific
-user or not when migrating from v2 to v3. However, from 3.1.1 onwards, v2 codes are no
-longer migrated to v3 since most of them were obsolete. Mind that the look and some
-behaviour changed or was enhanced.
+The code is stable now. There are plans for further enhancements. See open tasks in the [roadmap](https://github.com/datenschutz-individuell/twofactor_email/issues/7). It keeps the status of whether this provider is enabled for a specific user or not when migrating from v2 to v3. However, from 3.1.1 onwards, v2 codes are no longer migrated to v3 since most of them were obsolete. Mind that the look and some behaviour changed or was enhanced.
 
 ## Contributions welcome
 
-This app is a community effort. Any offers to help are welcome, whether it's
-code enhancements, refactoring, better test coverage, new features, security
-audits, translations or good documentation, examples, etc.
+This app is a community effort. Any offers to help are welcome, whether it's code enhancements, refactoring, better test coverage, new features, security audits, translations or good documentation, examples, etc.
 
-Prior to creating a PR, please discuss your idea in
-the [idea collection](https://github.com/datenschutz-individuell/twofactor_email/issues/8).
-Make sure your PR sticks to ONE change (so that we may review it cleanly), and
-that it doesn't break existing functionality. We will do our best to timely
-review and comment PRs.
+Prior to creating a PR, please discuss your idea in the [idea collection](https://github.com/datenschutz-individuell/twofactor_email/issues/8). Make sure your PR sticks to ONE change (so that we may review it cleanly), and that it doesn't break existing functionality. We will do our best to timely review and comment PRs.
 
-This app takes advantage of the transifex Nextcloud community. If the app is
-not yet available in your language, please consider creating a transifex
-account and join the [Nextcloud translators community](https://explore.transifex.com/nextcloud/).
+This app takes advantage of the transifex Nextcloud community. If the app is not yet available in your language, please consider creating a transifex account and join the [Nextcloud translators community](https://explore.transifex.com/nextcloud/).
 
-If you have any questions, please
-contact [the current maintainers](https://github.com/datenschutz-individuell/CONTRIBUTORS.md).
+If you have any questions, please contact [the current maintainers](https://github.com/datenschutz-individuell/CONTRIBUTORS.md).
 
 ## Building yourself
 
-To build the app, check out the repo and use `krankerl package` or follow these
-steps:
+To build the app, check out the repo and use `krankerl package` or follow these steps:
 
 * `composer i --no-dev`
 * `npm ci`
-* `npm run build`
-  or `npm run dev` [more info](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/npm.html)
+* `npm run build` or `npm run dev` [more info](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/npm.html)
 
 <small>[krankerl](https://github.com/ChristophWurst/krankerl/) is the tool proposed by Nextcloud to build apps.</small>

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To report a security vulnerability, see [SECURITY.md](SECURITY.md).
 
 ## State of the app
 
-This version 3.x.x ("v3") is the successor of the deprecated [twofactor_email](https://github.com/nursoda/twofactor_email/) app 2.x.x ("v2"). v2 will remain in the [Nextcloud App Store](https://apps.nextcloud.com/apps/twofactor_email) alongside v3 as long as upcoming security issues may be fixed with reasonable effort. After that, or after all supported Nextcloud versions may use v3, it will be pulled from the App Store. v3 is based on [twofactor_totp](https://github.com/nextcloud/twofactor_totp/) but has been refactored. v2 is installable on NC ≤33, v3 on NC ≥32.
+This version 3.x.x ("v3") is the successor of the deprecated [twofactor_email](https://github.com/nursoda/twofactor_email/) app 2.x.x ("v2"). v2 will remain in the [Nextcloud App Store](https://apps.nextcloud.com/apps/twofactor_email) alongside v3 as long as upcoming security issues may be fixed with reasonable effort. After that, or after all supported Nextcloud versions may use v3, it will be pulled from the App Store. v3 is based on [twofactor_totp](https://github.com/nextcloud/twofactor_totp/) but has been refactored. v2 is installable on NC ≤33, v3 on NC ≥33 (v3.0–3.3 also ran on NC 32).
 
 The code is stable now. There are plans for further enhancements. See open tasks in the [roadmap](https://github.com/datenschutz-individuell/twofactor_email/issues/7). It keeps the status of whether this provider is enabled for a specific user or not when migrating from v2 to v3. However, from 3.1.1 onwards, v2 codes are no longer migrated to v3 since most of them were obsolete. Mind that the look and some behaviour changed or was enhanced.
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -7,7 +7,7 @@ SPDX-PackageDownloadLocation = "https://github.com/datenschutz-individuell/twofa
 
 [[annotations]]
 path = [".github/CODEOWNERS", ".github/renovate.json",
-    "CHANGELOG.md", "CONTRIBUTORS.md", "README.md", "SECURITY.md",
+    "CHANGELOG.md", "CONTRIBUTORS.md", "README.md", "SECURITY.md", "doc/**",
     "composer.json", "composer.lock", "package.json", "package-lock.json",
     "vendor-bin/cs-fixer/composer.json", "vendor-bin/cs-fixer/composer.lock",
     "psalm.xml"]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,24 +1,17 @@
 # Security Policy
 
+The security model is documented by audience — [users](doc/users.md), [administrators](doc/admins.md), and [developers](doc/developers.md) — with a separate [threat model](doc/threat-model.md). For how the app is built, see [doc/architecture.md](doc/architecture.md).
+
 ## Supported Versions
 
-I only support the latest released version of the app for any Nextcloud version that still has official (not extended)
-support.
+I only support the latest released version of the app for any Nextcloud version that still has official (not extended) support.
 
 ## Reporting a Vulnerability
 
-You may create an issue in GitHub to report security vulnerabilities unless you think that it is not easily fixable and
-would affect many users. In this case, please email me directly using olav at seyfarth dot de. There is an OpenPGP key
-available for this address on the [OpenPGP keyserver](https://keys.openpgp.org/) that you may use.
+You may create an issue in GitHub to report security vulnerabilities unless you think that it is not easily fixable and would affect many users. In this case, please email me directly using olav at seyfarth dot de. There is an OpenPGP key available for this address on the [OpenPGP keyserver](https://keys.openpgp.org/) that you may use.
 
-We will timely review your report and fix it if we know how and if it's not an upstream issue. Please provide contact
-details so that we may get in touch with you. Once we publish the fixed code, we would like to pay credits to you. So
-please also include details on how we shall mention you.
-See [CONTRIBUTORS](https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md) for examples.
+We will timely review your report and fix it if we know how and if it's not an upstream issue. Please provide contact details so that we may get in touch with you. Once we publish the fixed code, we would like to pay credits to you. So please also include details on how we shall mention you. See [CONTRIBUTORS](https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md) for examples.
 
 ## Bounty
 
-I cannot provide any bounty for reporting. But if you feel that it would affect many users or Nextcloud as a platform,
-you may use their channel to report it, see the [security](https://nextcloud.com/security/) on the Nextcloud website. They used to use Hacker One
-as a reporting platform and provide a bounty if the report met their criteria. Due to too many AI generated reports,
-they abandoned that programme.
+I cannot provide any bounty for reporting. But if you feel that it would affect many users or Nextcloud as a platform, you may use their channel to report it, see the [security](https://nextcloud.com/security/) on the Nextcloud website. They used to use Hacker One as a reporting platform and provide a bounty if the report met their criteria. Due to too many AI generated reports, they abandoned that programme.

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -49,9 +49,9 @@ at the bottom of "Personal Settings/Security").]]></description>
     </author>
     <namespace>TwoFactorEMail</namespace>
     <documentation>
-        <user>https://github.com/datenschutz-individuell/twofactor_email/wiki/User-manual</user>
-        <admin>https://github.com/datenschutz-individuell/twofactor_email/wiki/Admin-manual</admin>
-        <developer>https://github.com/datenschutz-individuell/twofactor_email/wiki/Developer-notes</developer>
+        <user>https://github.com/datenschutz-individuell/twofactor_email/blob/main/doc/users.md</user>
+        <admin>https://github.com/datenschutz-individuell/twofactor_email/blob/main/doc/admins.md</admin>
+        <developer>https://github.com/datenschutz-individuell/twofactor_email/blob/main/doc/developers.md</developer>
     </documentation>
     <category>security</category>
 

--- a/doc/admins.md
+++ b/doc/admins.md
@@ -1,0 +1,25 @@
+# For administrators
+
+This page covers installing, configuring, and running the provider.
+
+## Installing & enabling
+
+- Install **Two-Factor Email** from the [Nextcloud App Store](https://apps.nextcloud.com/apps/twofactor_email). The server needs a working, configured mail server.
+- Users can enable it themselves in their security settings, or you can enable/disable it per user via `occ` (see below).
+- You can also **enforce 2FA** server-wide or per group (a Nextcloud feature). If you do, see the deployment note about email addresses below.
+
+## Settings
+
+Code length, code validity, the resend cooldown, and the challenge email subject/template are configurable — from the admin UI **and** via `occ`. All values go through one validator with fixed bounds (length, validity, cooldown ranges; subject/template max length; CR/LF rejected in the subject), so the web UI and `occ` cannot be used to set out-of-range or malformed values.
+
+## `occ` commands
+
+- `twofactor_email:settings` — show/change the app settings.
+- `twofactor_email:delete-codes` — delete the stored code of one user or all.
+- `twofactor_email:cleanup` — delete expired codes (also run daily by a background job).
+
+## Deployment notes
+
+- The app **requires working, trustworthy email**. The second factor travels over your mail path — use TLS to your mail server and treat the mailserver as part of your security perimeter.
+- When you **enforce 2FA**, each user needs at least one factor they can complete. Email is only critical for a user with no [other 2FA provider](https://docs.nextcloud.com/server/latest/user_manual/en/user_2fa.html) available. For that user, keep the primary email address valid — otherwise they are locked out.
+- Abuse of the "resend code" action is limited both by an app-level **cooldown** and by Nextcloud's **per-user rate limit and brute-force protection**.

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -1,0 +1,33 @@
+# Architecture
+
+The app plugs into Nextcloud's [two-factor provider framework](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/two-factor-provider.html). It is built against Nextcloud's public interfaces ([`OCP`](https://github.com/nextcloud-deps/ocp)) and its own small service interfaces, so the pieces are individually testable and replaceable. This document shows how they fit together; for the security mechanisms see [developers.md](developers.md), and the [threat model](threat-model.md) for its limits.
+
+## Login challenge flow
+
+The email challenge is the **second** stage of login. The first stage is a password — or a passwordless credential such as a passkey or security key. Once it succeeds, Nextcloud asks the enabled provider for a challenge, and this app generates a code, emails it, and verifies what the user enters:
+
+![Login challenge flow: after the first login stage, the provider reuses a still-valid code or issues a new one — generate with a CSPRNG, email it, then store its hash only after the email is sent. The code the user enters is checked with a constant-time hash comparison and deleted on success.](login-challenge-flow.svg)
+
+A new code is issued only when no unexpired one is stored, and the hash is written only after the email was sent. So reloading the login page does not spam the mailbox, and a failed send leaves the previous code valid.
+
+## Components
+
+The building blocks and the interface each one implements:
+
+| Concern                       | Interface                     | Implementation                                        |
+|-------------------------------|-------------------------------|-------------------------------------------------------|
+| 2FA provider entry point      | `IProvider` (OCP)             | `Provider\TwoFactorEMail`                             |
+| Login-setup at enforced login | `ILoginSetupProvider` (OCP)   | `Provider\LoginSetup`                                 |
+| Challenge orchestration       | `Service\ILoginChallenge`     | `Service\LoginChallenge`                              |
+| Code generation               | `Service\ICodeGenerator`      | `Service\NumericalCodeGenerator`                      |
+| Code storage                  | `Service\ICodeStorage`        | `Service\CodeStorage`                                 |
+| Email delivery                | `Service\IEMailSender`        | `Service\EMailSender` (+ `Mail\TemplateRenderer`)     |
+| Address masking               | `Service\IEMailAddressMasker` | `Service\EMailAddressMasker`                          |
+| Enable/disable state          | `Service\IStateManager`       | `Service\StateManager`                                |
+| Settings                      | `Service\IAppSettings`        | `Service\AppSettings` (+ `Service\SettingsValidator`) |
+
+Around these services sit the HTTP controllers, event listeners (activity/notifications/registry updates on state change and on email removal), the daily cleanup background job, `occ` commands, and the admin/personal settings sections.
+
+## Data footprint
+
+The app introduces no database table. Per user, it stores only the hashed current code and its timestamp (transient, expired-out and deleted on use). App-wide settings live in the app config. It does not store any personal data beyond the email address Nextcloud already holds.

--- a/doc/developers.md
+++ b/doc/developers.md
@@ -1,0 +1,33 @@
+# For developers
+
+The app plugs into Nextcloud's [two-factor provider framework](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/two-factor-provider.html) and is built against Nextcloud's public interfaces ([`OCP`](https://github.com/nextcloud-deps/ocp)). See [architecture.md](architecture.md) for how the components fit together and where data lives.
+
+## Building & testing
+
+- Set up a local dev environment with Docker: see [development-setup.md](development-setup.md).
+- Build the release package with `krankerl package`, or follow the manual steps in the README's [Building yourself](../README.md#building-yourself).
+- **PHP:** PHPUnit for the services, php-cs-fixer for style, and Psalm (including taint analysis) for static analysis. Psalm runs on the app's minimum PHP version, not on newer runtimes it does not yet support.
+- **Frontend:** Vitest for the logic and components, plus ESLint and Stylelint; `npm run build` produces the bundle.
+- Contributions are welcome — see [CONTRIBUTORS](../CONTRIBUTORS.md) and please discuss larger ideas first via the [idea collection](https://github.com/datenschutz-individuell/twofactor_email/issues/8).
+
+## Security mechanisms
+
+- **Code generation.** `NumericalCodeGenerator` uses `OCP\Security\ISecureRandom` (a CSPRNG) with `CHAR_DIGITS` and the configured length. No `rand()`/`mt_rand()`.
+- **Storage at rest.** `CodeStorage` stores `IHasher::hash($code)` — never the plaintext — in the user's config, plus a creation timestamp. The value is flagged `IUserConfig::FLAG_SENSITIVE`, so it is masked in `occ config:list` and in system/support reports.
+- **Verification.** `IHasher::verify()` is constant-time. The code is deleted only on **successful** verification (so a mistyped code can be retried); wrong tries are absorbed by Nextcloud's brute-force protection.
+- **Issuance policy.** A new code is issued only when no valid code is stored, which stops login-page reloads from flooding the mailbox. The new hash is persisted **only after** the email was sent successfully, so a failed delivery leaves the previous code valid.
+- **Resend throttling.** `ChallengeController::resend()` carries `#[NoAdminRequired]`, `#[NoTwoFactorRequired]`, `#[UserRateLimit(limit: 1, period: 60)]` and `#[BruteForceProtection]`, on top of the app-level resend cooldown (`ResendTooSoon`). See Nextcloud's [rate limiting](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/security.html#rate-limiting) docs.
+- **Sensitive-action confirmation & CSRF.** `StateController::save()` (enable/disable) carries `#[PasswordConfirmationRequired]`. All controllers are session-authenticated Nextcloud controllers subject to its CSRF protection.
+- **Email content safety (`TemplateRenderer`).** Everything is HTML-escaped (`htmlspecialchars`); raw HTML is impossible. Placeholders (`{code}`, `{user}`, `{cloud}`, `{validity}`, `{logo}`) and detected URLs are escaped individually, and inserted values (e.g. a display name) cannot smuggle in placeholders. The **subject** has CR/LF stripped as defense-in-depth against header injection.
+- **Input validation.** `SettingsValidator` enforces numeric ranges and string limits for every admin setting and is the single validation path shared by the web controller and the `occ` command.
+
+## Assurance
+
+- **Static analysis:** Psalm (errorLevel 3) plus **Psalm taint analysis** (source-to-sink SAST, added in 3.4.0) — currently **no findings**. Taint rides on the annotations shipped in [`nextcloud/ocp`](https://github.com/nextcloud-deps/ocp), so it needs no extra stubs.
+- **Tests:** PHPUnit for the PHP services, Vitest for the frontend logic and components.
+- **Frontend SAST:** CodeQL (JavaScript) via the repository's default setup.
+- **Supply chain:** `roave/security-advisories` blocks known-vulnerable composer packages; Dependabot tracks npm/composer updates; the release package ships only runtime files.
+
+## Licensing
+
+The app is licensed [AGPL-3.0-or-later](../LICENSES/) and is [REUSE](https://reuse.software/)/SPDX compliant: every file carries clear copyright and licence metadata, inline or via `REUSE.toml`, and CI verifies it. Bundled assets keep their own licences (e.g. the app icon).

--- a/doc/development-setup.md
+++ b/doc/development-setup.md
@@ -1,0 +1,73 @@
+# Development setup
+
+How to set up a local environment to work on this app, based on Nextcloud's Docker dev image, [nextcloud-docker-dev](https://github.com/juliushaertl/nextcloud-docker-dev).
+
+## Docker-based environment
+
+1. **Install Docker** (Docker Desktop, or the engine plus compose) — see the [Docker docs](https://docs.docker.com/desktop/install/ubuntu/).
+2. **Set up Nextcloud's dev image:**
+   ```
+   git clone https://github.com/juliushaertl/nextcloud-docker-dev
+   cd nextcloud-docker-dev
+   ./bootstrap.sh
+   ```
+   Start it — needed every time — with `docker compose up nextcloud`; stop it with Ctrl+C.
+3. **Clone the app into the workspace:**
+   ```
+   cd workspace/server/apps
+   git clone git@github.com:datenschutz-individuell/twofactor_email.git
+   ```
+4. **Install dependencies and build the frontend:**
+   ```
+   composer i
+   npm ci
+   npm run build
+   ```
+
+The app should now appear in Nextcloud and work once enabled.
+
+## Common commands
+
+- **Tail the PHP error log:** `docker exec -ti master-nextcloud-1 tail -f data/nextcloud.log`
+- **Rebuild the frontend** after changing Vue/JS files: `npm run build` (or `npm run dev`).
+- **Run the tests** inside the container:
+  ```
+  docker exec -it master-nextcloud-1 bash
+  cd apps/twofactor_email/
+  composer run-script test
+  ```
+- **Test against a specific Nextcloud version** — pick a branch or tag from [nextcloud/server](https://github.com/nextcloud/server) and mount your local checkout (replace `/PATH/TO` with the path to your `nextcloud-docker-dev` clone):
+  ```
+  docker run --rm -p 8080:80 -e SERVER_BRANCH=v27.1.7 \
+    -v /PATH/TO/nextcloud-docker-dev/workspace/server/apps/twofactor_email:/var/www/html/apps/twofactor_email \
+    ghcr.io/juliushaertl/nextcloud-dev-php80:latest
+  ```
+
+## Minimalist setup on Arch Linux
+
+Credits: @seyfahni. Follows the [nextcloud-docker-dev documentation](https://juliushaertl.github.io/nextcloud-docker-dev/).
+
+```
+# as root
+pacman -S docker docker-compose docker-buildx
+# optional: more networks with fewer hosts each
+cat >/etc/docker/daemon.json <<'EOF'
+{
+  "default-address-pools": [
+    { "base": "172.16.0.0/12", "size": 26 }
+  ],
+  "features": { "buildkit": true }
+}
+EOF
+systemctl enable --now docker.socket
+usermod -aG docker <DEV_USER>
+# log off and back on for the group change to take effect
+
+# as DEV_USER (with a working GitHub SSH setup)
+git clone git@github.com:juliushaertl/nextcloud-docker-dev.git
+cd nextcloud-docker-dev
+./bootstrap.sh
+
+docker compose up --pull always -d nextcloud
+# Nextcloud is then reachable at http://nextcloud.local/  (user: admin, password: admin)
+```

--- a/doc/login-challenge-flow.svg
+++ b/doc/login-challenge-flow.svg
@@ -1,0 +1,68 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 690" font-family="-apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif" font-size="13">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#4b6a88"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="640" height="690" fill="#ffffff"/>
+
+  <!-- box + diamond styles applied inline -->
+  <g fill="#eef2f6" stroke="#4b6a88" stroke-width="1.5">
+    <rect x="40" y="20"  width="360" height="56" rx="8"/>
+    <rect x="40" y="100" width="360" height="56" rx="8"/>
+    <rect x="40" y="262" width="360" height="98" rx="8"/>
+    <rect x="40" y="404" width="360" height="46" rx="8"/>
+    <rect x="40" y="490" width="360" height="60" rx="8"/>
+    <rect x="40" y="592" width="360" height="60" rx="8"/>
+  </g>
+  <!-- reuse note -->
+  <rect x="452" y="178" width="160" height="54" rx="8" fill="#eaf4ec" stroke="#3f8f5a" stroke-width="1.5"/>
+  <!-- decision diamond -->
+  <polygon points="220,171 292,206 220,241 148,206" fill="#fbe4c9" stroke="#b8860b" stroke-width="1.5"/>
+
+  <!-- arrows -->
+  <g stroke="#4b6a88" stroke-width="1.5" fill="none" marker-end="url(#arrow)">
+    <path d="M220,76 L220,100"/>
+    <path d="M220,156 L220,171"/>
+    <path d="M220,241 L220,262"/>              <!-- no -> issue -->
+    <path d="M292,206 L452,206"/>              <!-- yes -> reuse -->
+    <path d="M220,360 L220,404"/>              <!-- issue -> enter -->
+    <path d="M532,232 L532,427 L400,427"/>     <!-- reuse -> enter -->
+    <path d="M220,450 L220,490"/>
+    <path d="M220,550 L220,592"/>
+  </g>
+
+  <!-- edge labels -->
+  <g fill="#5a6b7a" font-size="12">
+    <text x="232" y="256">no</text>
+    <text x="360" y="198">yes</text>
+  </g>
+
+  <!-- box text -->
+  <g fill="#1b2733" text-anchor="middle">
+    <text x="220" y="43">First stage succeeds</text>
+    <text x="220" y="61" fill="#5a6b7a" font-size="12">password — or a passkey / passwordless login</text>
+
+    <text x="220" y="123">Nextcloud asks TwoFactorEMail (IProvider)</text>
+    <text x="220" y="141" fill="#5a6b7a" font-size="12">for a second-factor challenge</text>
+
+    <text x="220" y="206" font-size="12">unexpired code stored?</text>
+
+    <text x="220" y="285" font-weight="600">Issue a new code</text>
+    <text x="60" y="308" text-anchor="start" font-size="12">1 · generate — ISecureRandom (digits)</text>
+    <text x="60" y="328" text-anchor="start" font-size="12">2 · email → the user's mailbox</text>
+    <text x="60" y="348" text-anchor="start" font-size="12">3 · store the hash (only after the email is sent)</text>
+
+    <text x="220" y="432">User enters the code</text>
+
+    <text x="220" y="515">verifyChallenge() — IHasher::verify</text>
+    <text x="220" y="533" fill="#5a6b7a" font-size="12">constant-time comparison</text>
+
+    <text x="220" y="617">On success: delete the stored code,</text>
+    <text x="220" y="635" fill="#5a6b7a" font-size="12">login proceeds</text>
+  </g>
+
+  <text x="532" y="201" text-anchor="middle" fill="#1b2733" font-size="12">reuse it —</text>
+  <text x="532" y="219" text-anchor="middle" fill="#5a6b7a" font-size="12">no new email</text>
+</svg>

--- a/doc/threat-model.md
+++ b/doc/threat-model.md
@@ -1,0 +1,19 @@
+# Threat model & limitations
+
+This app raises the bar for account takeover but, like every second factor, it is not absolute.
+
+- **The email channel is the trust anchor.** The factor is "something you can *receive*". Its strength equals the security of the user's mailbox and the mail transport. A compromised mailbox, or mail read in transit, defeats it. This is the fundamental trade-off of email-based 2FA versus "something you *have*" factors (TOTP apps, hardware keys).
+- **No phishing resistance.** A real-time phishing proxy can prompt for the code and replay it, exactly as with TOTP. Only origin-bound factors ([FIDO2/WebAuthn](https://docs.nextcloud.com/server/latest/user_manual/en/user_2fa.html)) resist this.
+- **Limited code entropy, compensated by policy.** A six-digit code has ~10⁶ values; brute force is contained by the short validity, the single valid code, the resend rate limit, and Nextcloud's login brute-force protection — not by entropy alone.
+- **Residual timing side channel (accepted).** `verifyChallenge()` returns early when no code is stored, which is measurably faster than a hash comparison, so response time reveals whether an unexpired code exists — but only to someone who already passed the first factor, and the comparison itself stays constant-time. A decoy hash comparison on the miss path was deliberately left out.
+- **A full server compromise defeats any 2FA**, this one included; storing codes hashed limits exposure from lower-privilege config/DB reads, not from root.
+
+## How email 2FA compares
+
+| Factor                      | Phishing-resistant     | Depends on                      | Convenience                  |
+|-----------------------------|------------------------|---------------------------------|------------------------------|
+| **Email code (this app)**   | No                     | User's mailbox + mail path      | High (no extra device/setup) |
+| TOTP app                    | No                     | A provisioned authenticator app | Medium                       |
+| Hardware / FIDO2 (WebAuthn) | **Yes** (origin-bound) | A physical key                  | Medium                       |
+
+Email 2FA is a low-friction, broadly available second factor — a clear improvement over password-only. Nextcloud lets a user enable several providers at once, so pair it with a stronger, phishing-resistant method where possible. Users able to use one then get the better protection, with email as a fallback.

--- a/doc/users.md
+++ b/doc/users.md
@@ -1,0 +1,38 @@
+# For users
+
+Two-factor email adds a second step to your Nextcloud login: after your password, you confirm a short code that was sent to your email address. This page explains how to turn it on, how to use it, and how it keeps your account safe.
+
+## Turning it on
+
+- Set a primary email address in *Personal info* first — the code is sent there.
+- Enable **Email** under *Personal settings › Security › Two-Factor Authentication*.
+- From then on, each login asks for a code after your password.
+
+## Using it at login
+
+When you sign in, after your password you are asked for a short one-time code. The app sends that code to your email address, and you enter it to finish logging in. If it does not arrive, you can request a fresh one after a short cooldown.
+
+Once any 2FA is active, apps that cannot show the web login (some desktop/mobile clients) need an [app password](https://docs.nextcloud.com/server/latest/user_manual/en/session_management.html) instead of your account password.
+
+## What protects your codes
+
+- Codes are **randomly generated** and **short-lived** — your admin sets how long they stay valid (for example 10 minutes).
+- A code is **single-use**: once it logs you in, it is gone.
+- Only **one** code is valid at a time. Reloading the login page does **not** send you a flood of new mails.
+- The server never keeps your actual code — only a one-way **fingerprint** (hash) of it, so the code cannot be read back out of the system.
+- On the login screen your address is shown **masked** (like `a*@*.com`), so someone glancing at your screen does not learn your full email address.
+- Turning email 2FA **on or off** asks for your password again.
+
+## Good to know
+
+- Your codes arrive **by email**, so this factor is only as safe as your **mailbox**. Protect your email account with a strong, unique password and, ideally, its own second factor — or a passkey.
+- Like authenticator-app codes, an emailed code is **not phishing-proof**: a fake login page could ask you for the code and use it immediately. **Only ever enter a code on your genuine Nextcloud address.**
+- If you want the strongest protection, ask your admin whether a hardware security key or passkey (FIDO2/WebAuthn) is available — it resists phishing that codes cannot. Nextcloud lets you enable [several methods](https://docs.nextcloud.com/server/latest/user_manual/en/user_2fa.html) at once, so you can keep email as a fallback.
+
+For how email 2FA compares to other methods and where its limits are, see the [threat model](threat-model.md).
+
+## Not receiving a code?
+
+- Check that your **primary email address** in *Personal info* is correct and that you can receive mail there.
+- Look in your spam/junk folder.
+- If mail delivery on the server is broken you will not receive codes — contact your administrator. Consider setting up a second 2FA method as a backup.

--- a/doc/users.md
+++ b/doc/users.md
@@ -10,9 +10,21 @@ Two-factor email adds a second step to your Nextcloud login: after your password
 
 ## Using it at login
 
-When you sign in, after your password you are asked for a short one-time code. The app sends that code to your email address, and you enter it to finish logging in. If it does not arrive, you can request a fresh one after a short cooldown.
+When you sign in, you enter your username and password as usual. If email is your only second factor you go straight to the code step; if you have several methods enabled, Nextcloud first asks which one to use — choose **Email verification**:
 
-Once any 2FA is active, apps that cannot show the web login (some desktop/mobile clients) need an [app password](https://docs.nextcloud.com/server/latest/user_manual/en/session_management.html) instead of your account password.
+![Choosing email verification at login](../screenshots/select-auth_thumb.png)
+
+The app then emails you a short one-time code and shows the code-entry screen. Your address is displayed masked, so a bystander cannot read it. Enter the code to finish signing in:
+
+![Entering the emailed code on the login screen](../screenshots/challenge.png)
+
+If the mail does not arrive, request a fresh one with **Resend** after a short cooldown. Each code is single-use and only one is valid at a time, so reloading the page never floods your inbox.
+
+## Desktop and mobile apps
+
+Once any 2FA is active, apps that cannot show the web login — most desktop and mobile sync clients — can no longer sign in with your normal password. The Nextcloud manual covers this under [*Using client applications with two-factor authentication*](https://docs.nextcloud.com/server/stable/user_manual/en/user_2fa.html#using-client-applications-with-two-factor-authentication): you generate a **device-specific password** (also called an *app password*) for each such app and use that instead.
+
+Create them under *Personal settings › Security › Devices & sessions* — see [Manage connected browsers and devices](https://docs.nextcloud.com/server/stable/user_manual/en/session_management.html). One thing specific to email 2FA: an app password skips the second step entirely, so treat each one like a full password — give every device its own, name them clearly, and revoke any you no longer use.
 
 ## What protects your codes
 

--- a/lib/Service/LoginChallenge.php
+++ b/lib/Service/LoginChallenge.php
@@ -87,11 +87,11 @@ final class LoginChallenge implements ILoginChallenge {
 		$submittedCode = trim($submittedCode);
 		$storedCodeHash = $this->codeStorage->readCode($user->getUID());
 		// Accepted residual timing side channel: returning early when no code is
-		// stored is measurably faster than the hash verify, so the response time
-		// reveals whether an unexpired code currently exists — but only to someone
-		// who already passed the first factor, and the comparison itself stays
-		// constant-time (IHasher::verify). A dummy verify on the miss path was
-		// deliberately left out; the leak does not justify it.
+		// stored is measurably faster than the hash comparison, so the response
+		// time reveals whether an unexpired code currently exists — but only to
+		// someone who already passed the first factor, and the comparison itself
+		// stays constant-time (IHasher::verify). A decoy hash comparison on the
+		// miss path was deliberately left out; the leak does not justify it.
 		if (is_null($storedCodeHash)) {
 			$isValid = false;
 		} else {


### PR DESCRIPTION
## What
User, admin and developer documentation plus an architecture overview and threat model, all under `doc/`, linked from the README and SECURITY.md.

- `doc/users.md`, `doc/admins.md`, `doc/developers.md` — audience guides
- `doc/architecture.md` (with a hand-drawn login-challenge-flow SVG) and `doc/threat-model.md`
- `doc/development-setup.md` — the dev setup imported from the wiki (which is thereby retired; no more wiki links)
- README.md / SECURITY.md reflowed and pointed at the new docs; `info.xml <documentation>` now points at the audience guides
- REUSE.toml / `.nextcloudignore` extended for `doc/`

The docs deliberately avoid hardcoded tool/version specifics, so they stay valid across the other in-flight branches (Node 26 / Vite 8, the PHP 8.2 modernization, the dependency refresh).

## Note
Best merged **last**, after the functional branches, so it documents the final state.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
