### PR TITLE
Release 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 3.4.0 (2026-07-20)
+## 3.4.0 (2026-07-25)
+
+### Added
+
+- User, administrator and developer documentation
 
 ### Changed
 


### PR DESCRIPTION
Finalizes the 3.4.0 release: sets the CHANGELOG date to 2026-07-25 and adds the documentation entry.

The version (3.4.0) was already bumped in #145; all functional and internal work is already on `main` (PHP 8.2 / drop NC 32, Vite 8 / Node 26, the readonly/attribute-routing/psalm modernization, the dependency refresh, and the documentation).

Release-gate checks green locally: psalm (0 errors), 146 PHPUnit tests, eslint, stylelint, vitest, php-cs.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
