### PR TITLE
Remove the dead CODEOWNERS file and its REUSE.toml entries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-/appinfo/info.xml   @datenschutz-individuell/twofactor_email

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -6,8 +6,7 @@ SPDX-PackageSupplier = "Two-Factor email Support <twofactor-email@datenschutz-in
 SPDX-PackageDownloadLocation = "https://github.com/datenschutz-individuell/twofactor_email"
 
 [[annotations]]
-path = [".github/CODEOWNERS", ".github/renovate.json",
-    "CHANGELOG.md", "CONTRIBUTORS.md", "README.md", "SECURITY.md", "doc/**",
+path = ["CHANGELOG.md", "CONTRIBUTORS.md", "README.md", "SECURITY.md", "doc/**",
     "composer.json", "composer.lock", "package.json", "package-lock.json",
     "vendor-bin/cs-fixer/composer.json", "vendor-bin/cs-fixer/composer.lock",
     "psalm.xml"]


### PR DESCRIPTION
## What
Removes the dead `CODEOWNERS` file and its `REUSE.toml` entries.

The single CODEOWNERS rule (`/appinfo/info.xml @datenschutz-individuell/twofactor_email`) pointed at a team that does not exist — GitHub's `codeowners/errors` reports **Unknown owner** — so it enforced nothing. Dropped, together with its `REUSE.toml` path entry and a stale `.github/renovate.json` entry (this repo uses Dependabot, and no `renovate.json` exists).

REUSE stays compliant; no effect on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
