### PR TITLE
Raise nextcloud/coding-standard to 1.5.0

### DIFF
--- a/vendor-bin/cs-fixer/composer.json
+++ b/vendor-bin/cs-fixer/composer.json
@@ -1,5 +1,5 @@
 {
   "require-dev": {
-    "nextcloud/coding-standard": "1.4.0"
+    "nextcloud/coding-standard": "1.5.0"
   }
 }

--- a/vendor-bin/cs-fixer/composer.lock
+++ b/vendor-bin/cs-fixer/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cb754a20ec396f6d35308d8fab562823",
+    "content-hash": "a462de1585b03886da31f8b62fb423b6",
     "packages": [],
     "packages-dev": [
         {
@@ -61,16 +61,16 @@
         },
         {
             "name": "nextcloud/coding-standard",
-            "version": "v1.4.0",
+            "version": "v1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud/coding-standard.git",
-                "reference": "8e06808c1423e9208d63d1bd205b9a38bd400011"
+                "reference": "80547a93236fbb9c783e05f0f0899043851b0dba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud/coding-standard/zipball/8e06808c1423e9208d63d1bd205b9a38bd400011",
-                "reference": "8e06808c1423e9208d63d1bd205b9a38bd400011",
+                "url": "https://api.github.com/repos/nextcloud/coding-standard/zipball/80547a93236fbb9c783e05f0f0899043851b0dba",
+                "reference": "80547a93236fbb9c783e05f0f0899043851b0dba",
                 "shasum": ""
             },
             "require": {
@@ -100,9 +100,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nextcloud/coding-standard/issues",
-                "source": "https://github.com/nextcloud/coding-standard/tree/v1.4.0"
+                "source": "https://github.com/nextcloud/coding-standard/tree/v1.5.0"
             },
-            "time": "2025-06-19T12:27:27+00:00"
+            "time": "2026-05-19T18:30:09+00:00"
         },
         {
             "name": "php-cs-fixer/shim",


### PR DESCRIPTION
The cs-fixer tooling had been sitting on `nextcloud/coding-standard` 1.4.0 while 1.5.0 was already out.

**Why it slipped through the 3.4.0 refresh:** `composer outdated` in the project root does not look into the `vendor-bin/*` sub-projects that the bamarni bin-plugin creates — each has its own `composer.json`/`composer.lock`. The command that does see them is **`composer bin all outdated`**.

Kept as an **exact pin** on purpose: a code-style tool that drifts on its own can start demanding reformatting in an unrelated pull request. 1.5.0 wants no changes here — php-cs-fixer reports **0 of 73 files**.

(For reference, v2 now uses `^1.5`. Happy to align either way if you prefer one convention.)

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
