### PR TITLE
Document how to contribute and fix the throwaway-instance example

### DIFF
--- a/doc/developers.md
+++ b/doc/developers.md
@@ -8,7 +8,29 @@ The app plugs into Nextcloud's [two-factor provider framework](https://docs.next
 - Build the release package with `krankerl package`, or follow the manual steps in the README's [Building yourself](../README.md#building-yourself).
 - **PHP:** PHPUnit for the services, php-cs-fixer for style, and Psalm (including taint analysis) for static analysis. Psalm runs on the app's minimum PHP version, not on newer runtimes it does not yet support.
 - **Frontend:** Vitest for the logic and components, plus ESLint and Stylelint; `npm run build` produces the bundle.
-- Contributions are welcome — see [CONTRIBUTORS](../CONTRIBUTORS.md) and please discuss larger ideas first via the [idea collection](https://github.com/datenschutz-individuell/twofactor_email/issues/8).
+
+## Contributing
+
+Contributions are welcome — see [CONTRIBUTORS](../CONTRIBUTORS.md).
+
+1. **Discuss larger ideas first** in the [idea collection](https://github.com/datenschutz-individuell/twofactor_email/issues/8), so nobody builds something that will not be merged.
+2. **Branch off `main`** and keep one topic per pull request. A focused change can be reviewed properly; a mixed one usually cannot.
+3. **Run the checks locally before opening the PR** — CI runs the same ones, but finding it out yourself is faster:
+   ```
+   composer test:unit:dev && composer psalm && composer cs:check
+   npm run lint && npm run stylelint && npm test && npm run build
+   ```
+   `composer cs:fix` applies the style fixes automatically. Some of the tools cap
+   the PHP version they accept — Psalm in particular — so if your distribution
+   ships a newer default PHP you need an older interpreter for them (on Arch
+   Linux, for example, `php-legacy vendor/bin/psalm.phar`).
+4. **Add SPDX headers to new files.** The project is [REUSE](https://reuse.software/) compliant and CI enforces it; files that cannot carry a header (images, generated files) are annotated centrally in `REUSE.toml`.
+5. **Describe *why* in the commit message**, not *what* — the diff already shows what changed.
+6. **CI is the gate.** All checks have to pass; a red run will not be merged.
+
+If a change affects behaviour, say how you verified it. Unit tests cover the
+services and the frontend logic, but route registration, emails and the login flow
+only show up in a running Nextcloud — see [development-setup.md](development-setup.md).
 
 ## Security mechanisms
 

--- a/doc/development-setup.md
+++ b/doc/development-setup.md
@@ -36,12 +36,7 @@ The app should now appear in Nextcloud and work once enabled.
   cd apps/twofactor_email/
   composer run-script test
   ```
-- **Test against a specific Nextcloud version** — pick a branch or tag from [nextcloud/server](https://github.com/nextcloud/server) and mount your local checkout (replace `/PATH/TO` with the path to your `nextcloud-docker-dev` clone):
-  ```
-  docker run --rm -p 8080:80 -e SERVER_BRANCH=v27.1.7 \
-    -v /PATH/TO/nextcloud-docker-dev/workspace/server/apps/twofactor_email:/var/www/html/apps/twofactor_email \
-    ghcr.io/juliushaertl/nextcloud-dev-php80:latest
-  ```
+- **Test against a specific Nextcloud version** — see below.
 
 ## Minimalist setup on Arch Linux
 
@@ -71,3 +66,61 @@ cd nextcloud-docker-dev
 docker compose up --pull always -d nextcloud
 # Nextcloud is then reachable at http://nextcloud.local/  (user: admin, password: admin)
 ```
+
+## Throwaway instance for a specific Nextcloud version
+
+The app supports a range of Nextcloud versions, and a bug can be specific to one of
+them. The quickest way to check one is a disposable instance built from the official
+image. SQLite is enough, and a mail catcher is **required** — without SMTP the
+challenge email never arrives, so the login flow cannot be tested at all.
+
+`compose.yaml`:
+
+```yaml
+services:
+  nextcloud:
+    image: nextcloud:33-apache          # pick the version you want to test
+    ports: ["8080:80"]
+    environment:
+      SQLITE_DATABASE: nextcloud
+      NEXTCLOUD_ADMIN_USER: admin
+      NEXTCLOUD_ADMIN_PASSWORD: admin
+      NEXTCLOUD_TRUSTED_DOMAINS: localhost
+    volumes:
+      - nc-data:/var/www/html
+      # the built app, not the working tree — test what gets shipped
+      - ./twofactor_email:/var/www/html/custom_apps/twofactor_email:ro
+  mailpit:
+    image: axllent/mailpit
+    ports: ["8025:8025"]                # the challenge codes land here
+volumes:
+  nc-data:
+```
+
+Unpack a built package next to it and start the stack:
+
+```
+tar xzf build/artifacts/twofactor_email.tar.gz -C .
+docker compose up -d
+```
+
+Then point Nextcloud at the mail catcher, give the admin an address (the provider
+cannot be enabled without one) and enable the app:
+
+```
+occ() { docker compose exec -T -u www-data nextcloud php occ "$@"; }
+occ config:system:set mail_smtpmode --value=smtp
+occ config:system:set mail_smtphost --value=mailpit
+occ config:system:set mail_smtpport --value=1025
+occ config:system:set mail_from_address --value=nextcloud
+occ config:system:set mail_domain --value=example.org
+occ user:setting admin settings email admin@example.org
+occ app:enable twofactor_email
+```
+
+Nextcloud is at `http://localhost:8080` (admin/admin), the mailbox at
+`http://localhost:8025`. `docker compose down -v` removes everything again.
+
+If the Docker daemon refuses to start with `error initializing graphdriver: driver
+not supported`, the kernel was updated without a reboot since — the modules of the
+running kernel are gone, so overlayfs cannot be loaded. Rebooting fixes it.

--- a/doc/development-setup.md
+++ b/doc/development-setup.md
@@ -121,6 +121,35 @@ occ app:enable twofactor_email
 Nextcloud is at `http://localhost:8080` (admin/admin), the mailbox at
 `http://localhost:8025`. `docker compose down -v` removes everything again.
 
+To reach the login challenge you need the provider switched on for the user. That is
+a user setting, so a script can do it without opening the browser:
+
+```
+occ user:setting admin twofactor_email verified true
+```
+
+The next login then asks for the code, which you read in the mail catcher. Note that
+`occ twofactorauth:enable` cannot do this — it answers "The provider does not support
+this operation" — and `occ twofactorauth:state` still lists the app as disabled,
+because the app keeps its own state instead of using Nextcloud's provider registry.
+
+Two things that look like bugs but are not:
+
+- **The admin password cannot be changed to a weak one later.** `password_policy` is
+  active in the image and asks for ten characters and a password that is not on the
+  breach list. It does not apply while the instance is being installed, which is why
+  `admin/admin` works, but a later `occ user:resetpassword` to `admin` fails. Pick a
+  strong password, or throw the instance away and set it up again.
+- **A `curl` login needs an `Origin` header.** Nextcloud rejects a POST to `/login`
+  without a trusted `Origin` before it ever checks the password, and answers with a
+  redirect to `?direct=1&user=…` plus a misleading `Logging out` line in the log. It
+  looks exactly like a wrong password:
+
+  ```
+  curl -b jar -c jar -H 'Origin: http://localhost:8080' \
+    -d user=admin -d password=admin -d "requesttoken=$TOKEN" http://localhost:8080/login
+  ```
+
 If the Docker daemon refuses to start with `error initializing graphdriver: driver
 not supported`, the kernel was updated without a reboot since — the modules of the
 running kernel are gone, so overlayfs cannot be loaded. Rebooting fixes it.

--- a/doc/development-setup.md
+++ b/doc/development-setup.md
@@ -121,19 +121,17 @@ occ app:enable twofactor_email
 Nextcloud is at `http://localhost:8080` (admin/admin), the mailbox at
 `http://localhost:8025`. `docker compose down -v` removes everything again.
 
-To reach the login challenge you need the provider switched on for the user. That is
-a user setting, so a script can do it without opening the browser:
+To reach the login challenge, switch the provider on for the user. The app keeps this
+state in Nextcloud's own two-factor registry, so `occ` can do it without a browser:
 
 ```
-occ user:setting admin twofactor_email verified true
+occ twofactorauth:enable admin email
+occ twofactorauth:state admin        # email must be listed under "Enabled providers"
 ```
 
-The next login then asks for the code, which you read in the mail catcher. Note that
-`occ twofactorauth:enable` cannot do this — it answers "The provider does not support
-this operation" — and `occ twofactorauth:state` still lists the app as disabled,
-because the app keeps its own state instead of using Nextcloud's provider registry.
+The next login then asks for the code, which you read in the mail catcher.
 
-Two things that look like bugs but are not:
+Three things that look like bugs but are not:
 
 - **The admin password cannot be changed to a weak one later.** `password_policy` is
   active in the image and asks for ten characters and a password that is not on the
@@ -143,11 +141,16 @@ Two things that look like bugs but are not:
 - **A `curl` login needs an `Origin` header.** Nextcloud rejects a POST to `/login`
   without a trusted `Origin` before it ever checks the password, and answers with a
   redirect to `?direct=1&user=…` plus a misleading `Logging out` line in the log. It
-  looks exactly like a wrong password:
+  looks exactly like a wrong password.
+- **Send the request token as a header, not as a form field.** The token is base64, so
+  it often contains a `+`. `curl -d` sends the body verbatim and PHP turns that `+`
+  into a space while decoding, which breaks the token — but only for the tokens that
+  happen to contain one, so the same command works about one time in three. As a
+  header it needs no encoding:
 
   ```
-  curl -b jar -c jar -H 'Origin: http://localhost:8080' \
-    -d user=admin -d password=admin -d "requesttoken=$TOKEN" http://localhost:8080/login
+  curl -b jar -c jar -H 'Origin: http://localhost:8080' -H "requesttoken: $TOKEN" \
+    -d user=admin -d password=admin http://localhost:8080/login
   ```
 
 If the Docker daemon refuses to start with `error initializing graphdriver: driver


### PR DESCRIPTION
Two documentation gaps that showed up while releasing 3.4.0.

**`developers.md` — how to contribute.** So far this was a single sentence pointing at CONTRIBUTORS and the idea collection, which does not tell anyone how to produce a mergeable pull request. The new `Contributing` section covers: discuss larger ideas first, branch off `main` with one topic per PR, the checks to run locally before opening it, SPDX headers for new files, describing *why* in the commit message, and that CI is the gate.

It closes with the point that bit us during 3.4.0: unit tests cover the services and the frontend logic, but **route registration, emails and the login flow only show up in a running Nextcloud**. The `routes.php` → `#[FrontpageRoute]` switch would have passed CI even if no route had registered.

**`development-setup.md` — a broken example.** The "test against a specific Nextcloud version" snippet was pinned to `nextcloud-dev-php80` and `SERVER_BRANCH=v27.1.7`, i.e. PHP 8.0 and Nextcloud 27 — impossible for an app that requires PHP 8.2 and Nextcloud 33+. Replaced with a small compose stack from the official image, plus:

- a **mail catcher**, which is not optional: without SMTP the challenge email never arrives, so the login flow cannot be tested at all
- the built package is mounted, not the working tree, so you test what gets shipped
- the `error initializing graphdriver: driver not supported` case is explained (kernel updated without a reboot, so the running kernel's modules are gone)

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
