### PR TITLE
Keep the resend route reachable on Nextcloud 33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.4.1 (2026-07-26)
+
+### Fixed
+
+- Requesting a new code did nothing on Nextcloud 33
+
 ## 3.4.0 (2026-07-25)
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -42,7 +42,7 @@ Mind that, once a user enabled any 2FA provider, they can no longer use their
 password in applications that don't support the web-based 2FA login flow. For
 such applications, the user needs to create and use app passwords (to be found
 at the bottom of "Personal Settings/Security").]]></description>
-    <version>3.4.0</version>
+    <version>3.4.1</version>
     <licence>agpl</licence>
     <author mail="twofactor-email@datenschutz-individuell.de">
         Olav Seyfarth (datenschutz-individuell) [see CONTRIBUTORS.md for more]

--- a/lib/Controller/ChallengeController.php
+++ b/lib/Controller/ChallengeController.php
@@ -43,11 +43,20 @@ final class ChallengeController extends ALoginSetupController {
 		parent::__construct($appName, $request);
 	}
 
-	/*
+	/**
 	 * The service cooldown is the configurable source of truth. The rate limit
 	 * is an atomic backstop against concurrent bursts: period 60s matches the
 	 * minimum allowed resend cooldown (currently 1 minute), so it never rejects a
 	 * legitimately allowed resend.
+	 *
+	 * The annotation duplicates the attribute below on purpose. Nextcloud 33
+	 * exempts a route from the two-factor gate through the docblock only — its
+	 * TwoFactorMiddleware asks hasAnnotation('NoTwoFactorRequired') — while the
+	 * attribute exists from Nextcloud 34 on. With the attribute alone, a resend on
+	 * Nextcloud 33 gets a redirect to the provider selection instead of a new code.
+	 * Drop the annotation once the app requires Nextcloud 34.
+	 *
+	 * @NoTwoFactorRequired
 	 */
 	#[FrontpageRoute(verb: 'POST', url: '/challenge/resend')]
 	#[NoAdminRequired]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "twofactor_email",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "twofactor_email",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "twofactor_email",
   "description": "Two-Factor Email Provider",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "type": "module",
   "author": {
     "name": "Christoph Wurst",


### PR DESCRIPTION
## Was

Requesting a new code did nothing on Nextcloud 33. The endpoint answered with a redirect to the provider selection instead of sending a mail, so the button in the challenge dialog was dead on the oldest server the app declares support for.

Nextcloud 33 exempts a route from the two-factor gate through the **docblock annotation** only — its `TwoFactorMiddleware` asks `hasAnnotation('NoTwoFactorRequired')` — while `OCP\AppFramework\Http\Attribute\NoTwoFactorRequired` is `@since 34.0.0`. The route carried the attribute alone, so nothing exempted it on 33. The annotation now sits next to the attribute and can go once the app requires Nextcloud 34.

Present since the resend feature was added (10d1158), not a side effect of the move to attribute routing.

## Why no review was requested

The change adds one annotation and a comment; no logic is touched. It is verified on both supported server versions, and the reasoning is written down in the code so the duplication is not mistaken for a leftover later. Released as 3.4.1 right away because 3.4.0 ships the defect to every Nextcloud 33 user.

## Verification

Automated against throwaway instances built from the packaged app (`nextcloud:33-apache` and `nextcloud:34-apache`), 28 checks each, all green — login, challenge, mail, resend, wrong and right code, the admin routes including the 400 validation path, `state/save` in both directions, every asset of the challenge page, and a clean server log.

| | Nextcloud 33 | Nextcloud 34 |
|---|---|---|
| before | `303` to the provider selection, no mail | `200`, mail sent |
| after | `200 {"status":"sent"}`, mail sent | `200 {"status":"sent"}`, mail sent |

The gap existed because the manual browser pass runs on a Nextcloud 34 instance, which was never affected. An audit of the other six attributes the app uses found them all `@since` 27 to 29, so this was the only one out of range.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.