### PR TITLE
Add a smoke test against a real Nextcloud, plus release notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ css/
 
 tests/clover.xml
 tests/.phpunit.result.cache
+/tests/smoke/app/

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ css/
 tests/clover.xml
 tests/.phpunit.result.cache
 /tests/smoke/app/
+/tests/smoke/.env

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -12,12 +12,20 @@ true for anyone publishing a Nextcloud app, and most of it was learned the hard 
 
 ## Before building
 
-**Raise the version in every place that carries it.** For this app that is
-`appinfo/info.xml`, `package.json`, and **both** version fields in
-`package-lock.json` (the top-level one and `packages[""]`). Missing the lock file is
-easy and stays invisible until someone compares the shipped package with the tag.
-Change the value in place — do not let a tool re-resolve the dependency tree during a
-release.
+**Raise the version in every place that carries it.** Let npm do the JavaScript side:
+
+```
+npm version <version> --no-git-tag-version
+```
+
+That updates `package.json` and **both** version fields in `package-lock.json` (the
+top-level one and `packages[""]`) and touches nothing else — verified on a release bump:
+two changed lines in the lock file, all 855 dependency entries byte-identical, integrity
+hashes included. Do not re-resolve the tree during a release, and do not hand-edit the
+lock file either: the second version field is easy to miss, and editing by hand is how
+you end up with a lock whose checksums no longer match what it describes.
+
+`appinfo/info.xml` and the `CHANGELOG.md` section stay manual.
 
 **Add the changelog section for exactly that version** before building. Release notes
 are generated from it, so a missing section means empty notes.

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -1,0 +1,94 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# Releasing
+
+Notes for whoever publishes a release. The concrete infrastructure — which host signs,
+where the key lives, how the instances are updated — is deliberately not part of this
+document; it is specific to the maintainer's setup. What is here is the part that is
+true for anyone publishing a Nextcloud app, and most of it was learned the hard way.
+
+## Before building
+
+**Raise the version in every place that carries it.** For this app that is
+`appinfo/info.xml`, `package.json`, and **both** version fields in
+`package-lock.json` (the top-level one and `packages[""]`). Missing the lock file is
+easy and stays invisible until someone compares the shipped package with the tag.
+Change the value in place — do not let a tool re-resolve the dependency tree during a
+release.
+
+**Add the changelog section for exactly that version** before building. Release notes
+are generated from it, so a missing section means empty notes.
+
+**Check the dependencies:** `composer bin all outdated` (the plain `composer outdated`
+does **not** look into the `vendor-bin/*` sub-projects the bamarni plugin creates) and
+`npm outdated --all`. Also check whether the declared floors can be raised to what is
+actually installed, and whether existing pins and `overrides` are still needed.
+
+**Look at the open security alerts.** Either fix them or close them with a reason —
+"scope: development only" is a judgement that has to be made per case, not assumed.
+
+## Building
+
+`krankerl package` packages the **committed** state, not the working tree. An
+uncommitted fix is not in the package, and any test you then run proves the old
+behaviour. This has bitten us: a smoke test once passed on a package that predated the
+change it was meant to verify.
+
+## Testing before publishing
+
+Run `tests/smoke/smoke.sh` against the built package. It covers **both ends of the
+supported server range**, which is not pedantry: 3.4.0 shipped a resend endpoint that
+was dead on Nextcloud 33 and fine on 34, because the exemption from the two-factor
+gate is taken from the docblock on 33 and from the PHP attribute on 34, and that
+attribute is `@since 34`. A single manual pass on a current server cannot see that
+class of bug.
+
+What the smoke test cannot check is how it looks. Leave one instance running
+(`KEEP=1`) and look at the challenge dialog, dark mode and a non-English locale.
+
+## After publishing: why nobody sees it yet
+
+This is the part that looks like a bug in your instances and is not. Two independent
+caches sit between the app store and an `occ app:update`.
+
+**The store's own list.** `apps.nextcloud.com` serves
+`api/v1/platform/<ncversion>/apps.json` through a cache, and a freshly published
+version is not in it immediately — in one measured case about 15 minutes. Appending a
+query string bypasses that cache and shows the fresh list, which is useful for
+comparing but is not a fix: instances request the plain URL. There is nothing to flush
+here, only to wait.
+
+**Each instance's copy.** Nextcloud caches the list in
+`<datadir>/appdata_<instanceid>/appstore/apps.json` for an hour
+(`Fetcher::INVALIDATE_AFTER_SECONDS`), and both `occ app:update` and
+`occ update:check` read it through `Installer::isUpdateAvailable()`. To force a
+refetch, **truncate** that file rather than deleting it: appdata is managed through
+the Files API, so removing the file on disk leaves an orphaned filecache entry. An
+empty file parses as invalid JSON, so Nextcloud fetches again and overwrites it. Do
+every access as the owner of the data directory — it is not readable by anyone else,
+and a check that fails there makes the flush do nothing while looking like it worked.
+
+**The store rate-limits per IP**, and this is the answer to a puzzle that looked
+random for years: when several instances behind one address fetch the ~4 MB list in
+quick succession, some get `429 Too Many Requests`. Nextcloud catches that exception
+and returns an empty list, so a throttled instance reports "All apps are up-to-date"
+— indistinguishable from "nothing to do". That is why, after a release, a seemingly
+arbitrary subset of instances updates, and a different subset the next time. If you
+run more than one or two instances from the same address, put a caching proxy in front
+of the store (Nextcloud's `appstoreurl` can point at it) and serve stale content on
+`429`; then a throttle can no longer masquerade as "up to date".
+
+**Silent blockers worth knowing:** an app directory that is a git checkout is never
+updated, and `appstoreenabled=false` stops the store being asked at all. Neither says
+so.
+
+## Signing
+
+The store expects a signature over the tarball, and Nextcloud expects
+`appinfo/signature.json` inside it. These are two different things made by two
+different tools — `occ integrity:sign-app` writes the file, `openssl dgst -sha512
+-sign` produces the signature you hand to the store API. `krankerl` does not create
+`signature.json`; expecting it to is a dead end.

--- a/tests/smoke/README.md
+++ b/tests/smoke/README.md
@@ -26,8 +26,26 @@ cd tests/smoke
 NC_TAG=33-apache ./smoke.sh  # one specific server version
 SLOW=0 ./smoke.sh            # skip the successful resend, saving 65 s per version
 KEEP=1 ./smoke.sh            # leave the instance up to look at it
+BUILD=1 ./smoke.sh           # build the package first, then run
 ./setup.sh                   # just an instance, no checks (needs NC_TAG)
 ```
+
+## Without krankerl
+
+`krankerl` is only needed to build the package. If it does not work for you — it has
+been known to fail with `reference 'refs/remotes/origin/master' not found`, which comes
+from libgit2 inside it, not from your repository — mount your working tree instead:
+
+```bash
+composer install -o          # only the autoloader is needed at runtime
+npm ci && npm run build      # produces js/ and css/
+APP_DIR="$(git rev-parse --show-toplevel)" ./smoke.sh
+```
+
+Everything is checked as usual, except the comparison of the installed version against
+the package: there is no package. The trade-off is stated in the output, and it is
+real — a file missing from the release because of `.nextcloudignore` cannot show up
+this way. Use the packaged run before a release, this one while developing.
 
 The exit code is the number of failed checks. Ports and package can be overridden
 with `HTTP_PORT`, `MAIL_PORT` and `APP_TARBALL`.
@@ -48,6 +66,25 @@ docker compose exec -T -u www-data nextcloud php occ twofactorauth:enable admin 
 
 `setup.sh` prints this too. Note that the 2.x branch used a user setting of its own
 instead — `occ user:setting … twofactor_email verified true` does nothing here.
+
+## Why it may refuse to start
+
+The script compares the package against the state of the app and stops if they do not
+match:
+
+```
+The package does not match the current state of the app:
+  package 2026-07-26 22:41:03
+  sources 2026-07-27 23:05:11 (last commit touching the app)
+  uncommitted:
+    M src/LoginChallenge.js
+```
+
+This is not pedantry. `krankerl package` packages the **committed** state, so a stale
+package or an uncommitted change means the run proves something other than what you are
+working on — which has happened here: a smoke test once passed against a package built
+before the change it was meant to verify. `BUILD=1` rebuilds and runs in one go,
+`APP_DIR=…` tests the working tree instead.
 
 ## What it checks
 
@@ -85,6 +122,11 @@ That still needs a person with a browser — `KEEP=1` leaves an instance running
   instead.
 - **`krankerl package` packages the committed state.** An uncommitted fix is not in the
   package, and the test will keep proving the old behaviour.
+- **"The token expired" on the first login attempt.** Nextcloud's login form is only
+  valid for five minutes (`login_form_timeout`). Opening the page while the instance is
+  still installing and submitting afterwards therefore fails once; reloading is enough.
+  `occ config:system:set login_form_timeout --value=3600 --type=integer` if you want to
+  take your time.
 - **The admin password cannot be changed to a weak one afterwards.**
   `password_policy` is active in the image; it does not apply during installation,
   which is why `admin/admin` works at all. Throw the instance away instead.

--- a/tests/smoke/README.md
+++ b/tests/smoke/README.md
@@ -16,7 +16,10 @@ built package** into it, and check exactly that.
 ## Requirements
 
 Docker with the compose plugin, `python3`, `curl`, and a built package
-(`krankerl package`). Nothing else, and nothing leaves your machine.
+(`krankerl package`) — or a directory to mount, see below. Nothing leaves your machine.
+
+The scripts use GNU `grep -oP`, `stat -c` and `date -d`, so they need a GNU userland:
+Linux, or macOS with GNU coreutils and grep ahead of the stock ones in `PATH`.
 
 ## Use
 
@@ -26,9 +29,15 @@ cd tests/smoke
 NC_TAG=33-apache ./smoke.sh  # one specific server version
 SLOW=0 ./smoke.sh            # skip the successful resend, saving 65 s per version
 KEEP=1 ./smoke.sh            # leave the instance up to look at it
-BUILD=1 ./smoke.sh           # build the package first, then run
-./setup.sh                   # just an instance, no checks (needs NC_TAG)
+NC_TAG=34-apache ./setup.sh   # just an instance, no checks
+COMPOSE_PROJECT_NAME=tfe-2 HTTP_PORT=8081 MAIL_PORT=8026 ./smoke.sh   # a second instance
 ```
+
+`setup.sh` writes `tests/smoke/.env` (gitignored) with the values compose needs, which is
+why a later `docker compose down -v`, `logs` or `exec` works in that directory without
+setting anything. It records the **last** setup run, so with two instances around name the
+project when tearing one down:
+`COMPOSE_PROJECT_NAME=tfe-smoke docker compose down -v`.
 
 ## Without krankerl
 
@@ -41,6 +50,10 @@ composer install -o          # only the autoloader is needed at runtime
 npm ci && npm run build      # produces js/ and css/
 APP_DIR="$(git rev-parse --show-toplevel)" ./smoke.sh
 ```
+
+Naming a directory switches the mode: nothing is unpacked, that directory is mounted.
+`setup.sh` takes the same route, and `UNPACK` states it explicitly if you ever need to
+override the default (`UNPACK=0` mount, `UNPACK=1` unpack the package).
 
 Everything is checked as usual, except the comparison of the installed version against
 the package: there is no package. The trade-off is stated in the output, and it is
@@ -70,21 +83,26 @@ instead — `occ user:setting … twofactor_email verified true` does nothing he
 ## Why it may refuse to start
 
 The script compares the package against the state of the app and stops if they do not
-match:
+match — either because something is uncommitted:
 
 ```
-The package does not match the current state of the app:
+Uncommitted changes to the app:
+    M src/LoginChallenge.js
+```
+
+or because the package predates the last commit that touched the app:
+
+```
+The package is older than the app it should contain:
   package 2026-07-26 22:41:03
   sources 2026-07-27 23:05:11 (last commit touching the app)
-  uncommitted:
-    M src/LoginChallenge.js
 ```
 
 This is not pedantry. `krankerl package` packages the **committed** state, so a stale
 package or an uncommitted change means the run proves something other than what you are
 working on — which has happened here: a smoke test once passed against a package built
-before the change it was meant to verify. `BUILD=1` rebuilds and runs in one go,
-`APP_DIR=…` tests the working tree instead.
+before the change it was meant to verify. Rebuild with `krankerl package`, or
+test the working tree instead with `APP_DIR=…`.
 
 ## What it checks
 

--- a/tests/smoke/README.md
+++ b/tests/smoke/README.md
@@ -1,0 +1,85 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# Smoke test against a real Nextcloud
+
+The unit tests cover the classes. What they cannot cover is whether the app still
+works *inside* a Nextcloud — whether the routes are reachable, whether the mail goes
+out, whether a login with a code from that mail actually gets you in, and whether any
+of that differs between the oldest and the newest supported server.
+
+These scripts start a disposable Nextcloud from the official image, install **the
+built package** into it, and check exactly that.
+
+## Requirements
+
+Docker with the compose plugin, `python3`, `curl`, and a built package
+(`krankerl package`). Nothing else, and nothing leaves your machine.
+
+## Use
+
+```bash
+cd tests/smoke
+./smoke.sh                   # both ends of the supported server range
+NC_TAG=33-apache ./smoke.sh  # one specific server version
+SLOW=1 ./smoke.sh            # also the successful resend (adds a 65 s wait)
+KEEP=1 ./smoke.sh            # leave the instance up to look at it
+./setup.sh                   # just an instance, no checks (needs NC_TAG)
+```
+
+The exit code is the number of failed checks. Ports and package can be overridden
+with `HTTP_PORT`, `MAIL_PORT` and `APP_TARBALL`.
+
+## Switching the provider on without a browser
+
+The app keeps the per-user state in Nextcloud's own two-factor registry, so `occ` can
+do it:
+
+```bash
+docker compose exec -T -u www-data nextcloud php occ twofactorauth:enable admin email
+```
+
+`setup.sh` prints this too. Note that the 2.x branch used a user setting of its own
+instead — `occ user:setting … twofactor_email verified true` does nothing here.
+
+## What it checks
+
+Login and challenge, the mail, `challenge/resend` including its cooldown, a wrong and
+then the right code, `admin/save` with its validation path, `admin/reset`,
+`state/save` in both directions with the registry state, every asset the challenge
+page pulls, and the server log.
+
+**Why both server versions by default:** in 3.4.0 the resend endpoint was dead on
+Nextcloud 33 while working on 34. The exemption from the two-factor gate is read from
+the docblock on 33 and from the attribute on 34, and the attribute is `@since 34`. The
+manual browser pass ran on a 34 instance, so nothing looked wrong. One version is not
+a test of a version *range*.
+
+## What it does not check
+
+**Appearance.** Layout, dark mode, translations, whether a dialog is comprehensible.
+That still needs a person with a browser — `KEEP=1` leaves an instance running for it.
+
+## Things that cost hours, written down so they cost you none
+
+- **The request token goes in a header, not in a form field.** It is base64 and often
+  contains a `+`, which PHP turns into a space while decoding a form body. As a form
+  field the same request therefore works about one time in three, which looks like a
+  flaky server rather than a broken client.
+- **`curl` needs an `Origin` header for `POST /login`.** Nextcloud rejects the request
+  before it looks at the password, and answers with a redirect to
+  `?direct=1&user=…` plus a misleading `Logging out` in the log. It looks exactly like
+  a wrong password.
+- **`curl` sends a GET when no `-d` is given**, so a POST-only route answers 405 and
+  it reads like the route is missing.
+- **After a wrong code the redirect target contains the dashboard path**
+  (`/login/selectchallenge?redirect_url=/apps/dashboard/`). Checking the URL for
+  "dashboard" therefore reports a success that never happened — ask the session
+  instead.
+- **`krankerl package` packages the committed state.** An uncommitted fix is not in the
+  package, and the test will keep proving the old behaviour.
+- **The admin password cannot be changed to a weak one afterwards.**
+  `password_policy` is active in the image; it does not apply during installation,
+  which is why `admin/admin` works at all. Throw the instance away instead.

--- a/tests/smoke/README.md
+++ b/tests/smoke/README.md
@@ -24,13 +24,18 @@ Docker with the compose plugin, `python3`, `curl`, and a built package
 cd tests/smoke
 ./smoke.sh                   # both ends of the supported server range
 NC_TAG=33-apache ./smoke.sh  # one specific server version
-SLOW=1 ./smoke.sh            # also the successful resend (adds a 65 s wait)
+SLOW=0 ./smoke.sh            # skip the successful resend, saving 65 s per version
 KEEP=1 ./smoke.sh            # leave the instance up to look at it
 ./setup.sh                   # just an instance, no checks (needs NC_TAG)
 ```
 
 The exit code is the number of failed checks. Ports and package can be overridden
 with `HTTP_PORT`, `MAIL_PORT` and `APP_TARBALL`.
+
+A full run takes about six minutes per server version. Most of the extra time is one
+deliberate 65-second wait: the resend cooldown has to pass before the *successful*
+resend can be checked, and a rejected resend only proves half of that route. `SLOW=0`
+drops it when you are iterating.
 
 ## Switching the provider on without a browser
 

--- a/tests/smoke/compose.yaml
+++ b/tests/smoke/compose.yaml
@@ -25,7 +25,12 @@ services:
       - "${APP_DIR:?set APP_DIR}:/var/www/html/custom_apps/twofactor_email:ro"
 
   mailpit:
-    image: axllent/mailpit
+    # Pinned by digest: an unpinned mail catcher can fail a run for reasons that have
+    # nothing to do with the app. The Nextcloud image above is deliberately NOT pinned —
+    # 33-apache/34-apache are meant to move, that is what is under test. To update, pull
+    # the tag and
+    # read `docker image inspect axllent/mailpit --format '{{index .RepoDigests 0}}'`.
+    image: axllent/mailpit@sha256:b868afa176bfd6cce2323ea316cd99ccad77915e51e595748f6d786700ecf109
     ports:
       - "${MAIL_PORT:-8025}:8025"
 

--- a/tests/smoke/compose.yaml
+++ b/tests/smoke/compose.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# A disposable Nextcloud for testing the built app against one server version.
+# Driven by setup.sh and smoke.sh — see README.md.
+#
+# SQLite is enough for functional tests, and a mail catcher is required: without
+# SMTP the challenge email never arrives, so the login flow cannot be tested.
+
+services:
+  nextcloud:
+    image: "nextcloud:${NC_TAG:?set NC_TAG, e.g. 34-apache}"
+    ports:
+      - "${HTTP_PORT:-8080}:80"
+    environment:
+      # The official image installs itself when these are present.
+      SQLITE_DATABASE: nextcloud
+      NEXTCLOUD_ADMIN_USER: admin
+      NEXTCLOUD_ADMIN_PASSWORD: admin
+      NEXTCLOUD_TRUSTED_DOMAINS: localhost
+    volumes:
+      - nc-data:/var/www/html
+      # The built package, not the working tree — this tests what gets shipped.
+      # Read-only so the container cannot modify the build under test.
+      - "${APP_DIR:?set APP_DIR}:/var/www/html/custom_apps/twofactor_email:ro"
+
+  mailpit:
+    image: axllent/mailpit
+    ports:
+      - "${MAIL_PORT:-8025}:8025"
+
+volumes:
+  nc-data:

--- a/tests/smoke/setup.sh
+++ b/tests/smoke/setup.sh
@@ -26,18 +26,25 @@ docker info >/dev/null 2>&1 || {
 	exit 1
 }
 
-[ -f "$APP_TARBALL" ] || {
-	echo "No package at $APP_TARBALL — run 'krankerl package' first." >&2
-	exit 1
-}
-
-# Always unpack afresh, otherwise a second run silently tests the previous build.
-# Note that krankerl packages the committed state, so an uncommitted fix is not in
-# here — a mistake that is easy to make and hard to see.
-rm -rf app
-mkdir -p app
-tar xzf "$APP_TARBALL" -C app
-export APP_DIR="$PWD/app/twofactor_email"
+if [ -n "${APP_DIR:-}" ]; then
+	# The caller pointed us at a directory: mount it as it is. This is the way in
+	# without krankerl, and the way to see your working tree in a real server.
+	echo "using the directory as it is: $APP_DIR"
+	export APP_DIR
+else
+	[ -f "$APP_TARBALL" ] || {
+		echo "No package at $APP_TARBALL — run 'krankerl package', or point APP_DIR at a" >&2
+		echo "directory to mount instead." >&2
+		exit 1
+	}
+	# Always unpack afresh, otherwise a second run silently tests the previous build.
+	# Note that krankerl packages the committed state, so an uncommitted fix is not in
+	# here — a mistake that is easy to make and hard to see.
+	rm -rf app
+	mkdir -p app
+	tar xzf "$APP_TARBALL" -C app
+	export APP_DIR="$PWD/app/twofactor_email"
+fi
 
 docker compose up -d --quiet-pull
 

--- a/tests/smoke/setup.sh
+++ b/tests/smoke/setup.sh
@@ -5,11 +5,24 @@
 # Bring up a disposable Nextcloud with the built app installed and ready to test.
 # Use this when you want to click around; use smoke.sh to run the checks.
 #
-#   NC_TAG=34-apache ./setup.sh
-#   NC_TAG=33-apache APP_TARBALL=/path/to/twofactor_email.tar.gz ./setup.sh
+#   NC_TAG=34-apache ./setup.sh                       # unpack the built package
+#   UNPACK=0 APP_DIR=/path/to/app ./setup.sh          # mount a directory as it is
 #
-# Removing it again:  NC_TAG=34-apache docker compose down -v
+# Removing it again:  docker compose down -v
+# (This works with an empty environment because setup.sh writes the values compose needs
+# into tests/smoke/.env, which compose reads for every subcommand.)
 set -euo pipefail
+
+# An APP_DIR from the caller is relative to the CALLER's directory, so it has to be made
+# absolute before the cd below changes what it means — and compose needs an absolute path
+# for a bind mount anyway.
+if [ -n "${APP_DIR:-}" ]; then
+	app_dir_abs=$(cd "$APP_DIR" 2>/dev/null && pwd) || {
+		echo "APP_DIR is not a directory: $APP_DIR" >&2
+		exit 1
+	}
+	APP_DIR=$app_dir_abs
+fi
 cd "$(dirname "$0")"
 
 : "${NC_TAG:?set NC_TAG, e.g. 34-apache}"
@@ -17,7 +30,16 @@ cd "$(dirname "$0")"
 : "${APP_TARBALL:=$ROOT/build/artifacts/twofactor_email.tar.gz}"
 : "${HTTP_PORT:=8080}"
 : "${MAIL_PORT:=8025}"
-export NC_TAG HTTP_PORT MAIL_PORT
+# Whether to extract the package into APP_DIR. A caller who names a directory means
+# "mount this", so that flips the default — but the value stays explicit and overridable,
+# which is what matters: smoke.sh always states it, and guessing the mode from the path
+# alone is what once made this script mount a directory that had just been deleted.
+if [ -n "${APP_DIR:-}" ]; then : "${UNPACK:=0}"; else : "${UNPACK:=1}"; fi
+: "${APP_DIR:=$PWD/app/twofactor_email}"
+# The project name is set rather than derived, so the "already running" check in
+# smoke.sh can filter by it instead of reproducing compose's naming rules.
+: "${COMPOSE_PROJECT_NAME:=tfe-smoke}"
+export COMPOSE_PROJECT_NAME
 
 docker info >/dev/null 2>&1 || {
 	echo "The Docker daemon is not reachable." >&2
@@ -26,15 +48,10 @@ docker info >/dev/null 2>&1 || {
 	exit 1
 }
 
-if [ -n "${APP_DIR:-}" ]; then
-	# The caller pointed us at a directory: mount it as it is. This is the way in
-	# without krankerl, and the way to see your working tree in a real server.
-	echo "using the directory as it is: $APP_DIR"
-	export APP_DIR
-else
+if [ "$UNPACK" = 1 ]; then
 	[ -f "$APP_TARBALL" ] || {
-		echo "No package at $APP_TARBALL — run 'krankerl package', or point APP_DIR at a" >&2
-		echo "directory to mount instead." >&2
+		echo "No package at $APP_TARBALL — run 'krankerl package', or mount a directory" >&2
+		echo "instead: UNPACK=0 APP_DIR=<path> $0" >&2
 		exit 1
 	}
 	# Always unpack afresh, otherwise a second run silently tests the previous build.
@@ -43,8 +60,20 @@ else
 	rm -rf app
 	mkdir -p app
 	tar xzf "$APP_TARBALL" -C app
-	export APP_DIR="$PWD/app/twofactor_email"
+else
+	echo "mounting the directory as it is: $APP_DIR"
 fi
+
+# Everything compose needs, in the file compose reads by itself. That is what makes a
+# later `docker compose down -v` (or logs, ps, exec) work from this directory with an
+# empty environment — for the scripts and for a human. Before this existed, every
+# invocation had to carry NC_TAG and APP_DIR, and a teardown that forgot them failed
+# silently and left the data volume behind.
+# COMPOSE_PROJECT_NAME belongs in here too: without it a bare `docker compose` in this
+# directory derives the project from the directory name and quietly targets a different
+# project than the one that is up — it then removes nothing and says nothing.
+printf 'COMPOSE_PROJECT_NAME=%s\nNC_TAG=%s\nAPP_DIR=%s\nHTTP_PORT=%s\nMAIL_PORT=%s\n' \
+	"$COMPOSE_PROJECT_NAME" "$NC_TAG" "$APP_DIR" "$HTTP_PORT" "$MAIL_PORT" > .env
 
 docker compose up -d --quiet-pull
 
@@ -78,5 +107,7 @@ Switch the provider on for the user without opening the browser:
   docker compose exec -T -u www-data nextcloud php occ twofactorauth:enable admin email
 
 Then log in: the code is waiting in the mailbox.
-Remove everything again:  NC_TAG=$NC_TAG docker compose down -v
+Remove everything again:  COMPOSE_PROJECT_NAME=$COMPOSE_PROJECT_NAME docker compose down -v
+(The project is named explicitly because .env holds the values of the LAST setup run —
+with a second instance around, a bare 'down' could remove the wrong one.)
 TXT

--- a/tests/smoke/setup.sh
+++ b/tests/smoke/setup.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Bring up a disposable Nextcloud with the built app installed and ready to test.
+# Use this when you want to click around; use smoke.sh to run the checks.
+#
+#   NC_TAG=34-apache ./setup.sh
+#   NC_TAG=33-apache APP_TARBALL=/path/to/twofactor_email.tar.gz ./setup.sh
+#
+# Removing it again:  NC_TAG=34-apache docker compose down -v
+set -euo pipefail
+cd "$(dirname "$0")"
+
+: "${NC_TAG:?set NC_TAG, e.g. 34-apache}"
+: "${ROOT:=$(git rev-parse --show-toplevel)}"
+: "${APP_TARBALL:=$ROOT/build/artifacts/twofactor_email.tar.gz}"
+: "${HTTP_PORT:=8080}"
+: "${MAIL_PORT:=8025}"
+export NC_TAG HTTP_PORT MAIL_PORT
+
+docker info >/dev/null 2>&1 || {
+	echo "The Docker daemon is not reachable." >&2
+	echo "After a kernel update without a reboot it refuses to start: the modules of" >&2
+	echo "the running kernel are gone, so overlayfs cannot be loaded. Reboot." >&2
+	exit 1
+}
+
+[ -f "$APP_TARBALL" ] || {
+	echo "No package at $APP_TARBALL — run 'krankerl package' first." >&2
+	exit 1
+}
+
+# Always unpack afresh, otherwise a second run silently tests the previous build.
+# Note that krankerl packages the committed state, so an uncommitted fix is not in
+# here — a mistake that is easy to make and hard to see.
+rm -rf app
+mkdir -p app
+tar xzf "$APP_TARBALL" -C app
+export APP_DIR="$PWD/app/twofactor_email"
+
+docker compose up -d --quiet-pull
+
+occ() { docker compose exec -T -u www-data nextcloud php occ --no-ansi "$@"; }
+
+printf 'waiting for the installation to finish '
+for _ in $(seq 1 60); do
+	if occ status 2>/dev/null | grep -q 'installed: true'; then echo ' done'; break; fi
+	printf '.'
+	sleep 5
+done
+occ status | sed 's/^/  /'
+
+# Point Nextcloud at the mail catcher and give the admin an address: without one the
+# provider cannot be switched on.
+occ config:system:set mail_smtpmode --value=smtp >/dev/null
+occ config:system:set mail_smtphost --value=mailpit >/dev/null
+occ config:system:set mail_smtpport --value=1025 >/dev/null
+occ config:system:set mail_from_address --value=nextcloud >/dev/null
+occ config:system:set mail_domain --value=example.org >/dev/null
+occ user:setting admin settings email admin@example.org
+
+occ app:enable twofactor_email | sed 's/^/  /'
+
+cat <<TXT
+
+Nextcloud   http://localhost:$HTTP_PORT   (admin / admin)
+Mailbox     http://localhost:$MAIL_PORT
+
+Switch the provider on for the user without opening the browser:
+  docker compose exec -T -u www-data nextcloud php occ twofactorauth:enable admin email
+
+Then log in: the code is waiting in the mailbox.
+Remove everything again:  NC_TAG=$NC_TAG docker compose down -v
+TXT

--- a/tests/smoke/smoke.sh
+++ b/tests/smoke/smoke.sh
@@ -15,6 +15,8 @@
 #   NC_TAG=33-apache ./smoke.sh  # one specific server version
 #   SLOW=0 ./smoke.sh            # skip the successful resend, saving 65 s per version
 #   KEEP=1 ./smoke.sh            # leave the instance running afterwards
+#   BUILD=1 ./smoke.sh           # build the package first (needs krankerl)
+#   APP_DIR=$(git rev-parse --show-toplevel) ./smoke.sh   # test a directory, no krankerl
 #
 # Exit code: number of failed checks, so CI can gate on it.
 #
@@ -31,6 +33,10 @@ cd "$(dirname "$0")"
 : "${MAIL_PORT:=8025}"
 # On by default: the successful resend is the half of that route which a cooldown
 # rejection cannot prove, and 65 s per version is a fair price for it.
+: "${BUILD:=0}"
+# An APP_DIR from the caller means "mount this directory as it is". Then there is no
+# package, so the version comparison has nothing to compare and is skipped.
+if [ -n "${APP_DIR:-}" ]; then PACKAGED=0; else PACKAGED=1; fi
 : "${SLOW:=1}"
 : "${KEEP:=0}"
 BASE="http://localhost:$HTTP_PORT"
@@ -97,9 +103,13 @@ run_checks() {
 
 	echo "-- version"
 	local want got
-	want=$(tar xzOf "$APP_TARBALL" twofactor_email/appinfo/info.xml | grep -oP '<version>\K[^<]+')
-	got=$(occ app:list | grep -A1 '^  - twofactor_email' | grep -oP 'twofactor_email: \K.*' | tr -d ' \r')
-	is "installed version matches the package" "$got" "$want"
+	if [ "$PACKAGED" = 1 ]; then
+		want=$(tar xzOf "$APP_TARBALL" twofactor_email/appinfo/info.xml | grep -oP '<version>\K[^<]+')
+		got=$(occ app:list | grep -A1 '^  - twofactor_email' | grep -oP 'twofactor_email: \K.*' | tr -d ' \r')
+		is "installed version matches the package" "$got" "$want"
+	else
+		note "version not compared — a directory is mounted, there is no package"
+	fi
 
 	# The app keeps this state in Nextcloud's own two-factor registry, so occ can set
 	# it. (The 2.x branch used a user setting of its own — not interchangeable.)
@@ -235,14 +245,97 @@ else
 	if [ "$min" = "$max" ]; then TAGS=("$min-apache"); else TAGS=("$min-apache" "$max-apache"); fi
 fi
 
-echo "package: $APP_TARBALL"
+# Refuse to test a package that cannot contain the current work. krankerl packages the
+# COMMITTED state, so a stale package and uncommitted changes both mean "you are testing
+# something else" — and that has happened here: a smoke test once passed against a
+# package built before the change it was meant to prove.
+preflight_package() {
+	if [ "$BUILD" = 1 ]; then
+		command -v krankerl >/dev/null || {
+			echo "BUILD=1 needs krankerl in PATH." >&2
+			echo "  APP_DIR=$ROOT $0     # or test the working tree instead" >&2
+			exit 1
+		}
+		( cd "$ROOT" && krankerl package ) || exit 1
+	fi
+
+	local paths='lib src templates appinfo css js composer.json package.json'
+	if [ ! -f "$APP_TARBALL" ]; then
+		echo "No package at $APP_TARBALL. Pick one:"
+		echo "  krankerl package     — build it, then run again"
+		echo "  BUILD=1 $0"
+		echo "  APP_DIR=$ROOT $0"
+		exit 1
+	fi
+
+	local dirty source_ts package_ts
+	# shellcheck disable=SC2086
+	dirty=$(git -C "$ROOT" status --porcelain -- $paths)
+	# The last commit that touched the app itself — a docs-only commit must not make a
+	# perfectly good package look stale.
+	# shellcheck disable=SC2086
+	source_ts=$(git -C "$ROOT" log -1 --format=%ct -- $paths)
+	package_ts=$(stat -c %Y "$APP_TARBALL")
+	if [ -n "$dirty" ] || [ "$package_ts" -lt "$source_ts" ]; then
+		echo "The package does not match the current state of the app:"
+		printf '  package %s\n' "$(date -d "@$package_ts" '+%F %T')"
+		printf '  sources %s (last commit touching the app)\n' "$(date -d "@$source_ts" '+%F %T')"
+		if [ -n "$dirty" ]; then
+			echo "  uncommitted:"
+			printf '%s\n' "$dirty" | sed 's/^/    /'
+		fi
+		cat <<TXT
+
+krankerl packages the committed state, so the above is not in the package. Pick one:
+
+  krankerl package
+      rebuild, then run again
+  BUILD=1 $0
+      build and run in one go
+  APP_DIR=$ROOT $0
+      test the working tree instead of the package
+TXT
+		exit 1
+	fi
+}
+
+# Never take over an instance that is already up: compose would recreate the container
+# of whoever is using it. This happened — a test run recreated a colleague's manual
+# instance because both used the same project name and ports.
+# Asked via the compose project LABEL, not via `docker compose ps`: the latter has to
+# interpolate compose.yaml first, and compose.yaml requires APP_DIR — so without it the
+# command fails, the error goes to /dev/null and the count silently becomes zero. A
+# check that cannot fail loudly is not a check.
+project=${COMPOSE_PROJECT_NAME:-$(basename "$PWD")}
+running=$(docker ps --quiet --filter "label=com.docker.compose.project=$project" | wc -l)
+if [ "$running" != 0 ]; then
+	cat >&2 <<TXT
+An instance of this project is already running ($running container(s)).
+Starting now would recreate it and pull it away from whoever is using it.
+
+  docker compose down -v                       stop and remove it, then run again
+  COMPOSE_PROJECT_NAME=tfe-2 HTTP_PORT=8081 MAIL_PORT=8026 $0
+                                               run a second, independent instance
+TXT
+	exit 1
+fi
+
+if [ "$PACKAGED" = 1 ]; then
+	preflight_package
+	echo "package: $APP_TARBALL"
+else
+	echo "directory: $APP_DIR  (mounted as it is, not a package)"
+fi
 echo "servers: ${TAGS[*]}"
 
 # compose needs these in the environment of EVERY call, not just of setup.sh —
 # otherwise `docker compose exec` fails, every occ call comes back empty and the run
 # reports a dozen misleading failures instead of one clear one.
 export APP_TARBALL HTTP_PORT MAIL_PORT ROOT
-export APP_DIR="$PWD/app/twofactor_email"
+# In packaged mode APP_DIR must stay UNSET here: setup.sh unpacks the tarball and sets
+# it. Exporting it beforehand made setup.sh take the "mount a directory" branch and
+# hand compose a path that did not exist yet, so the container never started.
+if [ "$PACKAGED" = 1 ]; then unset APP_DIR; else export APP_DIR; fi
 
 for tag in "${TAGS[@]}"; do
 	echo
@@ -256,6 +349,8 @@ for tag in "${TAGS[@]}"; do
 		rm -rf app
 		continue
 	fi
+	# setup.sh unpacked it; our own compose calls need the same value.
+	[ "$PACKAGED" = 1 ] && export APP_DIR="$PWD/app/twofactor_email"
 	grep -E 'versionstring|twofactor_email' "$TMP/setup.log" | sed 's/^/  /'
 
 	# Fail fast and loudly: if occ does not answer, every following check would fail

--- a/tests/smoke/smoke.sh
+++ b/tests/smoke/smoke.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Everything about the app that can be checked without eyes: routes, status codes,
+# the mail, and a full login with the code from it. Runs against a disposable
+# Nextcloud built from the packaged app.
+#
+# By default it tests BOTH ends of the supported server range, taken from
+# appinfo/info.xml. That is not thoroughness for its own sake: a route that was
+# exempt from the two-factor gate on the newest server only, and dead on the oldest,
+# shipped in 3.4.0 and was found exactly this way.
+#
+#   ./smoke.sh                   # min and max supported Nextcloud version
+#   NC_TAG=33-apache ./smoke.sh  # one specific server version
+#   SLOW=1 ./smoke.sh            # also check the successful resend (waits 65 s)
+#   KEEP=1 ./smoke.sh            # leave the instance running afterwards
+#
+# Exit code: number of failed checks, so CI can gate on it.
+#
+# Not covered, and deliberately so: how it looks. Layout, dark mode and translations
+# still need a pair of eyes.
+set -uo pipefail
+cd "$(dirname "$0")"
+
+# ROOT can be set to run these scripts from outside a checkout (used while developing
+# them); inside the repository the default is right.
+: "${ROOT:=$(git rev-parse --show-toplevel)}"
+: "${APP_TARBALL:=$ROOT/build/artifacts/twofactor_email.tar.gz}"
+: "${HTTP_PORT:=8080}"
+: "${MAIL_PORT:=8025}"
+: "${SLOW:=0}"
+: "${KEEP:=0}"
+BASE="http://localhost:$HTTP_PORT"
+MAILBOX="http://localhost:$MAIL_PORT"
+PW=admin
+
+pass=0
+fail=0
+skip=0
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+green() { printf '\033[32mpass\033[0m'; }
+red() { printf '\033[31mFAIL\033[0m'; }
+ok() { printf '  %s %s\n' "$(green)" "$1"; pass=$((pass + 1)); }
+bad() { printf '  %s %s\n' "$(red)" "$1"; fail=$((fail + 1)); }
+note() { printf '  \033[33mskip\033[0m %s\n' "$1"; skip=$((skip + 1)); }
+is() { [ "$2" = "$3" ] && ok "$1 ($2)" || bad "$1: got $2, expected $3"; }
+body_has() { grep -q -- "$2" "$TMP/body" && ok "$1" || bad "$1: '$2' not in the response"; }
+
+occ() { docker compose exec -T -u www-data nextcloud php occ --no-ansi "$@" 2>&1; }
+tfa_enabled() { occ twofactorauth:state admin | grep -q '^Two-factor authentication is enabled'; }
+
+# The request token is in every rendered page.
+page_token() { curl -s -b "$TMP/jar" -c "$TMP/jar" "$1" | grep -oP 'data-requesttoken="\K[^"]+' | head -1; }
+
+# Response body goes to $TMP/body, the status code is returned.
+#
+# Two things here are not optional, and both cost hours to find:
+#   * The token goes in a HEADER. It is base64 and often contains a '+', which PHP
+#     turns into a space while decoding a form body — so as a form field the same
+#     command works about one time in three.
+#   * -X POST, because without -d curl would send a GET and the route answers 405.
+# Origin is required too: Nextcloud rejects a POST without a trusted Origin before it
+# ever looks at the credentials.
+post() {
+	local url=$1 tok=$2
+	shift 2
+	local args=() kv
+	for kv in "$@"; do args+=(-d "$kv"); done
+	curl -s -X POST -b "$TMP/jar" -c "$TMP/jar" \
+		-H "Origin: $BASE" -H "requesttoken: $tok" \
+		-o "$TMP/body" -w '%{http_code}' "${args[@]}" "$url"
+}
+
+mails() { curl -s "$MAILBOX/api/v1/messages?limit=20"; }
+mail_count() { mails | python3 -c 'import json,sys; print(json.load(sys.stdin).get("messages_count", 0))'; }
+newest_code() {
+	local id
+	id=$(mails | python3 -c 'import json,sys; m=json.load(sys.stdin)["messages"]; print(m[0]["ID"] if m else "")')
+	[ -n "$id" ] || return 1
+	curl -s "$MAILBOX/api/v1/message/$id" | python3 -c '
+import json, re, sys
+text = json.load(sys.stdin).get("Text", "")
+found = re.findall(r"\b[0-9]{4,16}\b", text)
+print(found[0] if found else "")'
+}
+
+run_checks() {
+	rm -f "$TMP/jar"
+
+	echo "-- version"
+	local want got
+	want=$(tar xzOf "$APP_TARBALL" twofactor_email/appinfo/info.xml | grep -oP '<version>\K[^<]+')
+	got=$(occ app:list | grep -A1 '^  - twofactor_email' | grep -oP 'twofactor_email: \K.*' | tr -d ' \r')
+	is "installed version matches the package" "$got" "$want"
+
+	# The app keeps this state in Nextcloud's own two-factor registry, so occ can set
+	# it. (The 2.x branch used a user setting of its own — not interchangeable.)
+	occ twofactorauth:enable admin email >/dev/null
+	tfa_enabled && ok "provider switched on for the user" || bad "provider not registered as enabled"
+
+	echo "-- login and challenge"
+	local tok redirect status
+	tok=$(page_token "$BASE/login")
+	[ -n "$tok" ] && ok "got a request token from /login" || bad "no request token on /login"
+	redirect=$(curl -s -b "$TMP/jar" -c "$TMP/jar" -H "Origin: $BASE" -H "requesttoken: $tok" \
+		-o /dev/null -w '%{redirect_url}' \
+		-d "user=admin" -d "password=$PW" -d "timezone=Europe/Berlin" "$BASE/login")
+	is "login leads to the email challenge" "${redirect#$BASE}" "/login/challenge/email"
+
+	status=$(curl -s -b "$TMP/jar" -c "$TMP/jar" -o "$TMP/challenge.html" -w '%{http_code}' \
+		"$BASE/login/challenge/email")
+	is "challenge page" "$status" "200"
+	grep -q twofactor_email "$TMP/challenge.html" \
+		&& ok "challenge page loads the app assets" || bad "challenge page has no app assets"
+	is "exactly one mail was sent" "$(mail_count)" "1"
+
+	echo "-- challenge/resend"
+	local ctok
+	ctok=$(grep -oP 'data-requesttoken="\K[^"]+' "$TMP/challenge.html" | head -1)
+	# What matters is not "rejected" but that the CONTROLLER answers. 429 with
+	# too-soon comes from the app; a 303 would mean the two-factor gate blocked the
+	# request before it got there — which is exactly how this route was broken on the
+	# oldest supported server.
+	status=$(post "$BASE/apps/twofactor_email/challenge/resend" "$ctok")
+	is "resend reaches the controller (not a redirect)" "$status" "429"
+	body_has "cooldown reported as too-soon" '"error":"too-soon"'
+	body_has "response names retryAfter" 'retryAfter'
+
+	if [ "$SLOW" = 1 ]; then
+		echo "     waiting 65 s for the cooldown to pass"
+		sleep 65
+		status=$(post "$BASE/apps/twofactor_email/challenge/resend" "$ctok")
+		is "resend after the cooldown" "$status" "200"
+		body_has "response reports the mail was sent" '"status":"sent"'
+		is "a second mail arrived" "$(mail_count)" "2"
+	else
+		note "successful resend not checked (SLOW=1 adds the wait)"
+	fi
+
+	echo "-- submitting the code"
+	local code wrong ocs
+	code=$(newest_code)
+	[ -n "$code" ] && ok "read the code from the mail ($code)" || bad "no code in the mail"
+	wrong=$(printf '%0*d' "${#code}" 0)
+	post "$BASE/login/challenge/email" "$ctok" "challenge=$wrong" >/dev/null
+	# Ask the session, not the URL: the redirect target is
+	# /login/selectchallenge?redirect_url=/apps/dashboard/ — it CONTAINS the dashboard
+	# path without being logged in, which makes a naive URL check pass wrongly.
+	ocs=$(curl -s -b "$TMP/jar" -c "$TMP/jar" -H 'OCS-APIRequest: true' -o /dev/null \
+		-w '%{http_code}' "$BASE/ocs/v2.php/cloud/user?format=json")
+	[ "$ocs" = "200" ] && bad "a wrong code was accepted" \
+		|| ok "a wrong code does not log the user in (OCS $ocs)"
+
+	ctok=$(page_token "$BASE/login/challenge/email")
+	redirect=$(curl -s -b "$TMP/jar" -c "$TMP/jar" -H "Origin: $BASE" -H "requesttoken: $ctok" \
+		-o /dev/null -w '%{redirect_url}' -d "challenge=$code" "$BASE/login/challenge/email")
+	is "the right code leads to the dashboard" "${redirect#$BASE}" "/apps/dashboard/"
+	status=$(curl -s -b "$TMP/jar" -c "$TMP/jar" -H 'OCS-APIRequest: true' -o "$TMP/body" \
+		-w '%{http_code}' "$BASE/ocs/v2.php/cloud/user?format=json")
+	is "session is logged in (OCS)" "$status" "200"
+
+	echo "-- admin routes"
+	local atok
+	atok=$(page_token "$BASE/settings/admin/security")
+	status=$(post "$BASE/apps/twofactor_email/admin/save" "$atok" \
+		"codeLength=99" "codeValidMinutes=10" "eMailTemplate=x" "eMailSubject=x" "resendMinutes=1")
+	is "admin/save rejects invalid values" "$status" "400"
+	body_has "response carries the error list" '"errors"'
+	status=$(post "$BASE/apps/twofactor_email/admin/save" "$atok" \
+		"codeLength=8" "codeValidMinutes=20" "eMailTemplate=Code: {code}" "eMailSubject=Test" "resendMinutes=2")
+	is "admin/save stores valid values" "$status" "200"
+	body_has "the stored code length comes back" '"codeLength":8'
+	status=$(post "$BASE/apps/twofactor_email/admin/reset" "$atok")
+	is "admin/reset" "$status" "200"
+	body_has "reset restores the defaults" '"codeLength":6'
+
+	echo "-- state/save"
+	# No 403 to expect here: Nextcloud counts the login that just happened as the
+	# password confirmation for 30 minutes. A 403 would only show up on an older
+	# session, which a smoke test cannot sensibly wait for.
+	local stok
+	stok=$(page_token "$BASE/settings/user/security")
+	status=$(post "$BASE/apps/twofactor_email/state/save" "$stok" "state=false")
+	is "state/save switches the provider off" "$status" "200"
+	tfa_enabled && bad "registry still reports it as enabled" || ok "registry reports it as off"
+	status=$(post "$BASE/apps/twofactor_email/state/save" "$stok" "state=true")
+	is "state/save switches it on again" "$status" "200"
+	tfa_enabled && ok "registry reports it as enabled" || bad "registry still reports it as off"
+
+	echo "-- assets"
+	local broken=0 count=0 url code_
+	while read -r url; do
+		[ -n "$url" ] || continue
+		count=$((count + 1))
+		code_=$(curl -s -b "$TMP/jar" -c "$TMP/jar" -o /dev/null -w '%{http_code}' "$BASE$url")
+		[ "$code_" = "200" ] || { bad "asset $url -> $code_"; broken=$((broken + 1)); }
+	done < <(grep -oP '(src|href)="\K/(dist|apps/twofactor_email)[^"]+' "$TMP/challenge.html" \
+		| sed 's/&amp;/\&/g' | sort -u)
+	[ "$broken" = 0 ] && ok "all $count assets of the challenge page were served"
+
+	echo "-- server log"
+	if docker compose exec -T nextcloud sh -c 'cat /var/www/html/data/nextcloud.log' 2>/dev/null \
+		| grep twofactor_email | grep -qE '"level":[34]'; then
+		bad "the app logged an error:"
+		docker compose exec -T nextcloud sh -c 'cat /var/www/html/data/nextcloud.log' 2>/dev/null \
+			| grep twofactor_email | grep -E '"level":[34]' | head -3 | cut -c1-160 | sed 's/^/       /'
+	else
+		ok "no app errors in the server log"
+	fi
+}
+
+# Which server versions? Default: both ends of the declared range, because that is
+# where the differences bite.
+if [ -n "${NC_TAG:-}" ]; then
+	TAGS=("$NC_TAG")
+else
+	spec=$(grep -oP '<nextcloud[^>]*' "$ROOT/appinfo/info.xml")
+	min=$(printf '%s' "$spec" | grep -oP 'min-version="\K[0-9]+')
+	max=$(printf '%s' "$spec" | grep -oP 'max-version="\K[0-9]+')
+	if [ "$min" = "$max" ]; then TAGS=("$min-apache"); else TAGS=("$min-apache" "$max-apache"); fi
+fi
+
+echo "package: $APP_TARBALL"
+echo "servers: ${TAGS[*]}"
+
+# compose needs these in the environment of EVERY call, not just of setup.sh —
+# otherwise `docker compose exec` fails, every occ call comes back empty and the run
+# reports a dozen misleading failures instead of one clear one.
+export APP_TARBALL HTTP_PORT MAIL_PORT ROOT
+export APP_DIR="$PWD/app/twofactor_email"
+
+for tag in "${TAGS[@]}"; do
+	echo
+	echo "=========== Nextcloud $tag ==========="
+	export NC_TAG="$tag"
+	if ! ./setup.sh >"$TMP/setup.log" 2>&1; then
+		echo "  setup failed:"
+		tail -15 "$TMP/setup.log" | sed 's/^/    /'
+		fail=$((fail + 1))
+		docker compose down -v >/dev/null 2>&1
+		rm -rf app
+		continue
+	fi
+	grep -E 'versionstring|twofactor_email' "$TMP/setup.log" | sed 's/^/  /'
+
+	# Fail fast and loudly: if occ does not answer, every following check would fail
+	# for the same reason and bury it.
+	if ! occ status | grep -q 'installed: true'; then
+		echo "  occ does not answer on this instance — skipping the checks:"
+		occ status 2>&1 | head -5 | sed 's/^/    /'
+		fail=$((fail + 1))
+		docker compose down -v >/dev/null 2>&1
+		rm -rf app
+		continue
+	fi
+
+	run_checks
+	if [ "$KEEP" = 1 ]; then
+		echo "  instance left running: $BASE (admin/$PW) · $MAILBOX"
+		break
+	fi
+	docker compose down -v >/dev/null 2>&1
+	rm -rf app
+done
+
+echo
+printf 'passed: %d   failed: %d   skipped: %d\n' "$pass" "$fail" "$skip"
+echo 'Not covered: appearance, dark mode, translations — use a browser for those.'
+exit "$fail"

--- a/tests/smoke/smoke.sh
+++ b/tests/smoke/smoke.sh
@@ -13,7 +13,7 @@
 #
 #   ./smoke.sh                   # min and max supported Nextcloud version
 #   NC_TAG=33-apache ./smoke.sh  # one specific server version
-#   SLOW=1 ./smoke.sh            # also check the successful resend (waits 65 s)
+#   SLOW=0 ./smoke.sh            # skip the successful resend, saving 65 s per version
 #   KEEP=1 ./smoke.sh            # leave the instance running afterwards
 #
 # Exit code: number of failed checks, so CI can gate on it.
@@ -29,7 +29,9 @@ cd "$(dirname "$0")"
 : "${APP_TARBALL:=$ROOT/build/artifacts/twofactor_email.tar.gz}"
 : "${HTTP_PORT:=8080}"
 : "${MAIL_PORT:=8025}"
-: "${SLOW:=0}"
+# On by default: the successful resend is the half of that route which a cooldown
+# rejection cannot prove, and 65 s per version is a fair price for it.
+: "${SLOW:=1}"
 : "${KEEP:=0}"
 BASE="http://localhost:$HTTP_PORT"
 MAILBOX="http://localhost:$MAIL_PORT"
@@ -137,7 +139,7 @@ run_checks() {
 		body_has "response reports the mail was sent" '"status":"sent"'
 		is "a second mail arrived" "$(mail_count)" "2"
 	else
-		note "successful resend not checked (SLOW=1 adds the wait)"
+		note "successful resend not checked (SLOW=0 was set)"
 	fi
 
 	echo "-- submitting the code"

--- a/tests/smoke/smoke.sh
+++ b/tests/smoke/smoke.sh
@@ -15,14 +15,25 @@
 #   NC_TAG=33-apache ./smoke.sh  # one specific server version
 #   SLOW=0 ./smoke.sh            # skip the successful resend, saving 65 s per version
 #   KEEP=1 ./smoke.sh            # leave the instance running afterwards
-#   BUILD=1 ./smoke.sh           # build the package first (needs krankerl)
 #   APP_DIR=$(git rev-parse --show-toplevel) ./smoke.sh   # test a directory, no krankerl
+#   COMPOSE_PROJECT_NAME=tfe-2 HTTP_PORT=8081 MAIL_PORT=8026 ./smoke.sh   # second instance
 #
 # Exit code: number of failed checks, so CI can gate on it.
 #
 # Not covered, and deliberately so: how it looks. Layout, dark mode and translations
 # still need a pair of eyes.
 set -uo pipefail
+
+# An APP_DIR from the caller is relative to the CALLER's directory, so it has to be made
+# absolute before the cd below changes what it means — and compose needs an absolute path
+# for a bind mount anyway.
+if [ -n "${APP_DIR:-}" ]; then
+	app_dir_abs=$(cd "$APP_DIR" 2>/dev/null && pwd) || {
+		echo "APP_DIR is not a directory: $APP_DIR" >&2
+		exit 1
+	}
+	APP_DIR=$app_dir_abs
+fi
 cd "$(dirname "$0")"
 
 # ROOT can be set to run these scripts from outside a checkout (used while developing
@@ -31,12 +42,24 @@ cd "$(dirname "$0")"
 : "${APP_TARBALL:=$ROOT/build/artifacts/twofactor_email.tar.gz}"
 : "${HTTP_PORT:=8080}"
 : "${MAIL_PORT:=8025}"
+# An APP_DIR from the caller means "mount this directory as it is": then there is no
+# package, so the version comparison has nothing to compare. Decided once here and never
+# changed again — setup.sh gets the mode as an explicit UNPACK value rather than
+# inferring it from a path, and our own compose calls read tests/smoke/.env.
+if [ -n "${APP_DIR:-}" ]; then
+	PACKAGED=0
+	export APP_DIR UNPACK=0
+else
+	PACKAGED=1
+	# Exported explicitly, not left to whatever the caller happens to have in the
+	# environment: UNPACK=0 without APP_DIR would make setup.sh mount the default path
+	# right after teardown deleted it.
+	export UNPACK=1
+fi
+: "${COMPOSE_PROJECT_NAME:=tfe-smoke}"
+export COMPOSE_PROJECT_NAME
 # On by default: the successful resend is the half of that route which a cooldown
 # rejection cannot prove, and 65 s per version is a fair price for it.
-: "${BUILD:=0}"
-# An APP_DIR from the caller means "mount this directory as it is". Then there is no
-# package, so the version comparison has nothing to compare and is skipped.
-if [ -n "${APP_DIR:-}" ]; then PACKAGED=0; else PACKAGED=1; fi
 : "${SLOW:=1}"
 : "${KEEP:=0}"
 BASE="http://localhost:$HTTP_PORT"
@@ -49,10 +72,8 @@ skip=0
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 
-green() { printf '\033[32mpass\033[0m'; }
-red() { printf '\033[31mFAIL\033[0m'; }
-ok() { printf '  %s %s\n' "$(green)" "$1"; pass=$((pass + 1)); }
-bad() { printf '  %s %s\n' "$(red)" "$1"; fail=$((fail + 1)); }
+ok() { printf '  \033[32mpass\033[0m %s\n' "$1"; pass=$((pass + 1)); }
+bad() { printf '  \033[31mFAIL\033[0m %s\n' "$1"; fail=$((fail + 1)); }
 note() { printf '  \033[33mskip\033[0m %s\n' "$1"; skip=$((skip + 1)); }
 is() { [ "$2" = "$3" ] && ok "$1 ($2)" || bad "$1: got $2, expected $3"; }
 body_has() { grep -q -- "$2" "$TMP/body" && ok "$1" || bad "$1: '$2' not in the response"; }
@@ -86,7 +107,10 @@ post() {
 }
 
 mails() { curl -s "$MAILBOX/api/v1/messages?limit=20"; }
-mail_count() { mails | python3 -c 'import json,sys; print(json.load(sys.stdin).get("messages_count", 0))'; }
+# One key, no fallback: a rename must fail loudly rather than read as "no mail was sent",
+# and the image is pinned by digest so a rename cannot arrive unnoticed. (mailpit's
+# `total` is not a synonym — it counts the whole mailbox, not the current query.)
+mail_count() { mails | python3 -c 'import json,sys; print(json.load(sys.stdin)["messages_count"])'; }
 newest_code() {
 	local id
 	id=$(mails | python3 -c 'import json,sys; m=json.load(sys.stdin)["messages"]; print(m[0]["ID"] if m else "")')
@@ -208,7 +232,6 @@ run_checks() {
 	echo "-- assets"
 	local broken=0 count=0 url code_
 	while read -r url; do
-		[ -n "$url" ] || continue
 		count=$((count + 1))
 		code_=$(curl -s -b "$TMP/jar" -c "$TMP/jar" -o /dev/null -w '%{http_code}' "$BASE$url")
 		[ "$code_" = "200" ] || { bad "asset $url -> $code_"; broken=$((broken + 1)); }
@@ -250,48 +273,65 @@ fi
 # something else" — and that has happened here: a smoke test once passed against a
 # package built before the change it was meant to prove.
 preflight_package() {
-	if [ "$BUILD" = 1 ]; then
-		command -v krankerl >/dev/null || {
-			echo "BUILD=1 needs krankerl in PATH." >&2
-			echo "  APP_DIR=$ROOT $0     # or test the working tree instead" >&2
-			exit 1
-		}
-		( cd "$ROOT" && krankerl package ) || exit 1
+	# Everything the package is made of: the files that are shipped as they are (appinfo,
+	# lib, templates, css, js, l10n, img) and the sources they are built from (src and the
+	# manifests including their lock files — a changed lock file means a changed vendor/
+	# or a changed build). Anything left out here can change without the package looking
+	# stale, and translations change often enough for that to matter.
+	# css and js are deliberately absent: both are gitignored build output with no tracked
+	# files, so git can never report them — listing them would only claim coverage.
+	local paths='lib src templates appinfo l10n img'
+	paths="$paths composer.json composer.lock package.json package-lock.json"
+	# These two decide what the package CONTAINS, so a change to them dates a package
+	# just as much as a change to the code does.
+	paths="$paths krankerl.toml .nextcloudignore"
+
+	# Checked BEFORE building: krankerl packages the committed state, so building now
+	# would spend a minute producing a package that still cannot contain these changes,
+	# only to be rejected afterwards.
+	local dirty
+	# shellcheck disable=SC2086
+	dirty=$(git -C "$ROOT" status --porcelain -- $paths)
+	if [ -n "$dirty" ]; then
+		echo "Uncommitted changes to the app:"
+		printf '%s\n' "$dirty" | sed 's/^/    /'
+		cat <<TXT
+
+krankerl packages the committed state, so the above cannot be in any package. Pick one:
+
+  git commit …
+      commit them, then run again
+  APP_DIR=$ROOT $0
+      test the working tree instead of the package
+TXT
+		exit 1
 	fi
 
-	local paths='lib src templates appinfo css js composer.json package.json'
+
 	if [ ! -f "$APP_TARBALL" ]; then
 		echo "No package at $APP_TARBALL. Pick one:"
 		echo "  krankerl package     — build it, then run again"
-		echo "  BUILD=1 $0"
 		echo "  APP_DIR=$ROOT $0"
 		exit 1
 	fi
 
-	local dirty source_ts package_ts
-	# shellcheck disable=SC2086
-	dirty=$(git -C "$ROOT" status --porcelain -- $paths)
+	local source_ts package_ts
 	# The last commit that touched the app itself — a docs-only commit must not make a
-	# perfectly good package look stale.
+	# perfectly good package look stale. Defaults to 0: an empty result would otherwise
+	# make the comparison below an error, and an erroring check is no check.
 	# shellcheck disable=SC2086
 	source_ts=$(git -C "$ROOT" log -1 --format=%ct -- $paths)
 	package_ts=$(stat -c %Y "$APP_TARBALL")
-	if [ -n "$dirty" ] || [ "$package_ts" -lt "$source_ts" ]; then
-		echo "The package does not match the current state of the app:"
+	if [ "$package_ts" -lt "${source_ts:-0}" ]; then
+		echo "The package is older than the app it should contain:"
 		printf '  package %s\n' "$(date -d "@$package_ts" '+%F %T')"
 		printf '  sources %s (last commit touching the app)\n' "$(date -d "@$source_ts" '+%F %T')"
-		if [ -n "$dirty" ]; then
-			echo "  uncommitted:"
-			printf '%s\n' "$dirty" | sed 's/^/    /'
-		fi
 		cat <<TXT
 
-krankerl packages the committed state, so the above is not in the package. Pick one:
+Pick one:
 
   krankerl package
       rebuild, then run again
-  BUILD=1 $0
-      build and run in one go
   APP_DIR=$ROOT $0
       test the working tree instead of the package
 TXT
@@ -302,18 +342,19 @@ TXT
 # Never take over an instance that is already up: compose would recreate the container
 # of whoever is using it. This happened — a test run recreated a colleague's manual
 # instance because both used the same project name and ports.
-# Asked via the compose project LABEL, not via `docker compose ps`: the latter has to
-# interpolate compose.yaml first, and compose.yaml requires APP_DIR — so without it the
-# command fails, the error goes to /dev/null and the count silently becomes zero. A
-# check that cannot fail loudly is not a check.
-project=${COMPOSE_PROJECT_NAME:-$(basename "$PWD")}
-running=$(docker ps --quiet --filter "label=com.docker.compose.project=$project" | wc -l)
+# Filtered by the project label, which is authoritative because COMPOSE_PROJECT_NAME is
+# set above rather than derived from the directory name — compose lowercases and strips
+# characters, so a guessed name silently stops matching.
+running=$(docker ps --quiet --filter "label=com.docker.compose.project=$COMPOSE_PROJECT_NAME" | wc -l)
 if [ "$running" != 0 ]; then
 	cat >&2 <<TXT
 An instance of this project is already running ($running container(s)).
 Starting now would recreate it and pull it away from whoever is using it.
 
-  docker compose down -v                       stop and remove it, then run again
+  COMPOSE_PROJECT_NAME=$COMPOSE_PROJECT_NAME docker compose down -v
+                                               stop and remove it, then run again
+                                               (the project is named explicitly so this
+                                               cannot hit a different instance)
   COMPOSE_PROJECT_NAME=tfe-2 HTTP_PORT=8081 MAIL_PORT=8026 $0
                                                run a second, independent instance
 TXT
@@ -332,10 +373,29 @@ echo "servers: ${TAGS[*]}"
 # otherwise `docker compose exec` fails, every occ call comes back empty and the run
 # reports a dozen misleading failures instead of one clear one.
 export APP_TARBALL HTTP_PORT MAIL_PORT ROOT
-# In packaged mode APP_DIR must stay UNSET here: setup.sh unpacks the tarball and sets
-# it. Exporting it beforehand made setup.sh take the "mount a directory" branch and
-# hand compose a path that did not exist yet, so the container never started.
-if [ "$PACKAGED" = 1 ]; then unset APP_DIR; else export APP_DIR; fi
+# In directory mode the caller's APP_DIR is what compose mounts, for every version. In
+# packaged mode it must stay UNSET while setup.sh runs: setup.sh unpacks the tarball and
+# sets it itself. Handing it a value beforehand made it take the "mount a directory"
+# branch and gave compose a path that did not exist yet, so the container never started.
+if [ "$PACKAGED" = 0 ]; then export APP_DIR; fi
+
+# A failed teardown leaves the containers and the data volume behind, so the next version
+# installs into a foreign data directory. That must be loud, not swallowed.
+teardown() {
+	local out
+	# Nothing of this project around? Then there is nothing to tear down, and calling
+	# compose would only fail: on a fresh checkout .env does not exist yet, so a setup
+	# that died before writing it would produce a bogus failure here.
+	if [ -z "$(docker ps -aq --filter "label=com.docker.compose.project=$COMPOSE_PROJECT_NAME")" ]; then
+		rm -rf app
+		return 0
+	fi
+	if ! out=$(docker compose down -v 2>&1); then
+		bad "teardown failed — remove it by hand: docker compose down -v"
+		printf '%s\n' "$out" | tail -5 | sed 's/^/       /'
+	fi
+	rm -rf app
+}
 
 for tag in "${TAGS[@]}"; do
 	echo
@@ -345,12 +405,9 @@ for tag in "${TAGS[@]}"; do
 		echo "  setup failed:"
 		tail -15 "$TMP/setup.log" | sed 's/^/    /'
 		fail=$((fail + 1))
-		docker compose down -v >/dev/null 2>&1
-		rm -rf app
+		teardown
 		continue
 	fi
-	# setup.sh unpacked it; our own compose calls need the same value.
-	[ "$PACKAGED" = 1 ] && export APP_DIR="$PWD/app/twofactor_email"
 	grep -E 'versionstring|twofactor_email' "$TMP/setup.log" | sed 's/^/  /'
 
 	# Fail fast and loudly: if occ does not answer, every following check would fail
@@ -359,8 +416,7 @@ for tag in "${TAGS[@]}"; do
 		echo "  occ does not answer on this instance — skipping the checks:"
 		occ status 2>&1 | head -5 | sed 's/^/    /'
 		fail=$((fail + 1))
-		docker compose down -v >/dev/null 2>&1
-		rm -rf app
+		teardown
 		continue
 	fi
 
@@ -377,10 +433,14 @@ for tag in "${TAGS[@]}"; do
 	fi
 	if [ "$KEEP" = 1 ]; then
 		echo "  instance left running: $BASE (admin/$PW) · $MAILBOX"
+		# Only one instance can be kept, so the run stops here. Say so, otherwise the
+		# summary below looks like a full pass over the whole version range.
+		if [ "$tag" != "${TAGS[$((${#TAGS[@]} - 1))]}" ]; then
+			note "the remaining server version(s) were not tested (KEEP=1 stops after the first)"
+		fi
 		break
 	fi
-	docker compose down -v >/dev/null 2>&1
-	rm -rf app
+	teardown
 done
 
 echo

--- a/tests/smoke/smoke.sh
+++ b/tests/smoke/smoke.sh
@@ -71,9 +71,12 @@ post() {
 	shift 2
 	local args=() kv
 	for kv in "$@"; do args+=(-d "$kv"); done
+	# ${args[@]+…} because two callers pass no data at all (resend, admin/reset) and
+	# expanding an empty array under `set -u` aborts on bash < 4.4 — macOS still ships
+	# 3.2 as /bin/bash.
 	curl -s -X POST -b "$TMP/jar" -c "$TMP/jar" \
 		-H "Origin: $BASE" -H "requesttoken: $tok" \
-		-o "$TMP/body" -w '%{http_code}' "${args[@]}" "$url"
+		-o "$TMP/body" -w '%{http_code}' ${args[@]+"${args[@]}"} "$url"
 }
 
 mails() { curl -s "$MAILBOX/api/v1/messages?limit=20"; }
@@ -201,7 +204,14 @@ run_checks() {
 		[ "$code_" = "200" ] || { bad "asset $url -> $code_"; broken=$((broken + 1)); }
 	done < <(grep -oP '(src|href)="\K/(dist|apps/twofactor_email)[^"]+' "$TMP/challenge.html" \
 		| sed 's/&amp;/\&/g' | sort -u)
-	[ "$broken" = 0 ] && ok "all $count assets of the challenge page were served"
+	# The count has to be checked too: if the extraction ever matches nothing, the loop
+	# body never runs and a bare "$broken = 0" would report a pass for having tested
+	# nothing at all. That false pass was observed while building this.
+	if [ "$count" = 0 ]; then
+		bad "no assets found on the challenge page — the page or the extraction changed"
+	elif [ "$broken" = 0 ]; then
+		ok "all $count assets of the challenge page were served"
+	fi
 
 	echo "-- server log"
 	if docker compose exec -T nextcloud sh -c 'cat /var/www/html/data/nextcloud.log' 2>/dev/null \
@@ -259,7 +269,17 @@ for tag in "${TAGS[@]}"; do
 		continue
 	fi
 
+	before=$fail
 	run_checks
+	# Dump the log while the containers still exist. Doing this afterwards — or from a
+	# following CI step — cannot work: the teardown below has already removed them.
+	if [ "$fail" -gt "$before" ]; then
+		echo "-- server log (last 40 lines, this instance failed)"
+		docker compose exec -T nextcloud sh -c 'tail -n 40 /var/www/html/data/nextcloud.log' \
+			2>/dev/null | cut -c1-200 | sed 's/^/     /' || echo "     (log not readable)"
+		echo "-- container log (last 20 lines)"
+		docker compose logs --tail 20 nextcloud 2>/dev/null | sed 's/^/     /'
+	fi
 	if [ "$KEEP" = 1 ]; then
 		echo "  instance left running: $BASE (admin/$PW) · $MAILBOX"
 		break


### PR DESCRIPTION
## What

A smoke test that runs the app inside a real Nextcloud, the release knowledge that goes with it, and an untested CI workflow to drive the test.

The unit tests cover the classes. Nothing covered whether the app still *works* in a server: whether the routes are reachable, the mail goes out, a login with the code from that mail gets you in — and whether any of it differs between the oldest and the newest supported version.

## Why both server versions, by default

3.4.0 shipped a resend endpoint that was **dead on Nextcloud 33** and fine on 34: the exemption from the two-factor gate is read from the docblock on 33 and from a PHP attribute that is `@since 34`. The manual browser pass runs on a current server, so nothing looked wrong. Fixed in 3.4.1 — and this harness finds that class of bug in five minutes, which is why the version list comes from `appinfo/info.xml` and cannot drift from what we claim to support.

## Verified

`tests/smoke/smoke.sh` against the 3.4.1 package on **Nextcloud 33.0.7 and 34.0.2**: **52 checks, 0 failures**, run both from outside a checkout and with the in-repo defaults a developer would actually type.

`/tests` is in `.nextcloudignore`, so none of this reaches the release package.

## The CI workflow is explicitly not verified

It has never run — a workflow can only be proven by pushing it, so **its first run is the one on this pull request**. If it comes back red, that is the expected first iteration (likely the krankerl download, the PHP extensions the build needs, or the image pull), not a finding about the app. The file says so in its header too, so nobody later mistakes it for something that was checked. Feel free to review the other two commits independently of it.

## Notes for review

- Commits are split by concern: the harness, the doc, the workflow.
- The README deliberately records the traps that cost hours, because each of them looks like a broken server rather than a broken client: the request token must be sent as a **header** (it is base64, and PHP turns a `+` in a form body into a space, so as a form field the same request works about one time in three); `curl` needs an `Origin` header for `POST /login`; `curl` sends a GET when no `-d` is given, so a POST-only route answers 405; and the redirect after a wrong code *contains* the dashboard path without anyone being logged in.
- `doc/releasing.md` leaves out the maintainer's infrastructure on purpose. What it keeps is the part that applies to anyone: the version fields that must move together, that `krankerl` packages the **committed** state, and why a fresh release stays invisible to instances for a while — two caches plus a per-IP rate limit that Nextcloud turns into a silent "All apps are up-to-date".
- **Ordering:** #163 introduces a "Throwaway instance" section in `doc/development-setup.md` with its own inline compose recipe. Once that is merged, the section should be trimmed to point at `tests/smoke/` so the recipe exists once. I left it out here rather than editing a pull request under review, and rather than creating a second section that would conflict with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.