### PR TITLE
Add CLAUDE.md and REVIEW.md

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: nextcloud/apps/twofactor_email
+          persist-credentials: false
 
       - name: Install dependencies
         working-directory: nextcloud/apps/twofactor_email

--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -12,6 +12,8 @@
 /.tx
 /build
 /.claude
+/CLAUDE.md
+/REVIEW.md
 /codecov.yml
 /doc
 /composer.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,86 @@
+# Working on this app
+
+Notes for AI agents. Facts and conventions only — the reasoning lives in
+[`doc/`](doc/), and this file should stay short enough that reading it is never a
+detour.
+
+## What it is
+
+A two-factor provider for Nextcloud that mails a one-time code. It plugs into
+Nextcloud's two-factor framework and is built against the public `OCP` interfaces
+only. [`doc/architecture.md`](doc/architecture.md) explains how the pieces fit;
+[`doc/threat-model.md`](doc/threat-model.md) states what the app defends against.
+
+## Supported versions
+
+| | |
+|---|---|
+| Nextcloud | 33–34 (`appinfo/info.xml`) |
+| PHP | 8.2–8.5 |
+| Node | `^24 \|\| ^26` |
+
+**The CI's PHP floor is derived from the Nextcloud `min-version`**, not from
+`<php min-version>`: `icewind1991/nextcloud-version-matrix` takes the minimum PHP of
+the oldest supported server. Raising the PHP floor therefore means dropping the
+Nextcloud versions that still allow the older PHP. When you touch the range, change
+`info.xml` (both), `composer.json` (`require.php`, `config.platform.php`,
+`nextcloud/ocp`) and `psalm.xml` together, then check that CI agrees.
+
+## Layout
+
+- `lib/` — PHP, namespace `OCA\TwoFactorEMail`. Controllers use routing attributes
+  (`#[FrontpageRoute]`); there is no `appinfo/routes.php` any more.
+- `src/` — Vue 3 with Pinia, tested with Vitest.
+- `templates/` — the login challenge plus the three settings templates.
+- `tests/Unit/` — PHPUnit, mirrors `lib/`.
+- `tests/smoke/` — the app running in a disposable Nextcloud; use it for anything
+  touching routes, controllers or the challenge flow. See its
+  [README](tests/smoke/README.md).
+
+## Commands
+
+```bash
+composer test:unit:dev            # PHPUnit without coverage
+composer cs:check                 # php-cs-fixer, nextcloud/coding-standard
+composer psalm                    # static analysis
+composer psalm:taint              # taint analysis, must stay empty
+npm run lint && npm run stylelint && npm test && npm run build
+krankerl package                  # release package
+```
+
+Psalm runs on the app's **minimum** PHP version and does not support newer runtimes;
+if your default PHP is newer, invoke it with the older one.
+
+**`composer outdated` in the root does not see `vendor-bin/*`.** The bamarni plugin
+gives those their own projects — use `composer bin all outdated`.
+
+## Conventions
+
+- **Every new file needs licensing.** Either an SPDX header or an entry in
+  `REUSE.toml`; the `reuse` CI job fails otherwise. Root-level Markdown is covered by
+  `REUSE.toml`, other files carry headers.
+- **GitHub Actions are pinned to a commit SHA** with a version comment, and every
+  checkout sets `persist-credentials: false`. Follow the existing workflows.
+- **A version bump touches four places:** `appinfo/info.xml`, `package.json`, and
+  **both** version fields in `package-lock.json` — plus a `CHANGELOG.md` section with
+  the release date. Change the values in place; do not re-resolve the lock file during
+  a release.
+- Do not reformat code you are not otherwise changing.
+
+## Things that look wrong and are not
+
+- **`ChallengeController::resend()` carries both `#[NoTwoFactorRequired]` and a
+  `@NoTwoFactorRequired` docblock annotation.** Nextcloud 33 reads the exemption from
+  the docblock only; the attribute is `@since 34`. Removing either one breaks a
+  supported server. The annotation goes when `min-version` reaches 34.
+- **`symfony/console` is held at `^6.4.42`.** Nextcloud bundles Symfony 6.4, and `occ`
+  commands must build against the same major.
+- **`@nextcloud/vite-config` is pinned to a pre-release.** Only that version allows
+  Vite 8; the stable line is still on Vite 7.
+
+## Releasing
+
+`krankerl package` packages the **committed** state, not the working tree — an
+uncommitted fix is not in the package, and a test against it proves the old behaviour.
+The rest, including why a published release stays invisible to instances for a while,
+is in [`doc/releasing.md`](doc/releasing.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,8 @@
 
 Notes for AI agents. Facts and conventions only — the reasoning lives in
 [`doc/`](doc/), and this file should stay short enough that reading it is never a
-detour.
+detour. [`REVIEW.md`](REVIEW.md) says what review pays attention to here and which
+questions are already settled.
 
 ## What it is
 
@@ -24,14 +25,16 @@ only. [`doc/architecture.md`](doc/architecture.md) explains how the pieces fit;
 the oldest supported server. Raising the PHP floor therefore means dropping the
 Nextcloud versions that still allow the older PHP. When you touch the range, change
 `info.xml` (both), `composer.json` (`require.php`, `config.platform.php`,
-`nextcloud/ocp`) and `psalm.xml` together, then check that CI agrees.
+`nextcloud/ocp`) and `psalm.xml` together, then check that CI agrees. Nextcloud 35
+requires PHP 8.3, so supporting it means dropping every server that still allows 8.2.
 
 ## Layout
 
 - `lib/` — PHP, namespace `OCA\TwoFactorEMail`. Controllers use routing attributes
   (`#[FrontpageRoute]`); there is no `appinfo/routes.php` any more.
 - `src/` — Vue 3 with Pinia, tested with Vitest.
-- `templates/` — the login challenge plus the three settings templates.
+- `templates/` — four templates: the login challenge, the enrolment step shown during
+  login (`LoginSetup`, an `ILoginSetupProvider`), and the admin and personal settings.
 - `tests/Unit/` — PHPUnit, mirrors `lib/`.
 - `tests/smoke/` — the app running in a disposable Nextcloud; use it for anything
   touching routes, controllers or the challenge flow. See its
@@ -51,20 +54,43 @@ krankerl package                  # release package
 Psalm runs on the app's **minimum** PHP version and does not support newer runtimes;
 if your default PHP is newer, invoke it with the older one.
 
+Run the checks that match your diff **before** opening a pull request. CI is the gate,
+but finding it locally is cheaper for everyone.
+
 **`composer outdated` in the root does not see `vendor-bin/*`.** The bamarni plugin
 gives those their own projects — use `composer bin all outdated`.
+
+**Query npm with `--all`.** `npm ls <package>` and friends traverse shallowly without
+it and silently miss deeper paths, which is how a dependency once looked dev-only when
+it was not. After an update, read the warnings and remove their cause rather than
+treating them as background noise, and re-check whether the existing pins and
+`overrides` still change anything — every one of them is debt.
 
 ## Conventions
 
 - **Every new file needs licensing.** Either an SPDX header or an entry in
-  `REUSE.toml`; the `reuse` CI job fails otherwise. Root-level Markdown is covered by
-  `REUSE.toml`, other files carry headers.
+  `REUSE.toml`; the `reuse` CI job fails otherwise. Root-level Markdown is licensed
+  through an **explicit filename entry** in `REUSE.toml` — only `doc/**` and `l10n/**`
+  are globbed, so a new root file has to be added there by hand.
 - **GitHub Actions are pinned to a commit SHA** with a version comment, and every
   checkout sets `persist-credentials: false`. Follow the existing workflows.
 - **A version bump touches four places:** `appinfo/info.xml`, `package.json`, and
   **both** version fields in `package-lock.json` — plus a `CHANGELOG.md` section with
   the release date. Change the values in place; do not re-resolve the lock file during
   a release.
+- **Decide for every new file whether it belongs in the release package.**
+  `.nextcloudignore` keeps the package to runtime files; a new file at the root ships
+  unless it is listed there.
+- **Write texts for translation.** Comments, docblocks and user-facing strings in
+  plain, simple English — short sentences, no idioms, nothing that only makes sense in
+  German. Translators and non-native readers both benefit.
+- **Changelog entries are one terse line each**; the reasoning belongs in the commit
+  message, not in `CHANGELOG.md`.
+- **Parametrise a test only when setup *and* expected result are identical** across the
+  cases. Differing expectations, or a different mock mechanism per case, mean separate
+  tests — a parametrised test with a branch inside it hides what it checks.
+- **SOLID pragmatically, not dogmatically.** Single-purpose classes, no abstraction
+  introduced for a second implementation that does not exist yet. Maintainability first.
 - Do not reformat code you are not otherwise changing.
 
 ## Things that look wrong and are not
@@ -76,7 +102,8 @@ gives those their own projects — use `composer bin all outdated`.
 - **`symfony/console` is held at `^6.4.42`.** Nextcloud bundles Symfony 6.4, and `occ`
   commands must build against the same major.
 - **`@nextcloud/vite-config` is pinned to a pre-release.** Only that version allows
-  Vite 8; the stable line is still on Vite 7.
+  Vite 8; the stable line is still on Vite 7. **This one expires:** switch as soon as a
+  stable release supports Vite 8, and treat the pin as a finding from then on.
 
 ## Releasing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,11 @@ treating them as background noise, and re-check whether the existing pins and
   supported server. The annotation goes when `min-version` reaches 34.
 - **`symfony/console` is held at `^6.4.42`.** Nextcloud bundles Symfony 6.4, and `occ`
   commands must build against the same major.
+- **`allowScripts` in `package.json` lists `fsevents`, which is never installed here.**
+  It is darwin-only; the entry exists for macOS machines, where npm would otherwise
+  warn about its install script. `npm install-scripts prune` reports it as unused and
+  removes it on Linux — do not run that blindly, and note that
+  `npm install-scripts deny fsevents` cannot recreate it here (`ENOMATCH`).
 - **`@nextcloud/vite-config` is pinned to a pre-release.** Only that version allows
   Vite 8; the stable line is still on Vite 7. **This one expires:** switch as soon as a
   stable release supports Vite 8, and treat the pin as a finding from then on.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -6,7 +6,8 @@ SPDX-PackageSupplier = "Two-Factor email Support <twofactor-email@datenschutz-in
 SPDX-PackageDownloadLocation = "https://github.com/datenschutz-individuell/twofactor_email"
 
 [[annotations]]
-path = ["CHANGELOG.md", "CONTRIBUTORS.md", "README.md", "SECURITY.md", "doc/**",
+path = ["CHANGELOG.md", "CLAUDE.md", "CONTRIBUTORS.md", "README.md", "REVIEW.md",
+    "SECURITY.md", "doc/**",
     "composer.json", "composer.lock", "package.json", "package-lock.json",
     "vendor-bin/cs-fixer/composer.json", "vendor-bin/cs-fixer/composer.lock",
     "psalm.xml"]

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -8,9 +8,8 @@ The general facts about the project — supported versions, layout, commands —
 
 ## Worth flagging
 
-**Correctness before everything.** This app guards a login. A defect that lets a
-second factor be skipped, accepted twice, or brute-forced matters more than anything
-about style.
+**Correctness comes first here.** This app guards a login, so a defect that lets a second
+factor be skipped, accepted twice or brute-forced outweighs any question of style.
 
 - **Security-relevant attributes on controllers.** A route reachable by a **fully
   logged-in** user that changes state without `#[PasswordConfirmationRequired]`; a

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -12,13 +12,15 @@ The general facts about the project — supported versions, layout, commands —
 second factor be skipped, accepted twice, or brute-forced matters more than anything
 about style.
 
-- **Security-relevant attributes on controllers.** A state-changing user route without
-  `#[PasswordConfirmationRequired]`, a public or challenge-time endpoint without
-  `#[BruteForceProtection]` or a rate limit, an admin route without
-  `#[AuthorizedAdminSetting]`. Also flag an exemption that is broader than the comment
-  next to it claims.
+- **Security-relevant attributes on controllers.** A route reachable by a **fully
+  logged-in** user that changes state without `#[PasswordConfirmationRequired]`; a
+  public or challenge-time endpoint without `#[BruteForceProtection]` or a rate limit;
+  an admin route without `#[AuthorizedAdminSetting]`. Also flag an exemption that is
+  broader than the comment next to it claims. Routes that run *during* the challenge
+  cannot use password confirmation — see the settled list below.
 - **Codes and their lifetime.** Anything that stores a code in clear text, keeps it
-  after use, compares it without constant-time semantics, or widens its validity.
+  after a **successful** verification, compares it without constant-time semantics, or
+  widens its validity beyond the configured window.
 - **An empty result treated as success.** `for` over nothing, a filter that matches
   nothing, a check whose loop body never runs — if "found nothing to test" can report a
   pass, that is a bug. This has happened here.
@@ -32,9 +34,19 @@ about style.
   range changes, workarounds for the dropped version become dead weight around
   security-relevant code. Flag them.
 - **Repository conventions**, because they exist for a reason and are easy to miss when
-  adding a file of a kind that already exists: SPDX/REUSE coverage for new files,
-  GitHub Actions pinned to a commit SHA with a version comment, `persist-credentials:
-  false` on every checkout, `curl` downloads with `-f`.
+  adding a file of a kind that already exists: SPDX/REUSE coverage for new files, a
+  decision about `.nextcloudignore` for anything new at the root, GitHub Actions pinned
+  to a commit SHA with a version comment, `persist-credentials: false` on checkouts,
+  and `-f` on any `curl` that **downloads a tool or artefact** (not on the test
+  requests in `tests/smoke/`, where the status code is the assertion).
+- **Texts that will not survive translation.** User-facing strings, comments and
+  docblocks should be plain, short English. Idioms, nested clauses and German sentence
+  structure in English words all make translation worse.
+- **Parametrised tests that hide differences.** `it.each` is right only when setup and
+  expected result are identical across cases; a branch inside the case, or a different
+  mock mechanism per case, means it should have been separate tests.
+- **Abstraction without a second implementation.** An interface, factory or base class
+  introduced for a case that does not exist yet.
 - **A version bump that misses one of its four places** (`appinfo/info.xml`,
   `package.json`, both fields in `package-lock.json`) or a missing changelog section.
 
@@ -43,10 +55,23 @@ about style.
 - **The duplicated `NoTwoFactorRequired`** in `ChallengeController::resend()`: the
   docblock annotation serves Nextcloud 33, the attribute serves 34 and is `@since 34`.
   Both are needed until `min-version` reaches 34. The docblock explains it.
-- **`symfony/console` at `^6.4`**: Nextcloud bundles Symfony 6.4 and `occ` commands
-  must match its major.
+- **`symfony/console` at `^6.4.42`**: Nextcloud bundles Symfony 6.4 and `occ` commands
+  must match its major. This one has no expiry — it moves when Nextcloud moves.
 - **`@nextcloud/vite-config` pinned to a pre-release**: it is the only version that
-  allows Vite 8.
+  allows Vite 8. **This one does expire** — once a stable release supports Vite 8, the
+  pin becomes exactly the kind of leftover the rule above asks you to flag.
+- **`ChallengeController::resend()` has no `#[PasswordConfirmationRequired]`.** It runs
+  before the second factor is complete, where password confirmation cannot be
+  satisfied. Its protection is the rate limit, brute-force protection and the service
+  cooldown.
+- **A wrong code does not invalidate the stored one.** Deleting it only on success is a
+  deliberate trade: users may mistype. Documented at the decision in
+  `LoginChallenge`.
+- **The remaining `npm audit` low findings.** They come from `elliptic` beneath the
+  Vite config's polyfill plugin; its latest release is the flagged one, nothing in the
+  chain has a fix, and none of it reaches the built bundle. Likewise the `EBADENGINE`
+  warnings, which appear because the `@nextcloud/*` packages have not declared Node 26
+  yet.
 - **Formatting.** `php-cs-fixer` with `nextcloud/coding-standard` owns it, ESLint and
   Stylelint own the frontend. Tabs, brace placement and import order are not review
   material.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,64 @@
+# Review guidance
+
+For automated review. It says what is worth flagging here, and what has already been
+decided so that it does not get re-litigated in every pull request.
+
+The general facts about the project — supported versions, layout, commands — are in
+[`CLAUDE.md`](CLAUDE.md).
+
+## Worth flagging
+
+**Correctness before everything.** This app guards a login. A defect that lets a
+second factor be skipped, accepted twice, or brute-forced matters more than anything
+about style.
+
+- **Security-relevant attributes on controllers.** A state-changing user route without
+  `#[PasswordConfirmationRequired]`, a public or challenge-time endpoint without
+  `#[BruteForceProtection]` or a rate limit, an admin route without
+  `#[AuthorizedAdminSetting]`. Also flag an exemption that is broader than the comment
+  next to it claims.
+- **Codes and their lifetime.** Anything that stores a code in clear text, keeps it
+  after use, compares it without constant-time semantics, or widens its validity.
+- **An empty result treated as success.** `for` over nothing, a filter that matches
+  nothing, a check whose loop body never runs — if "found nothing to test" can report a
+  pass, that is a bug. This has happened here.
+- **Failure paths that cannot work.** Diagnostics after a teardown, a log dump that
+  runs when the container is gone, `|| true` swallowing the very error the step exists
+  to surface.
+- **Shell portability in dev tooling.** Scripts under `tests/` are run by contributors
+  on macOS, whose stock `/bin/bash` is 3.2: expanding a possibly-empty array under
+  `set -u` aborts there.
+- **Version-range shims that outlived their reason.** When the supported Nextcloud
+  range changes, workarounds for the dropped version become dead weight around
+  security-relevant code. Flag them.
+- **Repository conventions**, because they exist for a reason and are easy to miss when
+  adding a file of a kind that already exists: SPDX/REUSE coverage for new files,
+  GitHub Actions pinned to a commit SHA with a version comment, `persist-credentials:
+  false` on every checkout, `curl` downloads with `-f`.
+- **A version bump that misses one of its four places** (`appinfo/info.xml`,
+  `package.json`, both fields in `package-lock.json`) or a missing changelog section.
+
+## Already decided — please do not flag
+
+- **The duplicated `NoTwoFactorRequired`** in `ChallengeController::resend()`: the
+  docblock annotation serves Nextcloud 33, the attribute serves 34 and is `@since 34`.
+  Both are needed until `min-version` reaches 34. The docblock explains it.
+- **`symfony/console` at `^6.4`**: Nextcloud bundles Symfony 6.4 and `occ` commands
+  must match its major.
+- **`@nextcloud/vite-config` pinned to a pre-release**: it is the only version that
+  allows Vite 8.
+- **Formatting.** `php-cs-fixer` with `nextcloud/coding-standard` owns it, ESLint and
+  Stylelint own the frontend. Tabs, brace placement and import order are not review
+  material.
+- **`package-lock.json` churn** in a dependency update, and generated translation
+  files.
+- **Test doubles that look over-specific.** Assertions on exact mock calls are
+  deliberate here; the unit tests are meant to pin behaviour, not to be flexible.
+
+## What "ready" means here
+
+CI green, no new Psalm or taint findings, and — for anything touching routes,
+controllers or the challenge flow — the smoke test run against **both** ends of the
+supported Nextcloud range. One server version is not a test of a version range: a
+resend endpoint once worked on the newest server and was dead on the oldest, and only
+that two-version run found it.


### PR DESCRIPTION
## What

Two guidance files, plus the one-line CI consistency fix that writing them uncovered.

**`CLAUDE.md`** — what an agent needs before touching anything: the supported version ranges and the fact that CI derives the PHP floor from the Nextcloud `min-version`, the layout, the commands, the four places a version lives, and the conventions (SPDX/REUSE, SHA-pinned actions, `.nextcloudignore` decisions, translatable texts, terse changelog lines, when to parametrise a test, SOLID pragmatically). It closes with the three things that look like mistakes and are deliberate.

**`REVIEW.md`** — what review should pay attention to in an app that guards a login: missing brute-force, password-confirmation or admin-authorisation attributes, code handling and lifetime, empty results reported as success, failure paths that cannot work, shell portability in dev tooling. And, just as important, a list of what is **already decided**, so the same pins and trade-offs are not re-litigated every time.

## Reviewed before pushing

I ran `/code-review` on the first draft. It produced eight findings and every one of them was real; each was verified against the code before I acted on it.

Two were false statements: "root-level Markdown is covered by `REUSE.toml`" (it is an explicit filename list — which is why these two files had to be added by hand), and a wrong description of `templates/` (four files, one of which is the enrolment step shown during login, not a settings page).

Three would have produced a finding in **every** future review — the opposite of the point:

| Would have been flagged forever | Why it is correct as it is |
|---|---|
| `resend()` without `#[PasswordConfirmationRequired]` | it runs before the second factor, where confirmation cannot be satisfied; rate limit, brute-force protection and cooldown guard it |
| a wrong code not invalidating the stored one | deliberate: users may mistype |
| `curl` without `-f` in `tests/smoke/` | the status code *is* the assertion there |

One made a pin look permanent: the `@nextcloud/vite-config` pre-release expires as soon as a stable release supports Vite 8, and stating it without that condition silences the rule meant to catch it.

The last two: both files **shipped inside the release package** (`.nextcloudignore` lists filenames and had no entry for them — verified fixed: the built package now contains zero matches while `README`/`SECURITY`/`CONTRIBUTORS`/`CHANGELOG` still ship), and `CLAUDE.md` never mentioned `REVIEW.md`, so an agent reading the file it is guaranteed to load never learned the review guidance existed.

## The CI commit

`test.yml`'s second checkout was the only one of twelve without `persist-credentials: false`. It surfaced while writing the convention down: a rule the repository itself breaks in one place is not a rule yet. Separate commit, one line.

## Base

Stacked on #165 because both files link to `doc/releasing.md` and `tests/smoke/README.md`. GitHub retargets this to `main` once #165 is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.