### PR TITLE
Deny the install script of fsevents as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
   },
   "allowScripts": {
     "@parcel/watcher": false,
-    "core-js": false
+    "core-js": false,
+    "fsevents": false
   }
 }


### PR DESCRIPTION
## What

`allowScripts` in `package.json` covered two of the three packages that `package-lock.json` marks `hasInstallScript`. The missing one is **`fsevents`** — optional, darwin-only, pulled in transitively by rollup and vite. On Linux it is never installed, so nothing was visible; on a macOS machine the npm 12 install-script warning that this list exists to silence still appeared.

Found by the automated review on #161, whose thread is still open there. One line, no lock file change (`allowScripts` has no counterpart in it, and `npm install --package-lock-only` produces no diff).

## Two things that look wrong about this entry and are not

Both reproduced here before committing:

```
$ npm install-scripts deny fsevents --no-allow-scripts-pin --dry-run
npm error code ENOMATCH
npm error No installed packages match: fsevents

$ npm install-scripts prune --dry-run
Would remove 1 unused allowScripts entry:
  fsevents (package not installed)
```

So the entry **has to be hand-written** on Linux, and **`npm install-scripts prune` will delete it again** — silently bringing the macOS warning back and producing a diff that reads like an unexplained revert. The commit message says so; once #167 is merged, this belongs in the "Things that look wrong and are not" list in `CLAUDE.md`, and I will add it there.

## Not verified by me

Whether denying the script is harmless on macOS. The review that found this checked that the published tarball ships a prebuilt universal binary, so skipping `node-gyp rebuild` costs nothing — but I have no macOS machine to confirm it on. If it turns out that fsevents does need its rebuild, the correct fix is `"fsevents": true` instead, and the warning goes away just the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.