### PR TITLE
Clear the fixable npm advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3619,9 +3619,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -5433,9 +5433,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -8861,9 +8861,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "node": "^24.0.0 || ^26.0.0"
   },
   "overrides": {
-    "brace-expansion": "^5.0.8",
+    "brace-expansion": "^5.0.9",
     "glob": "^13"
   },
   "devDependencies": {


### PR DESCRIPTION
Three in-range updates that clear every fixable advisory `npm audit` reports on main.

| Package | | Advisory |
|---|---|---|
| `fast-uri` | 3.1.4 → 3.1.5 | GHSA-7p8r-x3mc-p8w7 (host confusion) |
| `postcss` | 8.5.20 → 8.5.25 | GHSA-fxqj-rqcc-2cmp (`sourceMappingURL` parsing) |
| `brace-expansion` | 5.0.8 → 5.0.9 | GHSA-rgw5-rvv9-x895 (denial of service) |

The `overrides` floor for `brace-expansion` moves to `^5.0.9` as well. The new advisory covers `>=4.0.0 <5.0.9`, so the override that exists to keep the vulnerable version out was still permitting it.

`npm audit` now reports only the 7 low findings in the `elliptic → … → @nextcloud/vite-config` chain. Those are dev-only and have no fix available.

Verified: eslint and stylelint clean, 77/77 tests pass, and `npm run build` produces `js/*.mjs` bundles that are byte-identical to main — no runtime change. `npm install --package-lock-only` reproduces the lockfile unchanged, so `npm ci` will not drift.

Supersedes #170, which covers `fast-uri` and `postcss` but not `brace-expansion`.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
