### PR TITLE
Point the throwaway-instance section at tests/smoke

### DIFF
--- a/doc/development-setup.md
+++ b/doc/development-setup.md
@@ -75,14 +75,17 @@ official image — SQLite plus a mail catcher, because without SMTP the challeng
 never arrives and the login flow cannot be tested at all.
 
 ```bash
-krankerl package                  # the instance installs the built package
+krankerl package                  # both start from the built package
 cd tests/smoke
-NC_TAG=33-apache ./setup.sh       # an instance to click around in
-./smoke.sh                        # the automated checks, oldest and newest server
+
+./smoke.sh                        # either: the checks, oldest and newest server
+NC_TAG=33-apache ./setup.sh       # or:     one instance, left up to click around in
 ```
 
-`setup.sh` prints the URLs and how to switch the provider on for the user;
-`docker compose down -v` removes everything again. The options, what the checks cover,
+The last two are alternatives, not a sequence: `smoke.sh` refuses to run while an
+instance is up rather than pulling it away from whoever is using it. `setup.sh` prints
+the URLs and how to switch the provider on for the user; `docker compose down -v`
+removes everything again. The options, what the checks cover,
 and a list of things that behave surprisingly are in
 [tests/smoke/README.md](../tests/smoke/README.md).
 

--- a/doc/development-setup.md
+++ b/doc/development-setup.md
@@ -70,89 +70,26 @@ docker compose up --pull always -d nextcloud
 ## Throwaway instance for a specific Nextcloud version
 
 The app supports a range of Nextcloud versions, and a bug can be specific to one of
-them. The quickest way to check one is a disposable instance built from the official
-image. SQLite is enough, and a mail catcher is **required** — without SMTP the
-challenge email never arrives, so the login flow cannot be tested at all.
+them. [`tests/smoke/`](../tests/smoke/) holds a disposable instance built from the
+official image — SQLite plus a mail catcher, because without SMTP the challenge email
+never arrives and the login flow cannot be tested at all.
 
-`compose.yaml`:
-
-```yaml
-services:
-  nextcloud:
-    image: nextcloud:33-apache          # pick the version you want to test
-    ports: ["8080:80"]
-    environment:
-      SQLITE_DATABASE: nextcloud
-      NEXTCLOUD_ADMIN_USER: admin
-      NEXTCLOUD_ADMIN_PASSWORD: admin
-      NEXTCLOUD_TRUSTED_DOMAINS: localhost
-    volumes:
-      - nc-data:/var/www/html
-      # the built app, not the working tree — test what gets shipped
-      - ./twofactor_email:/var/www/html/custom_apps/twofactor_email:ro
-  mailpit:
-    image: axllent/mailpit
-    ports: ["8025:8025"]                # the challenge codes land here
-volumes:
-  nc-data:
+```bash
+krankerl package                  # the instance installs the built package
+cd tests/smoke
+NC_TAG=33-apache ./setup.sh       # an instance to click around in
+./smoke.sh                        # the automated checks, oldest and newest server
 ```
 
-Unpack a built package next to it and start the stack:
+`setup.sh` prints the URLs and how to switch the provider on for the user;
+`docker compose down -v` removes everything again. The options, what the checks cover,
+and a list of things that behave surprisingly are in
+[tests/smoke/README.md](../tests/smoke/README.md).
 
-```
-tar xzf build/artifacts/twofactor_email.tar.gz -C .
-docker compose up -d
-```
+Testing the **built package** rather than the working tree is deliberate: it is what
+users get, and it catches what a checkout hides — `krankerl` packages the committed
+state, so an uncommitted fix is simply not in it.
 
-Then point Nextcloud at the mail catcher, give the admin an address (the provider
-cannot be enabled without one) and enable the app:
-
-```
-occ() { docker compose exec -T -u www-data nextcloud php occ "$@"; }
-occ config:system:set mail_smtpmode --value=smtp
-occ config:system:set mail_smtphost --value=mailpit
-occ config:system:set mail_smtpport --value=1025
-occ config:system:set mail_from_address --value=nextcloud
-occ config:system:set mail_domain --value=example.org
-occ user:setting admin settings email admin@example.org
-occ app:enable twofactor_email
-```
-
-Nextcloud is at `http://localhost:8080` (admin/admin), the mailbox at
-`http://localhost:8025`. `docker compose down -v` removes everything again.
-
-To reach the login challenge, switch the provider on for the user. The app keeps this
-state in Nextcloud's own two-factor registry, so `occ` can do it without a browser:
-
-```
-occ twofactorauth:enable admin email
-occ twofactorauth:state admin        # email must be listed under "Enabled providers"
-```
-
-The next login then asks for the code, which you read in the mail catcher.
-
-Three things that look like bugs but are not:
-
-- **The admin password cannot be changed to a weak one later.** `password_policy` is
-  active in the image and asks for ten characters and a password that is not on the
-  breach list. It does not apply while the instance is being installed, which is why
-  `admin/admin` works, but a later `occ user:resetpassword` to `admin` fails. Pick a
-  strong password, or throw the instance away and set it up again.
-- **A `curl` login needs an `Origin` header.** Nextcloud rejects a POST to `/login`
-  without a trusted `Origin` before it ever checks the password, and answers with a
-  redirect to `?direct=1&user=…` plus a misleading `Logging out` line in the log. It
-  looks exactly like a wrong password.
-- **Send the request token as a header, not as a form field.** The token is base64, so
-  it often contains a `+`. `curl -d` sends the body verbatim and PHP turns that `+`
-  into a space while decoding, which breaks the token — but only for the tokens that
-  happen to contain one, so the same command works about one time in three. As a
-  header it needs no encoding:
-
-  ```
-  curl -b jar -c jar -H 'Origin: http://localhost:8080' -H "requesttoken: $TOKEN" \
-    -d user=admin -d password=admin http://localhost:8080/login
-  ```
-
-If the Docker daemon refuses to start with `error initializing graphdriver: driver
-not supported`, the kernel was updated without a reboot since — the modules of the
-running kernel are gone, so overlayfs cannot be loaded. Rebooting fixes it.
+If the Docker daemon refuses to start with `error initializing graphdriver: driver not
+supported`, the kernel was updated without a reboot since — the modules of the running
+kernel are gone, so overlayfs cannot be loaded. Rebooting fixes it.

--- a/doc/development-setup.md
+++ b/doc/development-setup.md
@@ -75,7 +75,7 @@ official image — SQLite plus a mail catcher, because without SMTP the challeng
 never arrives and the login flow cannot be tested at all.
 
 ```bash
-krankerl package                  # both start from the built package
+krankerl package                  # in the repository root; both start from the package
 cd tests/smoke
 
 ./smoke.sh                        # either: the checks, oldest and newest server
@@ -85,7 +85,16 @@ NC_TAG=33-apache ./setup.sh       # or:     one instance, left up to click aroun
 The last two are alternatives, not a sequence: `smoke.sh` refuses to run while an
 instance is up rather than pulling it away from whoever is using it. `setup.sh` prints
 the URLs and how to switch the provider on for the user; `docker compose down -v`
-removes everything again. The options, what the checks cover,
+removes everything again.
+
+While you still have uncommitted work, there is no package to test — `krankerl` packages
+the committed state, and `smoke.sh` stops rather than prove the wrong thing. Mount the
+working tree instead:
+
+```bash
+composer install -o && npm ci && npm run build
+APP_DIR="$(git rev-parse --show-toplevel)" ./smoke.sh
+``` The options, what the checks cover,
 and a list of things that behave surprisingly are in
 [tests/smoke/README.md](../tests/smoke/README.md).
 

--- a/tests/smoke/compose.yaml
+++ b/tests/smoke/compose.yaml
@@ -18,6 +18,15 @@ services:
       NEXTCLOUD_ADMIN_USER: admin
       NEXTCLOUD_ADMIN_PASSWORD: admin
       NEXTCLOUD_TRUSTED_DOMAINS: localhost
+      # Mail settings, read by config/smtp.config.php inside the image. It needs all
+      # three of SMTP_HOST, MAIL_FROM_ADDRESS and MAIL_DOMAIN before it writes
+      # anything, and it sets mail_smtpmode itself. Doing it here rather than with occ
+      # means the setting exists from the first start, before an installation could
+      # try to send anything.
+      SMTP_HOST: mailpit
+      SMTP_PORT: 1025
+      MAIL_FROM_ADDRESS: nextcloud
+      MAIL_DOMAIN: example.org
     volumes:
       - nc-data:/var/www/html
       # The built package, not the working tree — this tests what gets shipped.

--- a/tests/smoke/setup.sh
+++ b/tests/smoke/setup.sh
@@ -92,7 +92,12 @@ occ status | sed 's/^/  /'
 # belongs to the image, not to us: if a future version drops or renames it, the only
 # symptom would be a challenge email that never arrives — which reads like a bug in
 # the app.
-if [ "$(occ config:system:get mail_smtphost | tail -n 1 | tr -d '\r')" != mailpit ]; then
+# The port is checked separately on purpose. Host, sender and domain are the file's own
+# precondition, so losing one of them fails the host check anyway. The port is not: it
+# falls back to 25 when SMTP_PORT is missing, which leaves the host correct and the
+# mail catcher silent.
+setting() { occ config:system:get "$1" | tail -n 1 | tr -d '\r'; }
+if [ "$(setting mail_smtphost)" != mailpit ] || [ "$(setting mail_smtpport)" != 1025 ]; then
 	echo "The image did not apply the mail settings from compose.yaml." >&2
 	echo "Check whether nextcloud:$NC_TAG still ships config/smtp.config.php." >&2
 	exit 1

--- a/tests/smoke/setup.sh
+++ b/tests/smoke/setup.sh
@@ -103,10 +103,30 @@ if [ "$(setting mail_smtphost)" != mailpit ] || [ "$(setting mail_smtpport)" != 
 	exit 1
 fi
 
-# Without an address on the account the provider cannot be switched on.
-occ user:setting admin settings email admin@example.org
+# Right after the installation a write can fail with "database is locked": the
+# installer's own background work still holds the SQLite file, and `occ status`
+# reporting "installed" does not mean it has let go. Retry instead of hoping.
+# This used to be hidden: the five occ calls that configured the mail settings stood
+# here and took about a second each, which was enough for the lock to clear. Moving
+# them into compose.yaml removed that accidental delay and turned the race into a
+# failing CI run — on one of the two servers only, as races go.
+# Only writes need this. `config:system:get` above reads config.php, not the database.
+occ_write() {
+	local out
+	for _ in $(seq 1 10); do
+		if out=$(occ "$@" 2>&1); then
+			[ -n "$out" ] && echo "$out" | sed 's/^/  /'
+			return 0
+		fi
+		sleep 3
+	done
+	echo "$out" >&2
+	return 1
+}
 
-occ app:enable twofactor_email | sed 's/^/  /'
+# Without an address on the account the provider cannot be switched on.
+occ_write user:setting admin settings email admin@example.org
+occ_write app:enable twofactor_email
 
 cat <<TXT
 

--- a/tests/smoke/setup.sh
+++ b/tests/smoke/setup.sh
@@ -92,14 +92,27 @@ occ status | sed 's/^/  /'
 # belongs to the image, not to us: if a future version drops or renames it, the only
 # symptom would be a challenge email that never arrives — which reads like a bug in
 # the app.
-# The port is checked separately on purpose. Host, sender and domain are the file's own
+# The port is checked as well as the host. Host, sender and domain are that file's own
 # precondition, so losing one of them fails the host check anyway. The port is not: it
-# falls back to 25 when SMTP_PORT is missing, which leaves the host correct and the
-# mail catcher silent.
-setting() { occ config:system:get "$1" | tail -n 1 | tr -d '\r'; }
-if [ "$(setting mail_smtphost)" != mailpit ] || [ "$(setting mail_smtpport)" != 1025 ]; then
-	echo "The image did not apply the mail settings from compose.yaml." >&2
-	echo "Check whether nextcloud:$NC_TAG still ships config/smtp.config.php." >&2
+# falls back to 25 when SMTP_PORT is missing, which leaves the host right and the mail
+# catcher silent.
+# The two expected values repeat what compose.yaml declares. Keep the pair in step —
+# changing the port there without changing it here aborts every run.
+expected_host=mailpit
+expected_port=1025
+# `|| true` because a key that is not set makes occ exit 1, which pipefail would turn
+# into a silent abort of this script. An empty value is a result here, not a crash.
+setting() { occ config:system:get "$1" | tail -n 1 | tr -d '\r' || true; }
+host=$(setting mail_smtphost)
+port=$(setting mail_smtpport)
+if [ "$host" != "$expected_host" ] || [ "$port" != "$expected_port" ]; then
+	echo "The mail settings from compose.yaml did not arrive:" >&2
+	echo "  mail_smtphost: '$host' (expected '$expected_host')" >&2
+	echo "  mail_smtpport: '$port' (expected '$expected_port')" >&2
+	echo "Both empty means occ could not answer at all — see 'docker compose logs" >&2
+	echo "nextcloud'. Otherwise check whether nextcloud:$NC_TAG still ships" >&2
+	echo "config/smtp.config.php, which is where these values come from." >&2
+	echo "The instance is up; remove it with 'docker compose down -v'." >&2
 	exit 1
 fi
 
@@ -111,17 +124,34 @@ fi
 # them into compose.yaml removed that accidental delay and turned the race into a
 # failing CI run — on one of the two servers only, as races go.
 # Only writes need this. `config:system:get` above reads config.php, not the database.
+# Retrying is announced, because a run that needed nine attempts otherwise looks exactly
+# like a clean one — and then nobody notices that the budget below is getting tight.
 occ_write() {
-	local out
-	for _ in $(seq 1 10); do
+	local out attempt=1
+	while :; do
 		if out=$(occ "$@" 2>&1); then
 			[ -n "$out" ] && echo "$out" | sed 's/^/  /'
 			return 0
 		fi
+		# Only the lock is worth waiting for. A command that is broken for another
+		# reason — bad info.xml, a dependency the server does not have — has to say so
+		# now instead of after ten sleeps.
+		case $out in
+		*"database is locked"*) ;;
+		*)
+			echo "$out" >&2
+			return 1
+			;;
+		esac
+		if [ "$attempt" -ge 10 ]; then
+			echo "Still locked after $attempt attempts:" >&2
+			echo "$out" >&2
+			return 1
+		fi
+		echo "  database locked, retrying ($attempt)"
+		attempt=$((attempt + 1))
 		sleep 3
 	done
-	echo "$out" >&2
-	return 1
 }
 
 # Without an address on the account the provider cannot be switched on.

--- a/tests/smoke/setup.sh
+++ b/tests/smoke/setup.sh
@@ -87,13 +87,18 @@ for _ in $(seq 1 60); do
 done
 occ status | sed 's/^/  /'
 
-# Point Nextcloud at the mail catcher and give the admin an address: without one the
-# provider cannot be switched on.
-occ config:system:set mail_smtpmode --value=smtp >/dev/null
-occ config:system:set mail_smtphost --value=mailpit >/dev/null
-occ config:system:set mail_smtpport --value=1025 >/dev/null
-occ config:system:set mail_from_address --value=nextcloud >/dev/null
-occ config:system:set mail_domain --value=example.org >/dev/null
+# The mail settings are declared in compose.yaml; the image turns them into config by
+# itself. Check that they arrived, because the file doing it (config/smtp.config.php)
+# belongs to the image, not to us: if a future version drops or renames it, the only
+# symptom would be a challenge email that never arrives — which reads like a bug in
+# the app.
+if [ "$(occ config:system:get mail_smtphost | tail -n 1 | tr -d '\r')" != mailpit ]; then
+	echo "The image did not apply the mail settings from compose.yaml." >&2
+	echo "Check whether nextcloud:$NC_TAG still ships config/smtp.config.php." >&2
+	exit 1
+fi
+
+# Without an address on the account the provider cannot be switched on.
 occ user:setting admin settings email admin@example.org
 
 occ app:enable twofactor_email | sed 's/^/  /'


### PR DESCRIPTION
`doc/development-setup.md` described how to build a throwaway instance by hand: its own `compose.yaml`, its own `occ` calls, and a list of behaviours that look like bugs. Since #165 the same recipe exists in [`tests/smoke/`](../tree/main/tests/smoke) as a script that is actually run, so the copy in the docs could only drift from it.

The section now shows the three commands and links to [tests/smoke/README.md](../blob/main/tests/smoke/README.md), which covers every gotcha the old text listed — and four more. The one thing not covered there is kept: the `error initializing graphdriver` message after a kernel update without a reboot.

## And the same idea applied to the setup itself

Removing the duplicated `occ` calls from the docs raised the question why the script needs them at all. It mostly does not. The official image ships `config/smtp.config.php`, which builds the mail configuration from environment variables and sets `mail_smtpmode` itself, so five `occ` calls become four lines in `compose.yaml`:

```yaml
SMTP_HOST: mailpit
SMTP_PORT: 1025
MAIL_FROM_ADDRESS: nextcloud
MAIL_DOMAIN: example.org
```

Beyond being shorter, this makes the setting exist from the container's first start instead of after the installation has finished, which is when `occ` can first be used.

That file belongs to the image, not to us, so `setup.sh` now verifies that the settings arrived. Without the check, a future image that drops or renames it would produce a challenge email that never arrives — a symptom that reads like a bug in the app.

The two remaining `occ` calls stay: the admin address (the provider cannot be switched on without one) and `app:enable`. Both could move into the image's `post-installation` hook, but that would bury a failure in the container log instead of stopping the script visibly.

Verified with a full run against Nextcloud 33: the mail configuration is applied by the image, the challenge email arrives, and the login with the code from it succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
