### PR TITLE
3.3.1: keep the resend button working on Nextcloud 32 and 33

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,10 @@ on:
   pull_request:
     branches:
       - main
+      # Maintenance lines need the same gate. Without this, a pull request into
+      # release/3.3 gets the lint jobs but neither the PHP suite nor any of the
+      # install-and-run jobs for the declared Nextcloud versions.
+      - 'release/**'
 
 jobs:
   versions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.3.1 (2026-08-05)
+
+### Fixed
+
+- Requesting a new code works again on Nextcloud 32 and 33
+
+### Changed
+
+- Updated dependencies
+
 ## 3.3.0 (2026-07-20)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Requesting a new code works again on Nextcloud 32 and 33
+- Requesting a new code did nothing on Nextcloud 32 and 33
 
-### Changed
+### Security
 
-- Updated dependencies
+- Update dependencies to fix the fast-uri, postcss and brace-expansion advisories
 
 ## 3.3.0 (2026-07-20)
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -42,7 +42,7 @@ Mind that, once a user enabled any 2FA provider, they can no longer use their
 password in applications that don't support the web-based 2FA login flow. For
 such applications, the user needs to create and use app passwords (to be found
 at the bottom of "Personal Settings/Security").]]></description>
-    <version>3.3.0</version>
+    <version>3.3.1</version>
     <licence>agpl</licence>
     <author mail="twofactor-email@datenschutz-individuell.de">
         Olav Seyfarth (datenschutz-individuell) [see CONTRIBUTORS.md for more]

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -49,9 +49,9 @@ at the bottom of "Personal Settings/Security").]]></description>
     </author>
     <namespace>TwoFactorEMail</namespace>
     <documentation>
-        <user>https://github.com/datenschutz-individuell/twofactor_email/wiki/User-manual</user>
-        <admin>https://github.com/datenschutz-individuell/twofactor_email/wiki/Admin-manual</admin>
-        <developer>https://github.com/datenschutz-individuell/twofactor_email/wiki/Developer-notes</developer>
+        <user>https://github.com/datenschutz-individuell/twofactor_email/blob/main/doc/users.md</user>
+        <admin>https://github.com/datenschutz-individuell/twofactor_email/blob/main/doc/admins.md</admin>
+        <developer>https://github.com/datenschutz-individuell/twofactor_email/blob/main/doc/developers.md</developer>
     </documentation>
     <category>security</category>
 
@@ -59,8 +59,8 @@ at the bottom of "Personal Settings/Security").]]></description>
     <bugs>https://github.com/datenschutz-individuell/twofactor_email/issues</bugs>
     <repository>https://github.com/datenschutz-individuell/twofactor_email.git</repository>
     <screenshot
-            small-thumbnail="https://raw.githubusercontent.com/datenschutz-individuell/twofactor_email/main/screenshots/select-auth_thumb.webp">
-        https://raw.githubusercontent.com/datenschutz-individuell/twofactor_email/main/screenshots/challenge.webp
+            small-thumbnail="https://raw.githubusercontent.com/datenschutz-individuell/twofactor_email/3.3.1/screenshots/select-auth_thumb.webp">
+        https://raw.githubusercontent.com/datenschutz-individuell/twofactor_email/3.3.1/screenshots/challenge.webp
     </screenshot>
     <dependencies>
         <php min-version="8.1" max-version="8.5"/>

--- a/composer.lock
+++ b/composer.lock
@@ -1217,12 +1217,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "4fac0729c45b6dba8d6171a94eccb1d5d9514bf9"
+                "reference": "87faae4ca4b824c493788fac487f2e212be4fd22"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/4fac0729c45b6dba8d6171a94eccb1d5d9514bf9",
-                "reference": "4fac0729c45b6dba8d6171a94eccb1d5d9514bf9",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/87faae4ca4b824c493788fac487f2e212be4fd22",
+                "reference": "87faae4ca4b824c493788fac487f2e212be4fd22",
                 "shasum": ""
             },
             "conflict": {
@@ -1359,7 +1359,7 @@
                 "codingms/modules": "<4.3.11|>=5,<5.7.4|>=6,<6.4.2|>=7,<7.5.5",
                 "commerceteam/commerce": ">=0.9.6,<0.9.9",
                 "components/jquery": ">=1.0.3,<3.5",
-                "composer/composer": "<2.2.28|>=2.3,<2.9.8",
+                "composer/composer": "<2.2.29|>=2.3,<2.10.2",
                 "concrete5/concrete5": "<9.5.2",
                 "concrete5/core": "<8.5.8|>=9,<9.1",
                 "contao-components/mediaelement": ">=2.14.2,<2.21.1",
@@ -1419,7 +1419,7 @@
                 "doctrine/mongodb-odm-bundle": "<3.0.1",
                 "doctrine/orm": ">=1,<1.2.4|>=2,<2.4.8|>=2.5,<2.5.1|>=2.8.3,<2.8.4",
                 "dolibarr/dolibarr": "<=23.0.2",
-                "dompdf/dompdf": "<2.0.4",
+                "dompdf/dompdf": "<3.1.6",
                 "doublethreedigital/guest-entries": "<3.1.2",
                 "dreamfactory/df-core": "<1.0.4",
                 "drupal-pattern-lab/unified-twig-extensions": "<=0.1",
@@ -1574,10 +1574,10 @@
                 "gregwar/rst": "<1.0.3",
                 "grumpydictator/firefly-iii": "<=6.6.2",
                 "gugoan/economizzer": "<=0.9.0.0-beta1",
-                "guzzlehttp/guzzle": "<7.12.1",
+                "guzzlehttp/guzzle": "<7.15.2|>=8,<8.0.1",
                 "guzzlehttp/guzzle-services": "<1.5.4",
                 "guzzlehttp/oauth-subscriber": "<0.8.1",
-                "guzzlehttp/psr7": "<2.12.1",
+                "guzzlehttp/psr7": "<2.12.3",
                 "haffner/jh_captcha": "<=2.1.3|>=3,<=3.0.2",
                 "handcraftedinthealps/goodby-csv": "<1.4.3",
                 "harvesthq/chosen": "<1.8.7",
@@ -1695,7 +1695,7 @@
                 "librenms/librenms": "<26.3",
                 "liftkit/database": "<2.13.2",
                 "lightsaml/lightsaml": "<1.3.5",
-                "limesurvey/limesurvey": "<6.15.4",
+                "limesurvey/limesurvey": "<=7.0.0.0-beta1",
                 "livehelperchat/livehelperchat": "<=3.91",
                 "livewire-filemanager/filemanager": "<=1.0.4",
                 "livewire/livewire": "<2.12.7|>=3.0.0.0-beta1,<3.6.4",
@@ -1828,8 +1828,10 @@
                 "oro/customer-portal": ">=4.1,<=4.1.13|>=4.2,<=4.2.10|>=5,<=5.0.11|>=5.1,<=5.1.3",
                 "oro/platform": ">=1.7,<1.7.4|>=3.1,<3.1.29|>=4.1,<4.1.17|>=4.2,<=4.2.10|>=5,<=5.0.12|>=5.1,<=5.1.3",
                 "oveleon/contao-cookiebar": "<1.16.3|>=2,<2.1.3",
-                "oxid-esales/oxideshop-ce": "<=7.0.5",
+                "oxid-esales/oxideshop-ce": "<4.5|>=6,<6.14.4",
+                "oxid-esales/oxideshop-metapackage-ce": ">=6,<6.5.5",
                 "oxid-esales/paymorrow-module": ">=1,<1.0.2|>=2,<2.0.1",
+                "oxid-esales/smarty-component": "<1.0.1",
                 "packbackbooks/lti-1-3-php-library": "<5",
                 "padraic/humbug_get_contents": "<1.1.2",
                 "pagarme/pagarme-php": "<3",
@@ -1852,7 +1854,7 @@
                 "personnummer/personnummer": "<3.0.2",
                 "ph7software/ph7builder": "<=17.9.1",
                 "phanan/koel": "<=9.7",
-                "pheditor/pheditor": "<2.0.6",
+                "pheditor/pheditor": "<2.0.8",
                 "phenx/php-svg-lib": "<0.5.2",
                 "php-censor/php-censor": "<2.0.13|>=2.1,<2.1.5",
                 "php-mod/curl": "<2.3.2",
@@ -1868,7 +1870,7 @@
                 "phpoffice/common": "<0.2.9",
                 "phpoffice/math": "<=0.2",
                 "phpoffice/phpexcel": "<=1.8.2",
-                "phpoffice/phpspreadsheet": "<=1.30.4|>=2,<=2.1.15|>=2.2,<=2.4.4|>=3,<=3.10.4|>=4,<=5.6",
+                "phpoffice/phpspreadsheet": "<=1.30.5|>=2,<=2.1.17|>=2.2,<=2.4.6|>=3,<=3.10.6|>=4,<=5.8",
                 "phppgadmin/phppgadmin": "<=7.13",
                 "phpseclib/phpseclib": "<=2.0.54|>=3,<=3.0.53",
                 "phpservermon/phpservermon": "<3.6",
@@ -1895,7 +1897,7 @@
                 "pocketmine/pocketmine-mp": "<5.42.1",
                 "pocketmine/raklib": ">=0.14,<0.14.6|>=0.15,<0.15.1",
                 "pontedilana/php-weasyprint": "<=2.5.1",
-                "poweradmin/poweradmin": "<4.2.4|>=4.3,<4.3.3",
+                "poweradmin/poweradmin": "<4.2.5|>=4.3,<4.3.4",
                 "pressbooks/pressbooks": "<5.18",
                 "prestashop/autoupgrade": ">=4,<4.10.1",
                 "prestashop/blockreassurance": "<=5.1.3",
@@ -1914,7 +1916,7 @@
                 "propel/propel": ">=2.0.0.0-alpha1,<2.0.0.0-alpha8",
                 "propel/propel1": ">=1,<1.7.2",
                 "psy/psysh": "<=0.11.22|>=0.12,<=0.12.18",
-                "pterodactyl/panel": "<1.12.3",
+                "pterodactyl/panel": "<=1.12.4",
                 "ptheofan/yii2-statemachine": ">=2.0.0.0-RC1-dev,<=2",
                 "ptrofimov/beanstalk_console": "<1.7.14",
                 "pubnub/pubnub": "<6.1",
@@ -1934,7 +1936,7 @@
                 "rap2hpoutre/laravel-log-viewer": "<0.13",
                 "react/http": ">=0.7,<1.9",
                 "really-simple-plugins/complianz-gdpr": "<6.4.2",
-                "redaxo/source": "<5.21",
+                "redaxo/source": "<5.21.1",
                 "remdex/livehelperchat": "<4.29",
                 "renolit/reint-downloadmanager": "<4.0.2|>=5,<5.0.1",
                 "reportico-web/reportico": "<=8.1",
@@ -2048,6 +2050,7 @@
                 "sylius/admin-bundle": ">=1,<1.0.17|>=1.1,<1.1.9|>=1.2,<1.2.2",
                 "sylius/grid": ">=1,<1.1.19|>=1.2,<1.2.18|>=1.3,<1.3.13|>=1.4,<1.4.5|>=1.5,<1.5.1",
                 "sylius/grid-bundle": "<1.10.1",
+                "sylius/mollie-plugin": "<2.2.8|>=3,<3.2.4|>=3.3,<3.3.1",
                 "sylius/paypal-plugin": "<1.6.2|>=1.7,<1.7.2|>=2,<2.0.2",
                 "sylius/resource-bundle": ">=1,<1.3.14|>=1.4,<1.4.7|>=1.5,<1.5.2|>=1.6,<1.6.4",
                 "sylius/sylius": "<1.9.12|>=1.10,<1.10.16|>=1.11,<1.11.17|>=1.12,<=1.12.22|>=1.13,<=1.13.14|>=1.14,<=1.14.17|>=2,<2.0.18|>=2.1,<2.1.15|>=2.2,<2.2.6",
@@ -2225,7 +2228,8 @@
                 "wnx/laravel-backup-restore": "<=1.9.3",
                 "woocommerce/woocommerce": "<6.6|>=8.8,<8.8.5|>=8.9,<8.9.3",
                 "wp-cli/wp-cli": ">=0.12,<2.5",
-                "wp-graphql/wp-graphql": "<=1.14.5",
+                "wp-coding-standards/wpcs": ">=0.14.1,<3.4.1",
+                "wp-graphql/wp-graphql": "<=2.6",
                 "wp-premium/gravityforms": "<2.4.21",
                 "wpanel/wpanel4-cms": "<=4.3.1",
                 "wpcloud/wp-stateless": "<3.2",
@@ -2331,7 +2335,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-17T19:07:03+00:00"
+            "time": "2026-08-03T22:59:19+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -3288,16 +3292,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.42",
+            "version": "v6.4.43",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "9ef84af84a7b66396da483634227650506428639"
+                "reference": "3b643aa587acbc42f967a429af088a56ed8f046d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/9ef84af84a7b66396da483634227650506428639",
-                "reference": "9ef84af84a7b66396da483634227650506428639",
+                "url": "https://api.github.com/repos/symfony/console/zipball/3b643aa587acbc42f967a429af088a56ed8f046d",
+                "reference": "3b643aa587acbc42f967a429af088a56ed8f046d",
                 "shasum": ""
             },
             "require": {
@@ -3362,7 +3366,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.42"
+                "source": "https://github.com/symfony/console/tree/v6.4.43"
             },
             "funding": [
                 {
@@ -3382,7 +3386,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-15T05:35:29+00:00"
+            "time": "2026-07-26T14:44:19+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",

--- a/lib/Controller/ChallengeController.php
+++ b/lib/Controller/ChallengeController.php
@@ -43,11 +43,20 @@ final class ChallengeController extends ALoginSetupController {
 		parent::__construct($appName, $request);
 	}
 
-	/*
+	/**
 	 * The service cooldown is the configurable source of truth. The rate limit
 	 * is an atomic backstop against concurrent bursts: period 60s matches the
 	 * minimum allowed resend cooldown (currently 1 minute), so it never rejects a
 	 * legitimately allowed resend.
+	 *
+	 * The annotation duplicates the attribute below on purpose. Nextcloud 33
+	 * exempts a route from the two-factor gate through the docblock only — its
+	 * TwoFactorMiddleware asks hasAnnotation('NoTwoFactorRequired') — while the
+	 * attribute exists from Nextcloud 34 on. With the attribute alone, a resend on
+	 * Nextcloud 33 gets a redirect to the provider selection instead of a new code.
+	 * Drop the annotation once the app requires Nextcloud 34.
+	 *
+	 * @NoTwoFactorRequired
 	 */
 	#[NoAdminRequired]
 	#[NoTwoFactorRequired]

--- a/lib/Controller/ChallengeController.php
+++ b/lib/Controller/ChallengeController.php
@@ -49,12 +49,14 @@ final class ChallengeController extends ALoginSetupController {
 	 * minimum allowed resend cooldown (currently 1 minute), so it never rejects a
 	 * legitimately allowed resend.
 	 *
-	 * The annotation duplicates the attribute below on purpose. Nextcloud 33
-	 * exempts a route from the two-factor gate through the docblock only — its
-	 * TwoFactorMiddleware asks hasAnnotation('NoTwoFactorRequired') — while the
-	 * attribute exists from Nextcloud 34 on. With the attribute alone, a resend on
-	 * Nextcloud 33 gets a redirect to the provider selection instead of a new code.
-	 * Drop the annotation once the app requires Nextcloud 34.
+	 * The annotation below duplicates the #[NoTwoFactorRequired] attribute on purpose.
+	 * Nextcloud 32 and 33 read the exemption from the docblock only. Their
+	 * TwoFactorMiddleware calls hasAnnotation('NoTwoFactorRequired'). The attribute
+	 * was added in Nextcloud 34. With the attribute alone, a resend on 32 or 33 is
+	 * answered with a redirect to the provider selection, so no new code is sent.
+	 *
+	 * Do not remove the annotation on this branch. The 3.3 line exists to serve
+	 * Nextcloud 32, so its lowest supported server will never be 34.
 	 *
 	 * @NoTwoFactorRequired
 	 */

--- a/package-lock.json
+++ b/package-lock.json
@@ -984,9 +984,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3592,9 +3592,9 @@
       "license": "MIT"
     },
     "node_modules/@vue/language-core/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4166,16 +4166,16 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -5376,9 +5376,9 @@
       "license": "MIT"
     },
     "node_modules/editorconfig/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5609,9 +5609,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
-      "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -5621,7 +5621,7 @@
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/config-helpers": "^0.7.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
@@ -5645,7 +5645,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -6062,9 +6062,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -6518,9 +6518,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6661,9 +6661,9 @@
       "license": "ISC"
     },
     "node_modules/happy-dom": {
-      "version": "20.11.0",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.0.tgz",
-      "integrity": "sha512-XogN4asPd1a56di9prVG6bZxteNcXsZxxKmAvcEfc5Px5Ca2hMyMgk8wvqK2K1V8zXg40j9VANXsDaJYh9DeNA==",
+      "version": "20.11.1",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.1.tgz",
+      "integrity": "sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9383,9 +9383,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -12299,9 +12299,9 @@
       "optional": true
     },
     "node_modules/webdav/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "twofactor_email",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "twofactor_email",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "twofactor_email",
   "description": "Two-Factor Email Provider",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "type": "module",
   "author": {
     "name": "Christoph Wurst",

--- a/package.json
+++ b/package.json
@@ -68,8 +68,7 @@
     "npm": "^11.0.0"
   },
   "overrides": {
-    "esbuild": "^0.28.1",
-    "fast-xml-parser": "^5.7.0"
+    "esbuild": "^0.28.1"
   },
   "devDependencies": {
     "@mdi/js": "^7.4.47",


### PR DESCRIPTION
3.4 dropped Nextcloud 32, so for those installations 3.3 is the last available version — and the resend button is dead there. This is the maintenance release that fixes it, plus the dependency refresh.

## The defect

Nextcloud 32 and 33 read the two-factor exemption from the **docblock annotation** only; their `TwoFactorMiddleware` calls `hasAnnotation('NoTwoFactorRequired')`. The PHP attribute was added in Nextcloud 34. With the attribute alone, `challenge/resend` is answered with a redirect to the provider selection instead of a new code.

It was never a regression. Resend arrived in 3.2.0, and both 3.2.0 and 3.3.0 carry the attribute without the annotation, so the button has been dead on those servers since it shipped. `main` fixed this for the 3.4 line in 3.4.1 (5faf160d); this is the backport.

## Evidence

Run with the smoke harness from `main` against the built 3.3.1 package:

| Server | Result |
|---|---|
| Nextcloud 32 | 29/29, including resend, its cooldown, the successful resend and a second mail |
| Nextcloud 33 | 29/29 |
| Nextcloud 34 | 29/29 |

Counter-proof on Nextcloud 32: the same package with only the `@NoTwoFactorRequired` line deleted answers the resend with **303** and redirects to `/login/selectchallenge` — three failing checks, exactly the reported symptom. So the one line is the cause, not a coincidence.

## Dependencies

In-range updates only, so the branch keeps supporting Nextcloud 32 and PHP 8.1. This clears every advisory with a fix available — `fast-uri` 3.1.5, `postcss` 8.5.25, `brace-expansion` 5.0.9 — plus eslint 10.8.0, happy-dom 20.11.1 and `symfony/console` 6.4.43. What remains is the seven low findings in the `elliptic` chain, which have no fix and do not ship.

Deliberately not raised, because the branch has to keep its Nextcloud 32 and PHP 8.1 floor: `christophwurst/nextcloud_testing` 2→3 and vite 7→8 are majors, and `nextcloud/coding-standard` stays pinned exactly, since a style tool that moves can demand reformatting in a patch release. `vendor-bin/cs-fixer` was checked with `composer bin all outdated` and left alone for that reason.

## What the review changed

`/code-review max` against this branch found fifteen points. The one that mattered: **`test.yml` only triggered for pull requests into `main`**. This is the first branch that is not an ancestor of `main`, so this pull request would have looked green from the lint jobs while the 146 PHP tests and every Nextcloud 32/33/34 install-and-run job never fired — on a release whose entire content is a Nextcloud 32 compatibility fix. It now also triggers for `release/**`.

The rest: the docblock said "Nextcloud 33" although the floor here is 32, and repeated main's "remove it once the app requires 34", which this line will never reach; the changelog claimed a regression that never existed and filed an advisory-driven update as `Changed` rather than `Security`; the documentation links still pointed at wiki pages that moved into `doc/` with 3.4.0; the screenshot URLs followed `main`, so the first refresh there would have shown Nextcloud 32 admins a UI they cannot install; and the `fast-xml-parser` override no longer changed anything — removing it leaves the lockfile byte-identical, which is the proof.

Two findings belong to `main`, not here, and are tracked separately: the resend error path that hides the link permanently when no address is available (identical code on `main`), and `npm-audit-fix.yml`, whose matrix has to gain `release/3.3` on `main`, because GitHub only schedules cron workflows from the default branch.

## Checks

php-cs-fixer 0 of 74, psalm exit 0 (via the legacy PHP, psalm 6 does not run on 8.5), 146 PHP tests, 77 Vitest tests, eslint and stylelint clean, `info.xml` validates against the schema, the build succeeds, and `npm install --package-lock-only` reproduces the lockfile unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
