### PR TITLE
Pin the deliberate behaviour of the no-email resend path

### DIFF
--- a/src/LoginChallenge.js
+++ b/src/LoginChallenge.js
@@ -89,6 +89,9 @@ document.addEventListener('DOMContentLoaded', () => {
 				// The cooldown has not elapsed. retryAfter (seconds) comes from our controller.
 				startCountdown((data && data.retryAfter) || cooldown)
 			} else if (data && data.error === 'no-email') {
+				// The link stays hidden on purpose. Without an address the next attempt
+				// fails the same way, so offering the button again only invites a click
+				// that cannot work. The user has to ask an administrator first.
 				status.textContent = t('twofactor_email', 'No email address available, please contact your administrator.')
 			} else {
 				Logger.error('failed to resend two-factor email code', error)

--- a/src/LoginChallenge.test.js
+++ b/src/LoginChallenge.test.js
@@ -83,14 +83,17 @@ describe('LoginChallenge resend', () => {
 		expect(status.textContent).toContain('1 minute')
 	})
 
-	it('reports a missing email address', async () => {
+	it('reports a missing email address and keeps the link hidden', async () => {
 		Axios.post.mockRejectedValue({ response: { status: 400, data: { error: 'no-email' } } })
-		const { status } = render({ availableIn: 0 })
+		const { link, status } = render({ availableIn: 0 })
 
-		document.querySelector('.twofactor_email-resend').click()
+		link.click()
 		await vi.advanceTimersByTimeAsync(0)
 
 		expect(status.textContent).toContain('contact your administrator')
+		// Deliberate, and the one error path that does not offer the link again: until
+		// an administrator sets an address, another attempt fails the same way.
+		expect(link.hidden).toBe(true)
 	})
 
 	it('reports a generic failure and offers the link again', async () => {


### PR DESCRIPTION
A review of the 3.3 backport read the `no-email` branch of the resend error handling as a defect: it is the one error path that does not restore the resend link, so the button stays hidden until the login page is reloaded.

It is deliberate. Without an address on the account the next attempt fails the same way, so offering the button again invites a click that cannot work. The test beside it is already named *reports a generic failure and offers the link again* — that is the distinction being drawn. What was missing is that nothing said so: the intent lived only in the absence of a line.

The comment now states it and the test asserts it, so changing the behaviour later has to be a decision rather than an accident. Verified by inverting the behaviour: the new assertion fails.

No behaviour change — a comment, an assertion, and the test now uses the `link` it already destructures, like its siblings.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.