### PR TITLE
Repair the code fence broken in #172

### DIFF
--- a/doc/development-setup.md
+++ b/doc/development-setup.md
@@ -94,13 +94,14 @@ working tree instead:
 ```bash
 composer install -o && npm ci && npm run build
 APP_DIR="$(git rev-parse --show-toplevel)" ./smoke.sh
-``` The options, what the checks cover,
-and a list of things that behave surprisingly are in
-[tests/smoke/README.md](../tests/smoke/README.md).
+```
 
-Testing the **built package** rather than the working tree is deliberate: it is what
-users get, and it catches what a checkout hides — `krankerl` packages the committed
-state, so an uncommitted fix is simply not in it.
+Prefer the packaged run before a release, though: it is what users get, and it catches
+what a checkout hides — a file missing from the release because of `.nextcloudignore`
+cannot show up when the working tree is mounted.
+
+The options, what the checks cover, and a list of things that behave surprisingly are
+in [tests/smoke/README.md](../tests/smoke/README.md).
 
 If the Docker daemon refuses to start with `error initializing graphdriver: driver not
 supported`, the kernel was updated without a reboot since — the modules of the running


### PR DESCRIPTION
#172 replaced a paragraph in `doc/development-setup.md` and cut it mid-sentence: the pointer to `tests/smoke/README.md` ended up glued to the closing ``````, so the fence no longer closed the block and everything after it rendered as code.

My mistake, and one a diff review would not catch — the diff was correct line by line; only the rendered page is wrong.

While repairing it, the duplicated claim goes as well. The section stated twice that `krankerl` packages the committed state. What was worth keeping is *why* the packaged run is the better one before a release, and that is more concrete than "it is what users get": a file missing from the release because of `.nextcloudignore` cannot show up when the working tree is mounted.

Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.