### PR TITLE
Wait for HTTP before declaring the smoke instance ready

### DIFF
--- a/tests/smoke/README.md
+++ b/tests/smoke/README.md
@@ -124,6 +124,12 @@ That still needs a person with a browser — `KEEP=1` leaves an instance running
 
 ## Things that cost hours, written down so they cost you none
 
+- **"No request token on `/login`" means the server is not answering yet**, not that the
+  login page changed. `occ status` reporting `installed: true` goes through
+  `docker compose exec` and says nothing about Apache. The CI hit this on a loaded
+  runner: the same commit passed in one run and failed in the next, on one server
+  version only, with everything after the first check reporting 401 or an empty
+  response. `setup.sh` now waits for `/login` to answer before it returns.
 - **The request token goes in a header, not in a form field.** It is base64 and often
   contains a `+`, which PHP turns into a space while decoding a form body. As a form
   field the same request therefore works about one time in three, which looks like a

--- a/tests/smoke/setup.sh
+++ b/tests/smoke/setup.sh
@@ -158,6 +158,60 @@ occ_write() {
 occ_write user:setting admin settings email admin@example.org
 occ_write app:enable twofactor_email
 
+# Wait for HTTP too, not only for occ. `occ status` goes through docker exec, so it
+# reports "installed" while Apache may still be unable to serve a request. Whoever runs
+# next then talks to a server that is not there yet, and the first failure reads
+# "no request token on /login" followed by empty responses — which looks like the login
+# page changed rather than like a race. That is what happened to the CI on 2026-08-05:
+# the same commit passed in one run and failed in the next, on one server version only.
+# The budget is a deadline, not a number of attempts: a single attempt has to be allowed
+# to take long enough for the FIRST render of a fresh instance, which builds the asset
+# caches, while the total still cannot run away. A connection refusal — the case this
+# waits for — comes back instantly, so the per-attempt limit only ever applies to a
+# response that is already being generated. Aborting those would be actively harmful:
+# PHP's ignore_user_abort defaults to 0, so each abandoned probe kills a render halfway
+# through, and the caches it was building are what the asset checks read later.
+# `--noproxy` because an http_proxy in the environment would otherwise be asked to
+# resolve localhost.
+printf 'waiting for the server to answer '
+ready=0
+code=none
+deadline=$((SECONDS + 120))
+while [ "$SECONDS" -lt "$deadline" ]; do
+	code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 --noproxy localhost \
+		"http://localhost:$HTTP_PORT/login" || true)
+	case $code in
+	200 | 303)
+		ready=1
+		break
+		;;
+	4??)
+		# Answered, and not with something that becomes 200 by waiting: an untrusted
+		# domain is 400, a missing rewrite 404. Report it now instead of after the
+		# full budget.
+		echo ''
+		echo "The server answers on http://localhost:$HTTP_PORT/login with $code." >&2
+		echo "That will not change by waiting. 400 usually means the domain is not" >&2
+		echo "trusted; 404 means the request never reached Nextcloud." >&2
+		echo "Remove the instance with 'docker compose down -v'." >&2
+		exit 1
+		;;
+	esac
+	printf '.'
+	sleep 2
+done
+if [ "$ready" = 1 ]; then
+	echo ' done'
+else
+	echo ''
+	echo "The server does not answer on http://localhost:$HTTP_PORT (last status: $code)." >&2
+	echo "The instance is up, so look at 'docker compose logs nextcloud'." >&2
+	echo "If your docker daemon is not local (DOCKER_HOST), the published port is not" >&2
+	echo "on localhost and this check cannot work — that is a limitation, not a fault." >&2
+	echo "Remove the instance with 'docker compose down -v'." >&2
+	exit 1
+fi
+
 cat <<TXT
 
 Nextcloud   http://localhost:$HTTP_PORT   (admin / admin)


### PR DESCRIPTION
The smoke test failed on Nextcloud 33 on `main` while **the same code passed in the run before it**, and passed on 34 in the same run — the two commits differ by one Markdown file. The first failure was `no request token on /login`, then empty responses and 401 for everything after.

A race, not a regression. `setup.sh` waited for `occ status` to report `installed: true`, and `occ` goes through `docker compose exec` — it says nothing about whether Apache can serve a request yet. On a loaded runner the checks start against a server that is not answering, and the symptom points at the login page instead of at the timing.

Ruled out first: the `33-apache` tag *had* moved that morning (local image from 23 July, registry from 05 August 01:44), but a local run with the new image passes.

`setup.sh` now polls `/login` until it answers. Three details are deliberate, two of them from the review:

- **The budget is a deadline, not a count of attempts.** One attempt has to be allowed to take as long as the first render of a fresh instance, which builds the asset caches, while the total stays bounded. A refused connection returns instantly, so the per-attempt limit only ever applies to a response that is already being generated — and aborting those is harmful: PHP's `ignore_user_abort` defaults to 0, so each abandoned probe kills a render halfway, and those caches are what the asset checks read later.
- **A 4xx ends the wait immediately.** An untrusted domain answers 400, a missing rewrite 404; neither becomes 200 by waiting.
- **`--noproxy localhost`**, because an `http_proxy` in the environment would otherwise be asked to resolve localhost. The remaining limitation is named in the failure message: with a non-local docker daemon the published port is not on localhost and this check cannot work.

Verified in all three directions: the happy path on 33, an immediate exit against a 404 (mailpit's port as the probe, 0 s), and the deadline holding at 121 s against a closed port.

The lesson is also in the README's *things that cost hours* list — the misleading symptom is what cost the time, not the fix.

Merging this also makes `main` green again; the failed run cannot be restarted with the token available here.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.