### PR TITLE
Correct the claim that Psalm needs an older PHP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,11 @@ npm run lint && npm run stylelint && npm test && npm run build
 krankerl package                  # release package
 ```
 
-Psalm runs on the app's **minimum** PHP version and does not support newer runtimes;
-if your default PHP is newer, invoke it with the older one.
+Psalm **analyses** against the app's minimum PHP version — `phpVersion` in `psalm.xml`,
+and the CI checks that the two agree. That is independent of the interpreter it **runs**
+on: Psalm 6.16.1 runs fine on PHP 8.5, verified on 8.5.9 for both the normal and the
+taint pass. If a future version does cap the runtime, the error says so; do not reach
+for an older interpreter without one.
 
 Run the checks that match your diff **before** opening a pull request. CI is the gate,
 but finding it locally is cheaper for everyone.

--- a/doc/developers.md
+++ b/doc/developers.md
@@ -20,10 +20,11 @@ Contributions are welcome — see [CONTRIBUTORS](../CONTRIBUTORS.md).
    composer test:unit:dev && composer psalm && composer cs:check
    npm run lint && npm run stylelint && npm test && npm run build
    ```
-   `composer cs:fix` applies the style fixes automatically. Some of the tools cap
-   the PHP version they accept — Psalm in particular — so if your distribution
-   ships a newer default PHP you need an older interpreter for them (on Arch
-   Linux, for example, `php-legacy vendor/bin/psalm.phar`).
+   `composer cs:fix` applies the style fixes automatically. Note that Psalm
+   *analyses* against the minimum PHP version the app supports, set as `phpVersion`
+   in `psalm.xml`; that is not a limit on the interpreter it runs on. Should a tool
+   ever refuse your default PHP, it says so, and an older interpreter next to it
+   helps (on Arch Linux, for example, `php-legacy vendor/bin/psalm.phar`).
 4. **Add SPDX headers to new files.** The project is [REUSE](https://reuse.software/) compliant and CI enforces it; files that cannot carry a header (images, generated files) are annotated centrally in `REUSE.toml`.
 5. **Describe *why* in the commit message**, not *what* — the diff already shows what changed.
 6. **CI is the gate.** All checks have to pass; a red run will not be merged.


### PR DESCRIPTION
`CLAUDE.md` and `doc/developers.md` both told contributors that Psalm does not support newer runtimes and has to be invoked with an older interpreter. That is wrong, and it conflated two different things.

Psalm **analyses** against the app's minimum PHP version — `phpVersion` in `psalm.xml`, which `psalm.yml` checks against the derived minimum. That says nothing about the interpreter Psalm **runs** on.

Verified with a cleared cache on PHP 8.5.9, the default here:

| Pass | Result |
|---|---|
| `psalm` | No errors found, 5.03 s |
| `psalm:taint` | No errors found, 3.48 s |

The strongest evidence was already in the repositories: the v2 line has been running Psalm on PHP 8.5 in CI all along — its `static-analysis.yml` matrix has that cell, and it is green. The instruction was contradicted by our own CI.

Where the claim came from could not be established. `psalm/phar` declares no PHP constraint, so if an older 6.x did refuse 8.5 it did so at runtime, and that is not recoverable now. The correction therefore names the version it was verified at, rather than making a timeless claim that can rot the same way — and says what to do if a future version really does cap the runtime: the error will say so.

Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.