### PR TITLE
Release 3.4.2 with the DOMPurify fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.4.2 (2026-08-11)
+
+### Security
+
+- Update dependencies to fix the DOMPurify advisory
+
 ## 3.4.1 (2026-07-26)
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -42,7 +42,7 @@ Mind that, once a user enabled any 2FA provider, they can no longer use their
 password in applications that don't support the web-based 2FA login flow. For
 such applications, the user needs to create and use app passwords (to be found
 at the bottom of "Personal Settings/Security").]]></description>
-    <version>3.4.1</version>
+    <version>3.4.2</version>
     <licence>agpl</licence>
     <author mail="twofactor-email@datenschutz-individuell.de">
         Olav Seyfarth (datenschutz-individuell) [see CONTRIBUTORS.md for more]

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "bamarni/composer-bin-plugin": "^1.9.1",
     "christophwurst/nextcloud_testing": "^3.0",
     "nextcloud/ocp": "^33 || ^34",
-    "psalm/phar": "^6.16",
+    "psalm/phar": "^6.16.1",
     "roave/security-advisories": "dev-latest",
     "symfony/console": "^6.4.42"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "314df2bb26f1e75ec3cf2001b7ced360",
+    "content-hash": "498f898b10c5c5ce1f45328c3d7632fb",
     "packages": [],
     "packages-dev": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "twofactor_email",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "twofactor_email",
-      "version": "3.4.1",
+      "version": "3.4.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "twofactor_email",
   "description": "Two-Factor Email Provider",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "type": "module",
   "author": {
     "name": "Christoph Wurst",

--- a/vendor-bin/cs-fixer/composer.lock
+++ b/vendor-bin/cs-fixer/composer.lock
@@ -106,16 +106,16 @@
         },
         {
             "name": "php-cs-fixer/shim",
-            "version": "v3.95.17",
+            "version": "v3.95.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/shim.git",
-                "reference": "fe9462e0b3e59b33ee076f6eda626b474b8cf363"
+                "reference": "9b815f2ba5c581faaaec1386dcda4c16d511e6bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/shim/zipball/fe9462e0b3e59b33ee076f6eda626b474b8cf363",
-                "reference": "fe9462e0b3e59b33ee076f6eda626b474b8cf363",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/shim/zipball/9b815f2ba5c581faaaec1386dcda4c16d511e6bb",
+                "reference": "9b815f2ba5c581faaaec1386dcda4c16d511e6bb",
                 "shasum": ""
             },
             "require": {
@@ -152,9 +152,9 @@
             "description": "A tool to automatically fix PHP code style",
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/shim/issues",
-                "source": "https://github.com/PHP-CS-Fixer/shim/tree/v3.95.17"
+                "source": "https://github.com/PHP-CS-Fixer/shim/tree/v3.95.18"
             },
-            "time": "2026-07-24T13:55:04+00:00"
+            "time": "2026-07-30T15:46:28+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
Turns the dependency fix that landed in #183 into a release, rather than letting it wait for the next feature.

## Why its own release

`dompurify` 3.4.12 and earlier leave a detached subtree executable when an `IN_PLACE` hook is removed, an XSS vector ([GHSA-55q2-fjhq-7xh7](https://github.com/advisories/GHSA-55q2-fjhq-7xh7)). It reaches users: through `@nextcloud/l10n` and `@nextcloud/vue`, both runtime dependencies, and into the bundle we ship.

The alternative was to wait for #178, which closes the code-level leak this whole audit started from and is still with its reviewer. A finished security fix should not wait for an unfinished one.

## What is in this PR

The dependency change itself is already on `main` (#183). This adds what a release needs: the changelog section, the version in all four places, `psalm/phar`'s declared floor raised to the installed `^6.16.1`, and `php-cs-fixer/shim` refreshed in range.

`nanoid` and `js-yaml`, which the same lock file refresh closed, get no changelog line — both are dev-only and never reach the bundle. The changelog answers what an admin can observe.

## Cross-checks

The 3.3 line carried the identical `dompurify@3.4.12` and was invisible to Dependabot, which only scans the default branch. It is fixed in #184, released as 3.3.2.

The v2 repository had only a dev-only `nanoid` finding, so nothing there reaches a user and no release follows.

## Test status

146 PHP tests, 80 JS tests, `psalm` and `psalm:taint` without findings, `cs:check`, ESLint, Stylelint and the build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
