### PR TITLE
Warn early when the next Nextcloud would break us

### DIFF
--- a/.github/workflows/nextcloud-next.yml
+++ b/.github/workflows/nextcloud-next.yml
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+# SPDX-License-Identifier: MIT
+
+# Early warning against the Nextcloud release that is not out yet.
+#
+# The supported range in appinfo/info.xml drives every other workflow, and it
+# must not name a version that cannot be built against: nextcloud-deps/ocp only
+# grows a stableNN branch around that version's release candidate, so until then
+# `dev-stableNN` does not resolve. The next release lives on master.
+#
+# This job therefore builds against master instead of the declared range, and it
+# never blocks: it answers "would we still work on the next server", not "may
+# this merge".
+#
+# It needs no maintenance when a version ships. master is always the next
+# release, so once 35 is declared in info.xml, this keeps watching 36, then 37.
+# The one time it may be worth switching off is the weeks right after a release,
+# when master has just opened and churns; disable it in the Actions tab rather
+# than deleting it, so it is there for the next round.
+
+name: Nextcloud next
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches:
+      - main
+  schedule:
+    # Weekly, so upstream breakage surfaces even in a week without a pull request
+    - cron: '19 6 * * 1'
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    name: Unit tests against Nextcloud master
+
+    steps:
+      # 8.5 like the ordinary unit tests: the highest version this app declares,
+      # which is also what Nextcloud 35 recommends. The low end is covered better
+      # elsewhere — php-lint runs every declared version, psalm runs the floor.
+      - name: Set up php8.5
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          php-version: '8.5'
+          extensions: ctype,curl,dom,gd,iconv,intl,json,mbstring,openssl,posix,sqlite,xml,zip
+          coverage: none
+
+      - name: Checkout Nextcloud
+        run: git clone https://github.com/nextcloud/server.git --recursive --depth 1 -b master nextcloud
+
+      - name: Install Nextcloud
+        run: php -f nextcloud/occ maintenance:install --database-host 127.0.0.1 --database-name nextcloud --database-user nextcloud --database-pass nextcloud --admin-user admin --admin-pass admin --database sqlite
+
+      - name: Checkout app
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: nextcloud/apps/twofactor_email
+          persist-credentials: false
+
+      - name: Install dependencies
+        working-directory: nextcloud/apps/twofactor_email
+        run: composer install
+
+      - name: Run tests
+        working-directory: nextcloud/apps/twofactor_email
+        run: composer run test:unit:dev
+
+  static-analysis:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    name: Psalm against the OCP of Nextcloud master
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # 8.2 like the ordinary psalm job, so this differs from it in exactly one
+      # thing: the OCP it analyses against. psalm.xml targets 8.2 either way.
+      - name: Set up php8.2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          php-version: '8.2'
+          extensions: ctype,curl,dom,gd,iconv,intl,json,mbstring,openssl,posix,sqlite,xml,zip
+          coverage: none
+          ini-file: development
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dependencies
+        run: |
+          composer remove nextcloud/ocp --dev --no-scripts
+          composer i
+
+      - name: Install the OCP of Nextcloud master
+        run: composer require --dev nextcloud/ocp:dev-master --ignore-platform-reqs --with-dependencies
+
+      - name: Run static analysis
+        run: composer run psalm -- --threads=1 --monochrome --no-progress --output-format=github
+
+      - name: Run taint analysis
+        run: composer run psalm:taint -- --threads=1 --monochrome --no-progress --output-format=github


### PR DESCRIPTION
Nextcloud 35 reached beta 1 today and is due on **2026-09-16**. This adds an early-warning workflow so a breaking change upstream shows up here rather than in a bug report.

## Why not simply add 35 to the supported range

Every workflow derives its versions from `appinfo/info.xml`, and `nextcloud-deps/ocp` only grows a `stableNN` branch around that version's release candidate. Today it has `master`, `stable33`, `stable34` — so `dev-stable35` does not resolve and the Psalm job would fail. The versioned documentation under `/server/35/` does not exist yet either.

Declaring `max-version="35"` is therefore a promise we cannot yet build against. It becomes the usual four-file change once `stable35` appears, expected around RC 1 on **2026-08-20**.

## What this does instead

A separate workflow that builds against `master` — where Nextcloud 35 lives until then:

- unit tests inside a Nextcloud checked out from `master`
- Psalm and taint analysis against that `master`'s OCP

Each job runs on the PHP version its ordinary counterpart already uses — 8.5 for the unit tests, 8.2 for the analysis — so it differs from that counterpart in exactly one thing: the Nextcloud it builds against. A failure here can therefore only come from the newer server. Both carry `continue-on-error`. The job answers "would we still work on the next server", not "may this merge" — the release gate stays exactly as it was. A weekly schedule catches upstream breakage in weeks without a pull request.

## The Nextcloud 35 changes, checked against this code today

Nothing applies. Each one was grepped, not recalled:

| change | finding |
|---|---|
| Eight removed frontend globals (`oc_appswebroots`, `oc_config`, `oc_current_user`, `oc_debug`, `oc_defaults`, `oc_isadmin`, `oc_requesttoken`, `oc_webroot`, `OCDialogs`) | none used |
| Removed remote APIs, `IPreview::registerProvider`, `AutoCompleteEvent`, `IRootFolder` emitter, calendar/room managers | 0 hits |
| phpseclib 2 → 3 | not installed — it appears in `composer.lock` only through `roave/security-advisories` |
| MariaDB 10.6 / MySQL 8.0 dropped, stricter `GROUP BY`, MD5 deprecated | no schema and no queries; the single `SimpleMigrationStep` implements `postSchemaChange` alone |
| PHP 8.2 dropped, minimum 8.3 | applies to the **server**, not to us. No PHP feature newer than the declared 8.2 floor is in the code, so supporting 35 later will not cost us Nextcloud 33 |

Also checked, and the answer is no: there is no new Nextcloud API worth adopting that is available across the whole range the app would then support.

## When 35 is out

Add it to `info.xml`, `composer.json` and `psalm.xml`, smoke-test against `NC_TAG=35-apache`, release.

**This workflow stays.** Nothing in it names version 35 — it watches `master`, and `master` is always the next release, so once 35 is declared it keeps watching 36, then 37, with no edit. The one time it may be worth switching off is the weeks right after a release, when `master` has just opened and churns; disable it in the Actions tab rather than removing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
