### PR TITLE
Test the whole supported range, not only its upper end

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -21,7 +21,15 @@ jobs:
   static-analysis:
     runs-on: ubuntu-latest
 
-    name: static-psalm-analysis
+    strategy:
+      fail-fast: false
+      matrix:
+        # Both ends of the supported range. Against the newest OCP this finds an
+        # API that Nextcloud has removed; against the oldest it finds one that
+        # does not exist there yet. Only checking the newest sees half of that.
+        ocp: [min, max]
+
+    name: static-psalm-analysis (ocp ${{ matrix.ocp }})
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -51,7 +59,7 @@ jobs:
           composer i
 
       - name: Install nextcloud/ocp
-        run: composer require --dev nextcloud/ocp:dev-${{ steps.versions.outputs.branches-max }} --ignore-platform-reqs --with-dependencies
+        run: composer require --dev nextcloud/ocp:dev-${{ matrix.ocp == 'min' && steps.versions.outputs.branches-min || steps.versions.outputs.branches-max }} --ignore-platform-reqs --with-dependencies
 
       - name: Run coding standards check
         run: composer run psalm -- --threads=1 --monochrome --no-progress --output-format=github

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,11 @@ jobs:
   versions:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.versions.outputs.matrix }}
+      # full-matrix, not matrix: the latter gives one PHP per server, which was
+      # always the highest. The range in info.xml promises every version in it,
+      # and only running the tests proves the promise — php-lint merely parses
+      # and psalm never executes. Eight jobs of about a minute, run in parallel.
+      matrix: ${{ steps.versions.outputs.full-matrix }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: test-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   versions:
     runs-on: ubuntu-latest

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -60,7 +60,8 @@ factor be skipped, accepted twice or brute-forced outweighs any question of styl
   docblock silenced every undefined attribute on the route that skips the second
   factor, including a typo. `findUnusedIssueHandlerSuppression="false"` belongs to
   it, because the same handler is necessarily unused against the newest OCP. All of
-  it goes together when `min-version` reaches 34.
+  it goes together when `min-version` reaches 34 — and `CompatibilityShimsTest`
+  fails until it does, so this is enforced rather than remembered.
 - **`symfony/console` at `^6.4.42`**: Nextcloud bundles Symfony 6.4 and `occ` commands
   must match its major. This one has no expiry — it moves when Nextcloud moves.
 - **`@nextcloud/vite-config` pinned to a pre-release**: it is the only version that

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -54,9 +54,13 @@ factor be skipped, accepted twice or brute-forced outweighs any question of styl
 - **The duplicated `NoTwoFactorRequired`** in `ChallengeController::resend()`: the
   docblock annotation serves Nextcloud 33, the attribute serves 34 and is `@since 34`.
   Both are needed until `min-version` reaches 34. The docblock explains it, and so
-  does the `@psalm-suppress UndefinedAttributeClass` beside it — the attribute does
-  not exist in the oldest supported server's OCP, which the analysis now checks
-  against. All three go together when `min-version` reaches 34.
+  does the `UndefinedAttributeClass` handler in `psalm.xml` — the attribute does not
+  exist in the oldest supported server's OCP, which the analysis now checks against.
+  That handler names the **one** class on purpose; a suppression in the method's
+  docblock silenced every undefined attribute on the route that skips the second
+  factor, including a typo. `findUnusedIssueHandlerSuppression="false"` belongs to
+  it, because the same handler is necessarily unused against the newest OCP. All of
+  it goes together when `min-version` reaches 34.
 - **`symfony/console` at `^6.4.42`**: Nextcloud bundles Symfony 6.4 and `occ` commands
   must match its major. This one has no expiry — it moves when Nextcloud moves.
 - **`@nextcloud/vite-config` pinned to a pre-release**: it is the only version that

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -53,7 +53,10 @@ factor be skipped, accepted twice or brute-forced outweighs any question of styl
 
 - **The duplicated `NoTwoFactorRequired`** in `ChallengeController::resend()`: the
   docblock annotation serves Nextcloud 33, the attribute serves 34 and is `@since 34`.
-  Both are needed until `min-version` reaches 34. The docblock explains it.
+  Both are needed until `min-version` reaches 34. The docblock explains it, and so
+  does the `@psalm-suppress UndefinedAttributeClass` beside it — the attribute does
+  not exist in the oldest supported server's OCP, which the analysis now checks
+  against. All three go together when `min-version` reaches 34.
 - **`symfony/console` at `^6.4.42`**: Nextcloud bundles Symfony 6.4 and `occ` commands
   must match its major. This one has no expiry — it moves when Nextcloud moves.
 - **`@nextcloud/vite-config` pinned to a pre-release**: it is the only version that

--- a/lib/Controller/ChallengeController.php
+++ b/lib/Controller/ChallengeController.php
@@ -56,7 +56,15 @@ final class ChallengeController extends ALoginSetupController {
 	 * Nextcloud 33 gets a redirect to the provider selection instead of a new code.
 	 * Drop the annotation once the app requires Nextcloud 34.
 	 *
+	 * The attribute is the other half of the same shim, and it is why psalm has to
+	 * be told to look away here: analysed against the OCP of the oldest supported
+	 * server it does not exist yet. PHP resolves an attribute class only when
+	 * something reflects on it, so Nextcloud 33 never asks and never fails. The
+	 * suppression goes when the annotation does.
+	 *
 	 * @NoTwoFactorRequired
+	 *
+	 * @psalm-suppress UndefinedAttributeClass
 	 */
 	#[FrontpageRoute(verb: 'POST', url: '/challenge/resend')]
 	#[NoAdminRequired]

--- a/lib/Controller/ChallengeController.php
+++ b/lib/Controller/ChallengeController.php
@@ -56,15 +56,13 @@ final class ChallengeController extends ALoginSetupController {
 	 * Nextcloud 33 gets a redirect to the provider selection instead of a new code.
 	 * Drop the annotation once the app requires Nextcloud 34.
 	 *
-	 * The attribute is the other half of the same shim, and it is why psalm has to
-	 * be told to look away here: analysed against the OCP of the oldest supported
-	 * server it does not exist yet. PHP resolves an attribute class only when
-	 * something reflects on it, so Nextcloud 33 never asks and never fails. The
-	 * suppression goes when the annotation does.
+	 * The attribute is the other half of the same shim, and it is why psalm.xml
+	 * suppresses UndefinedAttributeClass for this one class: analysed against the OCP
+	 * of the oldest supported server it does not exist yet. PHP resolves an attribute
+	 * class only when something reflects on it, so Nextcloud 33 never asks and never
+	 * fails. That suppression goes when this annotation does.
 	 *
 	 * @NoTwoFactorRequired
-	 *
-	 * @psalm-suppress UndefinedAttributeClass
 	 */
 	#[FrontpageRoute(verb: 'POST', url: '/challenge/resend')]
 	#[NoAdminRequired]

--- a/psalm.xml
+++ b/psalm.xml
@@ -4,6 +4,7 @@
         phpVersion="8.2"
         findUnusedCode="false"
         ensureOverrideAttribute="false"
+        findUnusedIssueHandlerSuppression="false"
         autoloader="tests/bootstrap.php"
 >
     <projectFiles>
@@ -16,4 +17,16 @@
             <directory name="vendor/phpunit/php-code-coverage"/>
         </ignoreFiles>
     </extraFiles>
+	<issueHandlers>
+		<!-- One attribute, not one method: #[NoTwoFactorRequired] is @since 34 and the
+		     analysis also runs against the OCP of the oldest supported server, where it
+		     does not exist. A suppression in the docblock would have silenced every
+		     undefined attribute on that method, including a typo. Goes when min-version
+		     reaches 34, together with the docblock annotation beside it. -->
+		<UndefinedAttributeClass>
+			<errorLevel type="suppress">
+				<referencedClass name="OCP\AppFramework\Http\Attribute\NoTwoFactorRequired"/>
+			</errorLevel>
+		</UndefinedAttributeClass>
+	</issueHandlers>
 </psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -17,16 +17,18 @@
             <directory name="vendor/phpunit/php-code-coverage"/>
         </ignoreFiles>
     </extraFiles>
-	<issueHandlers>
-		<!-- One attribute, not one method: #[NoTwoFactorRequired] is @since 34 and the
-		     analysis also runs against the OCP of the oldest supported server, where it
-		     does not exist. A suppression in the docblock would have silenced every
-		     undefined attribute on that method, including a typo. Goes when min-version
-		     reaches 34, together with the docblock annotation beside it. -->
-		<UndefinedAttributeClass>
-			<errorLevel type="suppress">
-				<referencedClass name="OCP\AppFramework\Http\Attribute\NoTwoFactorRequired"/>
-			</errorLevel>
-		</UndefinedAttributeClass>
-	</issueHandlers>
+    <issueHandlers>
+        <!-- One attribute, not one method: #[NoTwoFactorRequired] is @since 34 and the
+             analysis also runs against the OCP of the oldest supported server, where it
+             does not exist. A suppression in the docblock would have silenced every
+             undefined attribute on that method, including a typo. This handler and the
+             findUnusedIssueHandlerSuppression attribute above are one unit and go
+             together when min-version reaches 34 — CompatibilityShimsTest fails until
+             they do. -->
+        <UndefinedAttributeClass>
+            <errorLevel type="suppress">
+                <referencedClass name="OCP\AppFramework\Http\Attribute\NoTwoFactorRequired"/>
+            </errorLevel>
+        </UndefinedAttributeClass>
+    </issueHandlers>
 </psalm>

--- a/tests/Unit/CompatibilityShimsTest.php
+++ b/tests/Unit/CompatibilityShimsTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Test\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A workaround for an old server outlives its reason quietly: nothing breaks when
+ * the version it served is dropped, it just sits there. This test makes the moment
+ * loud instead — it fails as soon as the supported range moves past the version a
+ * shim exists for, and names everything that has to go together.
+ */
+class CompatibilityShimsTest extends TestCase {
+	private const ROOT = __DIR__ . '/../..';
+
+	private function minimumNextcloudVersion(): int {
+		$info = file_get_contents(self::ROOT . '/appinfo/info.xml');
+		self::assertIsString($info, 'appinfo/info.xml is not readable');
+		self::assertSame(1, preg_match('/<nextcloud[^>]*min-version="(\d+)"/', $info, $m));
+		return (int)$m[1];
+	}
+
+	/**
+	 * Three pieces, one reason: Nextcloud 33 reads the two-factor exemption from the
+	 * docblock annotation and does not know the attribute, which is @since 34. The
+	 * attribute therefore has to sit next to the annotation, and psalm has to be told
+	 * that this one class is missing when it analyses against the oldest supported
+	 * OCP — which in turn needs the unused-suppression check switched off, because
+	 * the same handler is by nature unused against the newest OCP.
+	 *
+	 * Drop Nextcloud 33 and all three are dead weight around a security-relevant
+	 * route. Nobody would notice, so this test does.
+	 */
+	public function testTheNextcloud33ExemptionShimGoesWhenNextcloud33Does(): void {
+		$controller = file_get_contents(self::ROOT . '/lib/Controller/ChallengeController.php');
+		$psalm = file_get_contents(self::ROOT . '/psalm.xml');
+		self::assertIsString($controller);
+		self::assertIsString($psalm);
+
+		if ($this->minimumNextcloudVersion() >= 34) {
+			$this->assertStringNotContainsString(
+				'@NoTwoFactorRequired',
+				$controller,
+				'Nextcloud 33 is no longer supported: remove the @NoTwoFactorRequired docblock '
+				. 'annotation from ChallengeController::resend(). The attribute alone is enough now.',
+			);
+			$this->assertStringNotContainsString(
+				'UndefinedAttributeClass',
+				$psalm,
+				'Nextcloud 33 is no longer supported: remove the UndefinedAttributeClass handler '
+				. 'from psalm.xml. The attribute exists in every OCP the app is analysed against.',
+			);
+			$this->assertStringNotContainsString(
+				'findUnusedIssueHandlerSuppression',
+				$psalm,
+				'Nextcloud 33 is no longer supported: remove findUnusedIssueHandlerSuppression '
+				. 'from psalm.xml. It existed only for the handler above, and without it a stale '
+				. 'suppression would go unreported.',
+			);
+			return;
+		}
+
+		// While 33 is supported the three belong together: one without the others
+		// either breaks the resend route on 33 or turns one of the psalm runs red.
+		$this->assertStringContainsString('@NoTwoFactorRequired', $controller);
+		$this->assertStringContainsString('UndefinedAttributeClass', $psalm);
+		$this->assertStringContainsString('findUnusedIssueHandlerSuppression="false"', $psalm);
+	}
+}


### PR DESCRIPTION
`appinfo/info.xml` promises Nextcloud 33 and 34 on PHP 8.2 through 8.5. Two ends of that promise were never tested.

## What was missing

**The unit tests ran on PHP 8.5 alone**, once per server version. `php-lint` covers all four versions but only *parses*; psalm analyses without executing anything. So nothing ever ran this app's code on 8.2 — the version the range promises and the one an admin on Nextcloud 33 is most likely to have.

That is a poor place to be thin here. The security guarantee added in #178 rests on regular expressions: where a URL ends, what `/u` does to invalid UTF-8, how `preg_split` behaves on unusual bytes. That is precisely the class of behaviour that shifts between PHP versions.

**Psalm had the mirror image**: it analysed against the OCP of the *newest* supported server only. That finds an API Nextcloud has removed. It does not find one that does not exist in the oldest supported server yet.

So both floors were untested while both ceilings were covered twice — and the cheapest check ran across the whole range while the most telling one ran narrowest.

## What changed

| | before | after |
|---|---|---|
| unit tests | 2 jobs, php 8.5 only | 8 jobs, the full server × PHP product |
| psalm | OCP of the newest server | both ends of the range |

`icewind1991/nextcloud-version-matrix` already offers `full-matrix` and `branches-min`, so this is two small edits rather than a hand-built matrix.

## It found something on the first run

The OCP-floor job failed immediately, on `lib/Controller/ChallengeController.php:63`: `#[NoTwoFactorRequired]` does not exist in Nextcloud 33's OCP.

Not a defect — it is one half of the documented shim (33 reads the exemption from the docblock annotation, 34 from the attribute), and PHP resolves an attribute class only when something reflects on it, so 33 never asks. But it is precisely the class of thing this job exists to surface, and nothing else in the pipeline could see it. It is now suppressed where it occurs, with the reason and with the same expiry as the shim: annotation, attribute and suppression go together when `min-version` reaches 34.

## Cost

Six additional jobs of roughly a minute each, running in parallel, so the wall time barely moves.

## Not in this PR

The convention itself stays otherwise as it is, and deliberately so: `php-lint` across every declared version is cheap and catches syntax the floor rejects, and psalm's `phpVersion="8.2"` analysis target remains the floor, because static analysis should judge against the strictest supported version.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
