### PR TITLE
Smoke-test the next server as soon as it can be pulled

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tags: ${{ steps.read.outputs.tags }}
+      next-tag: ${{ steps.read.outputs.next-tag }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -45,16 +46,35 @@ jobs:
           min=$(printf '%s' "$spec" | grep -oP 'min-version="\K[0-9]+')
           max=$(printf '%s' "$spec" | grep -oP 'max-version="\K[0-9]+')
           if [ "$min" = "$max" ]; then
-            tags="[\"$min-apache\"]"
+            tags="\"$min-apache\""
           else
-            tags="[\"$min-apache\", \"$max-apache\"]"
+            tags="\"$min-apache\", \"$max-apache\""
           fi
-          echo "tags=$tags" >> "$GITHUB_OUTPUT"
-          echo "testing against: $tags"
+
+          # The server after the declared range, if the official image already has
+          # it. Nextcloud publishes a tag when a version is released, so this stays
+          # empty for most of a cycle and starts testing the moment it is not — no
+          # edit needed here when 35, then 36, then 37 appears. Nothing depends on
+          # it: the run is allowed to fail, see continue-on-error below.
+          next=$((max + 1))
+          if curl -sf "https://hub.docker.com/v2/repositories/library/nextcloud/tags/$next-apache" > /dev/null; then
+            echo "next-tag=$next-apache" >> "$GITHUB_OUTPUT"
+            tags="$tags, \"$next-apache\""
+            echo "the next server already has an image: $next-apache"
+          else
+            echo "next-tag=" >> "$GITHUB_OUTPUT"
+            echo "no image for Nextcloud $next yet"
+          fi
+
+          echo "tags=[$tags]" >> "$GITHUB_OUTPUT"
+          echo "testing against: [$tags]"
 
   smoke:
     needs: versions
     runs-on: ubuntu-latest
+    # The declared versions are a gate. The one after them is an early warning and
+    # must never block a merge — the app does not claim to support it yet.
+    continue-on-error: ${{ matrix.tag == needs.versions.outputs.next-tag }}
     strategy:
       fail-fast: false
       matrix:

--- a/tests/smoke/README.md
+++ b/tests/smoke/README.md
@@ -33,6 +33,20 @@ NC_TAG=34-apache ./setup.sh   # just an instance, no checks
 COMPOSE_PROJECT_NAME=tfe-2 HTTP_PORT=8081 MAIL_PORT=8026 ./smoke.sh   # a second instance
 ```
 
+### The server that is not out yet
+
+`NC_TAG` takes any tag of the official `nextcloud` image, and that is the limit: there
+is **no image for an unreleased version**. Nextcloud published `NN-beta` and `NN-rc`
+tags up to version 18 and stopped; today a tag appears when the version is released.
+So `NC_TAG=master` or `NC_TAG=35-apache` simply will not pull while 35 is in beta.
+
+Two things cover that gap instead. The `Nextcloud next` workflow runs the unit tests
+and Psalm against the server's `master` branch, which needs no image. And this smoke
+test picks the next version up **by itself**: its workflow asks the registry whether
+an image for the version after the declared range exists, and adds it to the run as
+soon as one does — as a warning, never as a gate. Nothing has to be edited for 35,
+then 36, then 37.
+
 `setup.sh` writes `tests/smoke/.env` (gitignored) with the values compose needs, which is
 why a later `docker compose down -v`, `logs` or `exec` works in that directory without
 setting anything. It records the **last** setup run, so with two instances around name the


### PR DESCRIPTION
Completes the early-warning coverage started in #186: the unit tests and Psalm already watch the next Nextcloud, the smoke test could not.

## Why it could not

The smoke test needs a *running* server, and the official `nextcloud` image has **no tag for an unreleased version**. Checked against Docker Hub today: `NN-beta` and `NN-rc` tags exist up to version 18 and were then abandoned; there is no `35`, no `master`, no `next`. So `NC_TAG=master` never had a chance to work.

## What it does now

The workflow asks the registry whether an image for the version *after* the declared range exists, and adds it to the matrix if so:

```
next=$((max + 1))
curl -sf ".../library/nextcloud/tags/$next-apache" && tags="$tags, \"$next-apache\""
```

Verified against the registry as it stands: `34-apache` is found, `35-apache` is not. So today the run is unchanged, and it starts the moment the image appears — for 35, then 36, then 37, with no edit here.

That entry carries `continue-on-error`, because the app does not claim to support a version it has not declared: a failure there is information, not a verdict. The declared versions stay the gate they were.

## Also

`tests/smoke/README.md` now states why `NC_TAG=master` does not work and what covers that gap instead, so the next person does not spend an evening establishing it.

## Coverage after this

| | today | when the image appears |
|---|---|---|
| unit tests, Psalm against the next server | #186, via the `master` branch | unchanged |
| smoke test against the next server | not possible | automatic, non-blocking |
| declared versions | gate | gate |

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
