### PR TITLE
Do not fail a build because coverage could not be uploaded

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,11 +74,16 @@ jobs:
         working-directory: nextcloud/apps/twofactor_email
         run: composer run test:unit
 
+      # Coverage is a report, not a gate: a failed upload says something about
+      # codecov or the runner's location, never about the code under test. It used
+      # to fail the whole matrix job — once for a documentation-only pull request,
+      # when codecov's storage refused the upload from that runner. A pull request
+      # from a fork has no token and would fail the same way.
       - name: Report coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./nextcloud/apps/twofactor_email/tests/clover.xml
           flags: unittests
-          fail_ci_if_error: true
+          fail_ci_if_error: false


### PR DESCRIPTION
PR #189 — documentation only — went red today. The tests passed on every combination; then codecov's storage refused the upload:

```
error -- Upload queued for processing failed:
  <Code>AccessDenied</Code>
  <Details>We're sorry, but this service is not available in your location</Details>
```

With `fail_ci_if_error: true` that failed the whole matrix job.

Coverage is a report. A failed upload says something about codecov or about where the runner happens to stand, never about the code under test — so it must not be able to block a merge. A pull request from a fork would fail the same way, having no token at all.

`always()` becomes `!cancelled()` while we are here, so a cancelled run stops instead of still trying to upload.

This is item 1 of task-list entry "CI-Kleinigkeiten aus dem twofactor_totp-Vergleich", pulled forward because it is blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.