### PR TITLE
Tell the admin when a reset failed

### DIFF
--- a/src/Store.js
+++ b/src/Store.js
@@ -86,16 +86,18 @@ export const useAdminSettingsStore = defineStore('adminSettings', {
 		},
 		async reset() {
 			const result = await resetAdminSettings()
-			if (typeof result.error !== 'string') {
-				this.$patch({
-					codeLength: result.codeLength,
-					codeValidMinutes: result.codeValidMinutes,
-					codeResendMinutes: result.codeResendMinutes,
-					eMailSubject: result.eMailSubject,
-					eMailTemplate: result.eMailTemplate,
-					error: null,
-				})
+			if (typeof result.error === 'string') {
+				this.$patch({ error: result.error })
+				return result
 			}
+			this.$patch({
+				codeLength: result.codeLength,
+				codeValidMinutes: result.codeValidMinutes,
+				codeResendMinutes: result.codeResendMinutes,
+				eMailSubject: result.eMailSubject,
+				eMailTemplate: result.eMailTemplate,
+				error: null,
+			})
 			return result
 		},
 	},

--- a/src/Store.test.js
+++ b/src/Store.test.js
@@ -78,7 +78,7 @@ describe('useAdminSettingsStore.reset', () => {
 		expect(store.codeLength).toBe(6)
 	})
 
-	it('does not touch the state on error', async () => {
+	it('does not touch the settings on error, but records the error', async () => {
 		resetAdminSettings.mockResolvedValue({ error: 'reset-failed' })
 		const store = useAdminSettingsStore()
 		store.codeLength = 8
@@ -86,6 +86,7 @@ describe('useAdminSettingsStore.reset', () => {
 		const result = await store.reset()
 
 		expect(store.codeLength).toBe(8)
+		expect(store.error).toBe('reset-failed')
 		expect(result.error).toBe('reset-failed')
 	})
 })

--- a/src/components/AdminSettings.test.js
+++ b/src/components/AdminSettings.test.js
@@ -81,6 +81,36 @@ describe('AdminSettings', () => {
 		expect(inputValues).toEqual(before)
 	})
 
+	it('says so when the reset failed, instead of only stopping the spinner', async () => {
+		store.reset.mockResolvedValue({ error: 'reset-failed' })
+		const wrapper = mount(AdminSettings)
+		expect(wrapper.find('.error').exists()).toBe(false)
+
+		await clickReset(wrapper)
+
+		expect(wrapper.find('.error').exists()).toBe(true)
+	})
+
+	it('says so when the reset threw', async () => {
+		store.reset.mockRejectedValue(new Error('network'))
+		const wrapper = mount(AdminSettings)
+		await clickReset(wrapper)
+
+		expect(wrapper.find('.error').exists()).toBe(true)
+	})
+
+	it('clears an earlier message when the next reset succeeds', async () => {
+		store.reset.mockResolvedValue({ error: 'reset-failed' })
+		const wrapper = mount(AdminSettings)
+		await clickReset(wrapper)
+		expect(wrapper.find('.error').exists()).toBe(true)
+
+		store.reset.mockResolvedValue({})
+		await clickReset(wrapper)
+
+		expect(wrapper.find('.error').exists()).toBe(false)
+	})
+
 	it('logs and recovers when reset throws', async () => {
 		store.reset.mockRejectedValue(new Error('network'))
 		const wrapper = mount(AdminSettings)

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -77,6 +77,9 @@
 				</template>
 				{{ t('twofactor_email', 'Reset all Two-Factor email app-wide admin settings to their defaults') }}
 			</NcButton>
+			<span v-if="resetFailed" class="error">
+				{{ t('twofactor_email', 'Could not reset the settings. Reload the page to see their current state.') }}
+			</span>
 		</NcSettingsSection>
 	</div>
 </template>
@@ -95,6 +98,7 @@ import Logger from '../Logger.js'
 import { useAdminSettingsStore } from '../Store.js'
 
 const resetting = ref(false)
+const resetFailed = ref(false)
 
 const fieldKeys = ['codeLength', 'codeValidMinutes', 'codeResendMinutes', 'eMailSubject', 'eMailTemplate']
 
@@ -127,14 +131,19 @@ const bodyHelperText = [
 
 async function onReset() {
 	resetting.value = true
+	resetFailed.value = false
 	try {
 		const result = await store.reset()
-		if (typeof result?.error !== 'string') {
+		if (typeof result?.error === 'string') {
+			resetFailed.value = true
+			Logger.error('reset failed:', result.error)
+		} else {
 			for (const key of fieldKeys) {
 				inputValues[key] = store[key]
 			}
 		}
 	} catch (e) {
+		resetFailed.value = true
 		Logger.error('reset failed:', e)
 	} finally {
 		resetting.value = false


### PR DESCRIPTION
Resetting the admin settings could fail without saying anything: the spinner stopped and nothing else happened, which looks exactly like success.

## Two silent paths

`resetAdminSettings()` never throws — it catches and returns `{ error: 'reset-failed' }`. So the failure arrived as a **return value** and ran into a condition that only handled the success case:

```js
const result = await store.reset()
if (typeof result?.error !== 'string') {
    // copy defaults back into the inputs
}
```

The `catch` beside it logged to the console, and could never fire for the network case it looked like it was there for.

The store had the same gap: `reset()` cleared `error` on success but left the previous value in place on failure, so the state did not reflect what had happened either.

## What changed

The store records the error. The component shows a message next to the reset button and clears it when a later attempt succeeds.

The wording asks for a reload rather than claiming nothing changed — `AdminSettingsController::reset()` resets before it answers, so a failed response does not prove the settings are untouched.

`PersonalSettings.vue` already handled its errors this way; this brings the admin side in line.

## Tests

Four added, each one verified to fail without its fix: the store records the error, the component reports a returned error, reports a thrown one, and clears the message on a later success. 83 frontend tests, ESLint, Stylelint and the build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
