### PR TITLE
Let psalm demand the #[\Override] attribute

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,11 @@ treating them as background noise, and re-check whether the existing pins and
   are globbed, so a new root file has to be added there by hand.
 - **GitHub Actions are pinned to a commit SHA** with a version comment, and every
   checkout sets `persist-credentials: false`. Follow the existing workflows.
+- **A method that overrides or implements anything carries `#[\Override]`** — an
+  interface, an abstract class, a parent method, whether from OCP, Symfony or this app.
+  Psalm requires it (`ensureOverrideAttribute`) and names every method missing one. It
+  is what turns a method Nextcloud has renamed into an analysis error instead of code
+  that is quietly never called again.
 - **A version bump touches four places:** `appinfo/info.xml`, `package.json`, and
   **both** version fields in `package-lock.json` — plus a `CHANGELOG.md` section with
   the release date. Change the values in place; do not re-resolve the lock file during

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -37,7 +37,8 @@ factor be skipped, accepted twice or brute-forced outweighs any question of styl
   decision about `.nextcloudignore` for anything new at the root, GitHub Actions pinned
   to a commit SHA with a version comment, `persist-credentials: false` on checkouts,
   and `-f` on any `curl` that **downloads a tool or artefact** (not on the test
-  requests in `tests/smoke/`, where the status code is the assertion).
+  requests in `tests/smoke/`, where the status code is the assertion). Psalm enforces
+  `#[\Override]` on every override, so that one reports itself.
 - **Texts that will not survive translation.** User-facing strings, comments and
   docblocks should be plain, short English. Idioms, nested clauses and German sentence
   structure in English words all make translation worse.

--- a/lib/Activity/Provider.php
+++ b/lib/Activity/Provider.php
@@ -24,6 +24,7 @@ final readonly class Provider implements IProvider {
 	) {
 	}
 
+	#[\Override]
 	public function parse($language, IEvent $event, ?IEvent $previousEvent = null): IEvent {
 		if ($event->getApp() !== Application::APP_ID) {
 			throw new UnknownActivityException();

--- a/lib/Activity/Setting.php
+++ b/lib/Activity/Setting.php
@@ -20,30 +20,37 @@ final readonly class Setting implements ISetting {
 	) {
 	}
 
+	#[\Override]
 	public function canChangeMail(): bool {
 		return false;
 	}
 
+	#[\Override]
 	public function canChangeStream(): bool {
 		return false;
 	}
 
+	#[\Override]
 	public function getIdentifier(): string {
 		return Application::APP_ID;
 	}
 
+	#[\Override]
 	public function getName(): string {
 		return $this->l10n->t('Email');
 	}
 
+	#[\Override]
 	public function getPriority(): int {
 		return 10;
 	}
 
+	#[\Override]
 	public function isDefaultEnabledMail(): bool {
 		return true;
 	}
 
+	#[\Override]
 	public function isDefaultEnabledStream(): bool {
 		return true;
 	}

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -42,6 +42,7 @@ final class Application extends App implements IBootstrap {
 		parent::__construct(self::APP_ID);
 	}
 
+	#[\Override]
 	public function register(IRegistrationContext $context): void {
 		include_once __DIR__ . '/../../vendor/autoload.php';
 
@@ -64,6 +65,7 @@ final class Application extends App implements IBootstrap {
 		$context->registerNotifierService(Notifier::class);
 	}
 
+	#[\Override]
 	public function boot(IBootContext $context): void {
 	}
 }

--- a/lib/BackgroundJob/CleanUpExpiredCodes.php
+++ b/lib/BackgroundJob/CleanUpExpiredCodes.php
@@ -31,6 +31,7 @@ final class CleanUpExpiredCodes extends TimedJob {
 		$this->setTimeSensitivity(IJob::TIME_INSENSITIVE);
 	}
 
+	#[\Override]
 	protected function run(mixed $argument): void {
 		$this->codeStorage->deleteExpired();
 	}

--- a/lib/Command/CleanUp.php
+++ b/lib/Command/CleanUp.php
@@ -23,12 +23,14 @@ final class CleanUp extends Command {
 		parent::__construct();
 	}
 
+	#[\Override]
 	protected function configure(): void {
 		$this
 			->setName('twofactor_email:cleanup')
 			->setDescription('Remove expired two-factor email codes.');
 	}
 
+	#[\Override]
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$io = new SymfonyStyle($input, $output);
 		$io->title('Removing expired two-factor email codes');

--- a/lib/Command/DeleteCodes.php
+++ b/lib/Command/DeleteCodes.php
@@ -32,6 +32,7 @@ final class DeleteCodes extends Command {
 		parent::__construct();
 	}
 
+	#[\Override]
 	protected function configure(): void {
 		$this
 			->setName('twofactor_email:delete-codes')
@@ -40,6 +41,7 @@ final class DeleteCodes extends Command {
 			->addOption('all', null, InputOption::VALUE_NONE, 'Delete the codes of all users');
 	}
 
+	#[\Override]
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$io = new SymfonyStyle($input, $output);
 		$uid = $input->getArgument('uid');

--- a/lib/Command/Settings.php
+++ b/lib/Command/Settings.php
@@ -35,6 +35,7 @@ final class Settings extends Command {
 		parent::__construct();
 	}
 
+	#[\Override]
 	protected function configure(): void {
 		$settings = implode(', ', [...self::INT_SETTINGS, ...self::STRING_SETTINGS]);
 		$this
@@ -45,6 +46,7 @@ final class Settings extends Command {
 			->addOption('reset', null, InputOption::VALUE_NONE, 'Reset all settings to their defaults');
 	}
 
+	#[\Override]
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$io = new SymfonyStyle($input, $output);
 		$key = $input->getArgument('key');

--- a/lib/Listener/EMailDeleted.php
+++ b/lib/Listener/EMailDeleted.php
@@ -53,6 +53,7 @@ final readonly class EMailDeleted implements IEventListener {
 	 *   the generic narrows $event to UserChangedEvent, but we still verify it
 	 *   at runtime rather than trust the dispatcher registration.
 	 */
+	#[\Override]
 	public function handle(Event $event): void {
 		if (!$event instanceof UserChangedEvent || $event->getFeature() !== 'eMailAddress') {
 			return;

--- a/lib/Listener/StateChangeActivity.php
+++ b/lib/Listener/StateChangeActivity.php
@@ -29,6 +29,7 @@ final readonly class StateChangeActivity implements IEventListener {
 	) {
 	}
 
+	#[\Override]
 	public function handle(Event $event): void {
 		if (!$event instanceof StateChanged) {
 			return;

--- a/lib/Listener/StateChangeNotification.php
+++ b/lib/Listener/StateChangeNotification.php
@@ -34,6 +34,7 @@ final readonly class StateChangeNotification implements IEventListener {
 	) {
 	}
 
+	#[\Override]
 	public function handle(Event $event): void {
 		if (!$event instanceof StateChanged) {
 			return;

--- a/lib/Listener/StateChangeRegistryUpdater.php
+++ b/lib/Listener/StateChangeRegistryUpdater.php
@@ -26,6 +26,7 @@ final readonly class StateChangeRegistryUpdater implements IEventListener {
 	) {
 	}
 
+	#[\Override]
 	public function handle(Event $event): void {
 		if (!$event instanceof StateChanged) {
 			return;

--- a/lib/Migration/RemovePersistedDefaultTemplate.php
+++ b/lib/Migration/RemovePersistedDefaultTemplate.php
@@ -38,10 +38,12 @@ final readonly class RemovePersistedDefaultTemplate implements IRepairStep {
 	) {
 	}
 
+	#[\Override]
 	public function getName(): string {
 		return 'Remove the email template that 3.1.x persisted without customization';
 	}
 
+	#[\Override]
 	public function run(IOutput $output): void {
 		if ($this->appSettings->getEMailTemplate() !== self::OLD_DEFAULT_TEMPLATE) {
 			return;

--- a/lib/Migration/Version03000400Date20250829000000.php
+++ b/lib/Migration/Version03000400Date20250829000000.php
@@ -47,6 +47,7 @@ final class Version03000400Date20250829000000 extends SimpleMigrationStep {
 	) {
 	}
 
+	#[\Override]
 	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
 		// Count all users that have a v2 authentication code stored
 		try {

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -29,14 +29,17 @@ final readonly class Notifier implements INotifier {
 	) {
 	}
 
+	#[\Override]
 	public function getID(): string {
 		return Application::APP_ID;
 	}
 
+	#[\Override]
 	public function getName(): string {
 		return $this->l10nFactory->get(Application::APP_ID)->t('Email two-factor authentication');
 	}
 
+	#[\Override]
 	public function prepare(INotification $notification, string $languageCode): INotification {
 		if ($notification->getApp() !== Application::APP_ID) {
 			throw new UnknownNotificationException();

--- a/lib/Provider/LoginSetup.php
+++ b/lib/Provider/LoginSetup.php
@@ -25,6 +25,7 @@ final readonly class LoginSetup implements ILoginSetupProvider {
 	) {
 	}
 
+	#[\Override]
 	public function getBody(): ITemplate {
 		try {
 			$template = $this->templateManager->getTemplate(Application::APP_ID, 'LoginSetup');

--- a/lib/Provider/TwoFactorEMail.php
+++ b/lib/Provider/TwoFactorEMail.php
@@ -57,14 +57,17 @@ class TwoFactorEMail implements IProvider, IProvidesIcons, IProvidesPersonalSett
 	) {
 	}
 
+	#[\Override]
 	public function getId(): string {
 		return 'email';
 	}
 
+	#[\Override]
 	public function getDisplayName(): string {
 		return 'Email';
 	}
 
+	#[\Override]
 	public function getDescription(): string {
 		return $this->l10n->t('Authenticate by email');
 	}
@@ -75,6 +78,7 @@ class TwoFactorEMail implements IProvider, IProvidesIcons, IProvidesPersonalSett
 	 * It sends a challenge code by email, unless a still-valid code exists —
 	 * so reloading the page does not send another email.
 	 */
+	#[\Override]
 	public function getTemplate(IUser $user): ITemplate {
 		try {
 			$template = $this->templateManager->getTemplate(Application::APP_ID, 'LoginChallenge');
@@ -102,6 +106,7 @@ class TwoFactorEMail implements IProvider, IProvidesIcons, IProvidesPersonalSett
 		return $template;
 	}
 
+	#[\Override]
 	public function verifyChallenge(IUser $user, string $challenge): bool {
 		return $this->challengeService->verifyChallenge($user, $challenge);
 	}
@@ -113,18 +118,22 @@ class TwoFactorEMail implements IProvider, IProvidesIcons, IProvidesPersonalSett
 	 * If no entry exists for the provider "email" and the given user, this method is called during the login flow.
 	 * Nextcloud then saves the current state.
 	 */
+	#[\Override]
 	public function isTwoFactorAuthEnabledForUser(IUser $user): bool {
 		return $this->stateManager->isEnabled($user);
 	}
 
+	#[\Override]
 	public function getLightIcon(): string {
 		return $this->urlGenerator->imagePath(Application::APP_ID, 'app.svg');
 	}
 
+	#[\Override]
 	public function getDarkIcon(): string {
 		return $this->urlGenerator->imagePath(Application::APP_ID, 'app-dark.svg');
 	}
 
+	#[\Override]
 	public function getPersonalSettings(IUser $user): IPersonalProviderSettings {
 		$email = $user->getEMailAddress() ?? '';
 		$this->initialStateService->provideInitialState('enabled', $this->stateManager->isEnabled($user));
@@ -135,10 +144,12 @@ class TwoFactorEMail implements IProvider, IProvidesIcons, IProvidesPersonalSett
 		);
 	}
 
+	#[\Override]
 	public function disableFor(IUser $user): void {
 		$this->stateManager->disable($user, StateChangeActor::ADMIN);
 	}
 
+	#[\Override]
 	public function enableFor(IUser $user): void {
 		$this->stateManager->enable($user, StateChangeActor::ADMIN);
 	}
@@ -147,6 +158,7 @@ class TwoFactorEMail implements IProvider, IProvidesIcons, IProvidesPersonalSett
 	 * @throws NotFoundExceptionInterface
 	 * @throws ContainerExceptionInterface
 	 */
+	#[\Override]
 	public function getLoginSetup(IUser $user): ILoginSetupProvider {
 		$maskedEmail = $this->emailAddressMasker->maskForUI($user->getEMailAddress() ?? '');
 		$this->initialStateService->provideInitialState('maskedEmail', $maskedEmail);

--- a/lib/Service/AppSettings.php
+++ b/lib/Service/AppSettings.php
@@ -38,34 +38,42 @@ final readonly class AppSettings implements IAppSettings {
 	) {
 	}
 
+	#[\Override]
 	public function getCodeLength(): int {
 		return $this->appConfig->getValueInt(Application::APP_ID, self::KEY_CODE_LENGTH, self::DEFAULT_CODE_LENGTH);
 	}
 
+	#[\Override]
 	public function getCodeValidMinutes(): int {
 		return $this->appConfig->getValueInt(Application::APP_ID, self::KEY_CODE_VALID_MINUTES, self::DEFAULT_CODE_VALID_MINUTES);
 	}
 
+	#[\Override]
 	public function getResendMinMinutes(): int {
 		return $this->appConfig->getValueInt(Application::APP_ID, self::KEY_RESEND_MIN_MINUTES, self::DEFAULT_RESEND_MIN_MINUTES);
 	}
 
+	#[\Override]
 	public function getResendCooldownSeconds(): int {
 		return $this->getResendMinMinutes() * 60;
 	}
 
+	#[\Override]
 	public function getEMailSubject(): string {
 		return $this->appConfig->getValueString(Application::APP_ID, self::KEY_EMAIL_SUBJECT, self::DEFAULT_EMAIL_SUBJECT);
 	}
 
+	#[\Override]
 	public function getEMailTemplate(): string {
 		return $this->appConfig->getValueString(Application::APP_ID, self::KEY_EMAIL_TEMPLATE, self::DEFAULT_EMAIL_TEMPLATE);
 	}
 
+	#[\Override]
 	public function getDefaultEMailSubject(): string {
 		return $this->l10n->t('Login attempt for %s', ['{user} @ {cloud}']);
 	}
 
+	#[\Override]
 	public function getDefaultEMailBody(): string {
 		// The {logo} and {code} structure is kept outside of the translatable
 		// strings so translations cannot break it; every chunk is a complete
@@ -78,26 +86,32 @@ final readonly class AppSettings implements IAppSettings {
 			. $this->l10n->t('If you did not try to log in, somebody else knows your username and your password — change your password and inform your administrator.');
 	}
 
+	#[\Override]
 	public function setCodeLength(int $codeLength): void {
 		$this->appConfig->setValueInt(Application::APP_ID, self::KEY_CODE_LENGTH, $codeLength);
 	}
 
+	#[\Override]
 	public function setCodeValidMinutes(int $codeValidMinutes): void {
 		$this->appConfig->setValueInt(Application::APP_ID, self::KEY_CODE_VALID_MINUTES, $codeValidMinutes);
 	}
 
+	#[\Override]
 	public function setResendMinMinutes(int $resendMinutes): void {
 		$this->appConfig->setValueInt(Application::APP_ID, self::KEY_RESEND_MIN_MINUTES, $resendMinutes);
 	}
 
+	#[\Override]
 	public function setEMailSubject(string $subject): void {
 		$this->appConfig->setValueString(Application::APP_ID, self::KEY_EMAIL_SUBJECT, $subject);
 	}
 
+	#[\Override]
 	public function setEMailTemplate(string $body): void {
 		$this->appConfig->setValueString(Application::APP_ID, self::KEY_EMAIL_TEMPLATE, $body);
 	}
 
+	#[\Override]
 	public function resetToDefaults(): void {
 		$this->appConfig->deleteKey(Application::APP_ID, self::KEY_CODE_LENGTH);
 		$this->appConfig->deleteKey(Application::APP_ID, self::KEY_CODE_VALID_MINUTES);

--- a/lib/Service/CodeStorage.php
+++ b/lib/Service/CodeStorage.php
@@ -21,6 +21,7 @@ final readonly class CodeStorage implements ICodeStorage {
 	) {
 	}
 
+	#[\Override]
 	public function readCode(string $userId): ?string {
 		$expiresBefore = time() - $this->settings->getCodeValidMinutes() * 60;
 		$createdAt = $this->config->getValueInt($userId, Application::APP_ID, self::KEY_CREATED_AT);
@@ -37,6 +38,7 @@ final readonly class CodeStorage implements ICodeStorage {
 		return $code;
 	}
 
+	#[\Override]
 	public function secondsSinceLastCode(string $userId): ?int {
 		// Only a still-valid code counts: an expired one is treated as "none"
 		// so the user may request a fresh code without waiting.
@@ -47,6 +49,7 @@ final readonly class CodeStorage implements ICodeStorage {
 		return max(0, time() - $createdAt);
 	}
 
+	#[\Override]
 	public function deleteCode(string $userId): bool {
 		$existed = $this->config->getValueString($userId, Application::APP_ID, self::KEY_CODE) !== '';
 		$this->config->deleteUserConfig($userId, Application::APP_ID, self::KEY_CODE);
@@ -54,6 +57,7 @@ final readonly class CodeStorage implements ICodeStorage {
 		return $existed;
 	}
 
+	#[\Override]
 	public function writeCode(string $userId, string $code, ?int $createdAt = null): void {
 		$createdAt ??= time();
 		// The stored value is a hash, but flag it sensitive so it is masked in
@@ -62,6 +66,7 @@ final readonly class CodeStorage implements ICodeStorage {
 		$this->config->setValueInt($userId, Application::APP_ID, self::KEY_CREATED_AT, $createdAt);
 	}
 
+	#[\Override]
 	public function deleteAllCodes(): int {
 		$count = count($this->config->getValuesByUsers(Application::APP_ID, self::KEY_CREATED_AT, ValueType::INT));
 		$this->config->deleteKey(Application::APP_ID, self::KEY_CODE);
@@ -69,6 +74,7 @@ final readonly class CodeStorage implements ICodeStorage {
 		return $count;
 	}
 
+	#[\Override]
 	public function deleteExpired(): int {
 		$expiresBefore = time() - $this->settings->getCodeValidMinutes() * 60;
 		$creationTime = $this->config->getValuesByUsers(Application::APP_ID, self::KEY_CREATED_AT, ValueType::INT);

--- a/lib/Service/EMailAddressMasker.php
+++ b/lib/Service/EMailAddressMasker.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\TwoFactorEMail\Service;
 
 final class EMailAddressMasker implements IEMailAddressMasker {
+	#[\Override]
 	public function maskForUI(string $emailAddress): string {
 		if (!preg_match('/^([^@\s]+)@([^@\s]+)$/', $emailAddress, $m)) {
 			return $emailAddress;

--- a/lib/Service/EMailSender.php
+++ b/lib/Service/EMailSender.php
@@ -26,6 +26,7 @@ final readonly class EMailSender implements IEMailSender {
 	) {
 	}
 
+	#[\Override]
 	public function sendChallengeEMail(IUser $user, string $code): void {
 		$email = $user->getEMailAddress();
 		if ($email === null) {

--- a/lib/Service/LoginChallenge.php
+++ b/lib/Service/LoginChallenge.php
@@ -31,6 +31,7 @@ final readonly class LoginChallenge implements ILoginChallenge {
 	 * @throws SendEMailFailed
 	 * @throws EMailNotSet
 	 */
+	#[\Override]
 	public function sendChallenge(IUser $user): bool {
 		/**
 		 * The code is stored hashed, so it stays secret and resistant to timing
@@ -61,6 +62,7 @@ final readonly class LoginChallenge implements ILoginChallenge {
 	 * @throws EMailNotSet
 	 * @throws SendEMailFailed
 	 */
+	#[\Override]
 	public function resendChallenge(IUser $user): void {
 		$elapsed = $this->codeStorage->secondsSinceLastCode($user->getUID());
 		$cooldown = $this->settings->getResendCooldownSeconds();
@@ -71,6 +73,7 @@ final readonly class LoginChallenge implements ILoginChallenge {
 		$this->issueCode($user);
 	}
 
+	#[\Override]
 	public function secondsUntilResendAllowed(IUser $user): int {
 		$elapsed = $this->codeStorage->secondsSinceLastCode($user->getUID());
 		if ($elapsed === null) {
@@ -83,6 +86,7 @@ final readonly class LoginChallenge implements ILoginChallenge {
 		return max(0, $cooldown - $elapsed);
 	}
 
+	#[\Override]
 	public function verifyChallenge(IUser $user, string $submittedCode): bool {
 		$submittedCode = trim($submittedCode);
 		$storedCodeHash = $this->codeStorage->readCode($user->getUID());

--- a/lib/Service/NumericalCodeGenerator.php
+++ b/lib/Service/NumericalCodeGenerator.php
@@ -18,6 +18,7 @@ final readonly class NumericalCodeGenerator implements ICodeGenerator {
 	) {
 	}
 
+	#[\Override]
 	public function generateChallengeCode(): string {
 		return $this->secureRandom->generate(
 			$this->settings->getCodeLength(),

--- a/lib/Service/StateManager.php
+++ b/lib/Service/StateManager.php
@@ -30,18 +30,22 @@ final readonly class StateManager implements IStateManager {
 	) {
 	}
 
+	#[\Override]
 	public function enable(IUser $user, StateChangeActor $actor = StateChangeActor::USER): void {
 		$this->eventDispatcher->dispatchTyped(new StateChanged($user, true, $actor));
 	}
 
+	#[\Override]
 	public function disable(IUser $user, StateChangeActor $actor = StateChangeActor::USER): void {
 		$this->eventDispatcher->dispatchTyped(new StateChanged($user, false, $actor));
 	}
 
+	#[\Override]
 	public function isEnabled(IUser $user): bool {
 		return $this->registry->getProviderStates($user)[self::PROVIDER_ID] ?? false;
 	}
 
+	#[\Override]
 	public function hasOtherActiveProvider(IUser $user): bool {
 		foreach ($this->registry->getProviderStates($user) as $providerId => $enabled) {
 			if ($enabled && $providerId !== self::PROVIDER_ID) {

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -56,12 +56,6 @@ final readonly class AdminSettings implements IDelegatedSettings {
 		return $this->l10n->t('Email');
 	}
 
-	// Both required by Nextcloud at runtime via IDelegatedSettings
-	/** @noinspection PhpUnused */
-	public function getAuthorizedGroupIds(): array {
-		return []; // real admins only
-	}
-
 	#[\Override]
 	public function getAuthorizedAppConfig(): array {
 		return []; // no app config keys delegated to non-admins

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -25,6 +25,7 @@ final readonly class AdminSettings implements IDelegatedSettings {
 	) {
 	}
 
+	#[\Override]
 	public function getForm(): TemplateResponse {
 		$this->initialState->provideInitialState('codeLength', $this->appSettings->getCodeLength());
 		$this->initialState->provideInitialState('codeValidMinutes', $this->appSettings->getCodeValidMinutes());
@@ -40,14 +41,17 @@ final readonly class AdminSettings implements IDelegatedSettings {
 		return new TemplateResponse(Application::APP_ID, 'AdminSettings', renderAs: TemplateResponse::RENDER_AS_BLANK);
 	}
 
+	#[\Override]
 	public function getSection(): string {
 		return 'security';
 	}
 
+	#[\Override]
 	public function getPriority(): int {
 		return 30;
 	}
 
+	#[\Override]
 	public function getName(): ?string {
 		return $this->l10n->t('Email');
 	}
@@ -58,6 +62,7 @@ final readonly class AdminSettings implements IDelegatedSettings {
 		return []; // real admins only
 	}
 
+	#[\Override]
 	public function getAuthorizedAppConfig(): array {
 		return []; // no app config keys delegated to non-admins
 	}

--- a/lib/Settings/PersonalSettings.php
+++ b/lib/Settings/PersonalSettings.php
@@ -23,6 +23,7 @@ final readonly class PersonalSettings implements IPersonalProviderSettings {
 	) {
 	}
 
+	#[\Override]
 	public function getBody(): ITemplate {
 		try {
 			return $this->templateManager->getTemplate(Application::APP_ID, 'PersonalSettings');

--- a/psalm.xml
+++ b/psalm.xml
@@ -3,7 +3,7 @@
         errorLevel="3"
         phpVersion="8.2"
         findUnusedCode="false"
-        ensureOverrideAttribute="false"
+        ensureOverrideAttribute="true"
         findUnusedIssueHandlerSuppression="false"
         autoloader="tests/bootstrap.php"
 >

--- a/tests/smoke/smoke.sh
+++ b/tests/smoke/smoke.sh
@@ -216,6 +216,18 @@ run_checks() {
 	is "admin/reset" "$status" "200"
 	body_has "reset restores the defaults" '"codeLength":6'
 
+	# The admin settings are an IDelegatedSettings. No HTTP route reaches that
+	# side of the class: the server builds the delegation list on its own and
+	# asks each setting for its name and priority. If it ever expected a method
+	# the class does not have, this is where it would show.
+	# The needle is the JSON key, not just the class name: a PHP error names the
+	# class too, so grepping for the name alone would pass on the very failure
+	# this check exists to catch.
+	echo "-- delegated admin settings"
+	is "the settings class is offered for delegation" \
+		"$(occ admin-delegation:show --output=json \
+			| grep -cF '"className":"OCA\\TwoFactorEMail\\Settings\\AdminSettings"')" "1"
+
 	echo "-- state/save"
 	# No 403 to expect here: Nextcloud counts the login that just happened as the
 	# password confirmation for 30 minutes. A 403 would only show up on an older


### PR DESCRIPTION
## Why

The app implements a lot of OCP interfaces. If Nextcloud renames or removes one
of their methods, the implementation here quietly stops implementing anything:
it still parses, it is simply never called again. Nothing reports it.

## What

`ensureOverrideAttribute` in `psalm.xml`, and `#[\Override]` on the 77 methods
psalm named — every method that genuinely overrides something.

The same rename now produces `InvalidOverride` in the psalm job that runs
against the **newest** OCP, which is the job that exists to meet the next server
version before its users do. PHP enforces the attribute itself from 8.3, so the
test matrix fails on it as well. On PHP 8.2, the app's floor, the attribute is
inert — verified on a real 8.2, not assumed.

The two checks point in opposite directions and neither replaces the other:
psalm demands that an overriding method *carries* the attribute, PHP demands
that a *present* attribute has a parent.

## A method that turned out to be dead

`AdminSettings::getAuthorizedGroupIds()` is gone. A comment claimed Nextcloud
required it at runtime via `IDelegatedSettings`. It does not. That interface
declares `getName()` and `getAuthorizedAppConfig()` and nothing else, in
Nextcloud 30 through 34 and in master alike. The server touches a delegated
setting in three places — `Manager` calls `getPriority()` and `getSection()`,
the delegation page and `admin-delegation:show` call `getName()`, and
`AppConfigController` calls `getAuthorizedAppConfig()`. The deleted method
appears nowhere in the server, and Nextcloud's own delegated settings do not
define it either; delegated group assignments live in a database table read
through `AuthorizedGroupMapper`.

The `#[\Override]` attribute is what surfaced it. Psalm required one on the
method directly beside it and required none here, because this method overrides
nothing.

## The smoke test now walks that path

No HTTP route reaches the delegation side of the settings class, so the smoke
run could not have caught a mistake there. It now calls
`admin-delegation:show`, which is where the server builds the list itself and
asks each setting for its name and priority — on both supported servers.

The check asserts on the JSON key, not on the class name alone: a PHP error
message names the class too, so the simpler grep would have passed on exactly
the failure the check exists to catch. Verified by breaking the path on
purpose, where this check fails and the other 29 still pass.

## Checked

- psalm, taint, `cs:check` and 147 unit tests pass; the attribute placement
  needed no formatting change
- Proof the psalm check fires in both directions: removing one attribute
  produces `MissingOverrideAttribute`, adding one where nothing is overridden
  produces `InvalidOverride`

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
