### PR TITLE
Stop installing the formatter where nothing formats

### DIFF
--- a/.github/workflows/nextcloud-next.yml
+++ b/.github/workflows/nextcloud-next.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: nextcloud/apps/twofactor_email
-        run: composer install
+        run: composer install --no-scripts
 
       - name: Run tests
         working-directory: nextcloud/apps/twofactor_email
@@ -94,10 +94,10 @@ jobs:
       - name: Install dependencies
         run: |
           composer remove nextcloud/ocp --dev --no-scripts
-          composer i
+          composer i --no-scripts
 
       - name: Install the OCP of Nextcloud master
-        run: composer require --dev nextcloud/ocp:dev-master --ignore-platform-reqs --with-dependencies
+        run: composer require --dev nextcloud/ocp:dev-master --ignore-platform-reqs --with-dependencies --no-scripts
 
       - name: Run static analysis
         run: composer run psalm -- --threads=1 --monochrome --no-progress --output-format=github

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -56,10 +56,10 @@ jobs:
       - name: Install dependencies
         run: |
           composer remove nextcloud/ocp --dev --no-scripts
-          composer i
+          composer i --no-scripts
 
       - name: Install nextcloud/ocp
-        run: composer require --dev nextcloud/ocp:dev-${{ matrix.ocp == 'min' && steps.versions.outputs.branches-min || steps.versions.outputs.branches-max }} --ignore-platform-reqs --with-dependencies
+        run: composer require --dev nextcloud/ocp:dev-${{ matrix.ocp == 'min' && steps.versions.outputs.branches-min || steps.versions.outputs.branches-max }} --ignore-platform-reqs --with-dependencies --no-scripts
 
       - name: Run coding standards check
         run: composer run psalm -- --threads=1 --monochrome --no-progress --output-format=github

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: nextcloud/apps/twofactor_email
-        run: composer install
+        run: composer install --no-scripts
 
       - name: Run tests
         working-directory: nextcloud/apps/twofactor_email

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,12 @@ but finding it locally is cheaper for everyone.
 **`composer outdated` in the root does not see `vendor-bin/*`.** The bamarni plugin
 gives those their own projects — use `composer bin all outdated`.
 
+**A root `composer install` also installs `vendor-bin/*`**, through a hook that exists
+so working in the repo takes one command instead of two. CI and the package build do
+not need the tooling and pass `--no-scripts`; the only job that keeps it is the one
+running `cs:check`. A new workflow that installs dependencies should pass
+`--no-scripts` too.
+
 **Query npm with `--all`.** `npm ls <package>` and friends traverse shallowly without
 it and silently miss deeper paths, which is how a dependency once looked dev-only when
 it was not. After an update, read the warnings and remove their cause rather than

--- a/krankerl.toml
+++ b/krankerl.toml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 [package]
 before_cmds = [
-    "composer install --no-dev -o",
+    "composer install --no-dev -o --no-scripts",
     "npm ci",
     "npm run build",
 ]


### PR DESCRIPTION
## Why

A root `composer install` also installs `vendor-bin/*`, through a hook that
exists so working in the repo takes one command instead of two. CI does not
benefit: of thirteen jobs, one runs `cs:check` and twelve download the
php-cs-fixer tool chain to run something else. The package build pulled it in
too, by way of krankerl's `composer install --no-dev`.

Each download can fail on something unrelated to the change under test, and
they do.

## What

`--no-scripts` on every dependency install that does not format code, including
the package build. `lint-php-cs.yml` keeps the hook, and so does a developer's
`composer install`.

## Checked

- The two hooks are the only lifecycle scripts in `composer.json`, so
  `--no-scripts` disables nothing else
- `krankerl package` still succeeds and produces the same 269 files;
  `vendor-bin` was already excluded by `.nextcloudignore`, so it was downloaded
  but never shipped

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
