### PR TITLE
Treat a deprecated Nextcloud API as an error

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,9 +113,12 @@ treating them as background noise, and re-check whether the existing pins and
   `@NoTwoFactorRequired` docblock annotation.** Nextcloud 33 reads the exemption from
   the docblock only; the attribute is `@since 34`. Removing either one breaks a
   supported server. Nextcloud 35 still reads both, so this is never urgent —
-  `CompatibilityShimsTest` fails as soon as `min-version` reaches 34 and names the
-  three pieces that go together: the annotation, the `UndefinedAttributeClass`
-  handler in `psalm.xml`, and the `findUnusedIssueHandlerSuppression` beside it.
+  `CompatibilityShimsTest` fails as soon as `min-version` reaches 34 and names the two
+  pieces that go together: the annotation and the `UndefinedAttributeClass` handler in
+  `psalm.xml`. **That test is the register of every such carve-out**, each with the
+  condition that ends it. A new workaround the app carries only because it spans
+  several server or PHP versions belongs there, so that dropping a version is a sweep
+  and not a search.
 - **`symfony/console` is held at `^6.4.42`.** Nextcloud bundles Symfony 6.4, and `occ`
   commands must build against the same major.
 - **`allowScripts` in `package.json` lists `fsevents`, which is never installed here.**

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -31,7 +31,10 @@ factor be skipped, accepted twice or brute-forced outweighs any question of styl
   `set -u` aborts there.
 - **Version-range shims that outlived their reason.** When the supported Nextcloud
   range changes, workarounds for the dropped version become dead weight around
-  security-relevant code. Flag them.
+  security-relevant code. Flag them. Flag a **new** one too if it is not registered in
+  `CompatibilityShimsTest`: that class is meant to list every workaround the app carries
+  only because it spans several versions, so that dropping a version is a sweep rather
+  than a search.
 - **Repository conventions**, because they exist for a reason and are easy to miss when
   adding a file of a kind that already exists: SPDX/REUSE coverage for new files, a
   decision about `.nextcloudignore` for anything new at the root, GitHub Actions pinned

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -83,6 +83,11 @@ factor be skipped, accepted twice or brute-forced outweighs any question of styl
 - **Formatting.** `php-cs-fixer` with `nextcloud/coding-standard` owns it, ESLint and
   Stylelint own the frontend. Tabs, brace placement and import order are not review
   material.
+- **There is no Rector configuration, on purpose.** Its Nextcloud sets for 33, 34 and
+  35 are the same file, and running them against `lib/` changes nothing. Keeping the
+  tool would add a dependency project that only earns its keep when a future server
+  renames an API. Run it from a throwaway checkout when the supported range moves —
+  `doc/development-setup.md` says how — rather than carrying it here.
 - **`package-lock.json` churn** in a dependency update, and generated translation
   files.
 - **Test doubles that look over-specific.** Assertions on exact mock calls are

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -62,10 +62,14 @@ factor be skipped, accepted twice or brute-forced outweighs any question of styl
   exist in the oldest supported server's OCP, which the analysis now checks against.
   That handler names the **one** class on purpose; a suppression in the method's
   docblock silenced every undefined attribute on the route that skips the second
-  factor, including a typo. `findUnusedIssueHandlerSuppression="false"` belongs to
-  it, because the same handler is necessarily unused against the newest OCP. All of
-  it goes together when `min-version` reaches 34 — and `CompatibilityShimsTest`
-  fails until it does, so this is enforced rather than remembered.
+  factor, including a typo. Both go when `min-version` reaches 34 — and
+  `CompatibilityShimsTest` fails until they do, so this is enforced rather than
+  remembered.
+- **`findUnusedIssueHandlerSuppression="false"` outlives that pair.** Every suppression
+  in `psalm.xml` serves one end of the supported range and is therefore unused at the
+  other, where the analysis also runs. The flag belongs to all of them and goes with
+  the last one, which is a check of its own — not to the handler it was first added
+  for.
 - **`ISecureRandom::generate` is deprecated in Nextcloud 35 and still used.** Its
   replacement, `Random\Randomizer::getBytesFromString()`, needs PHP 8.3, and the app's
   floor is 8.2 because Nextcloud 33 allows it. Psalm is told to accept that one method

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -63,6 +63,11 @@ factor be skipped, accepted twice or brute-forced outweighs any question of styl
   it, because the same handler is necessarily unused against the newest OCP. All of
   it goes together when `min-version` reaches 34 — and `CompatibilityShimsTest`
   fails until it does, so this is enforced rather than remembered.
+- **`ISecureRandom::generate` is deprecated in Nextcloud 35 and still used.** Its
+  replacement, `Random\Randomizer::getBytesFromString()`, needs PHP 8.3, and the app's
+  floor is 8.2 because Nextcloud 33 allows it. Psalm is told to accept that one method
+  by name, so every other deprecated call stays an error, and
+  `CompatibilityShimsTest` fails as soon as the floor reaches 8.3.
 - **`symfony/console` at `^6.4.42`**: Nextcloud bundles Symfony 6.4 and `occ` commands
   must match its major. This one has no expiry — it moves when Nextcloud moves.
 - **`@nextcloud/vite-config` pinned to a pre-release**: it is the only version that

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -65,11 +65,11 @@ factor be skipped, accepted twice or brute-forced outweighs any question of styl
   factor, including a typo. Both go when `min-version` reaches 34 — and
   `CompatibilityShimsTest` fails until they do, so this is enforced rather than
   remembered.
-- **`findUnusedIssueHandlerSuppression="false"` outlives that pair.** Every suppression
-  in `psalm.xml` serves one end of the supported range and is therefore unused at the
-  other, where the analysis also runs. The flag belongs to all of them and goes with
-  the last one, which is a check of its own — not to the handler it was first added
-  for.
+- **`findUnusedIssueHandlerSuppression="false"` outlives that pair.** A suppression in
+  `psalm.xml` exists because the app spans several versions, so in any single analysis
+  run it may simply not be triggered — and psalm would then report it as unused. The
+  flag belongs to all of them and goes with the last one, which is a check of its own,
+  not to the handler it was first added for.
 - **`ISecureRandom::generate` is deprecated in Nextcloud 35 and still used.** Its
   replacement, `Random\Randomizer::getBytesFromString()`, needs PHP 8.3, and the app's
   floor is 8.2 because Nextcloud 33 allows it. Psalm is told to accept that one method

--- a/doc/development-setup.md
+++ b/doc/development-setup.md
@@ -110,9 +110,9 @@ kernel are gone, so overlayfs cannot be loaded. Rebooting fixes it.
 ## Rector, when the Nextcloud range moves
 
 Rector can rewrite calls that a new server renamed, but it is not part of this project:
-its Nextcloud sets for 33, 34 and 35 are the same file, and they change nothing here.
-Run it from a throwaway directory when the supported range moves, then throw the
-directory away:
+its Nextcloud sets for 33, 34 and 35 are the same file, and over `lib/` they propose
+nothing at all. Run it from a throwaway directory when the supported range moves, then
+throw the directory away:
 
 ```bash
 mkdir -p /tmp/rector && cd /tmp/rector || exit
@@ -122,7 +122,10 @@ cat > rector.php <<'PHP'
 use Nextcloud\Rector\Set\NextcloudSets;
 use Rector\Config\RectorConfig;
 return RectorConfig::configure()
-	->withPaths(['/path/to/twofactor_email/lib'])
+	->withPaths([
+		'/path/to/twofactor_email/lib',
+		'/path/to/twofactor_email/tests',
+	])
 	->withAutoloadPaths([
 		'/path/to/twofactor_email/vendor/autoload.php',
 		'/path/to/twofactor_email/tests/bootstrap.php',
@@ -142,5 +145,7 @@ every `parent::setUp()` in the test suite. `nextcloud/ocp` ships no autoload sec
 its own, which is why `tests/bootstrap.php` belongs in the list: it registers the
 autoloader for `OCP\` and `NCU\` that nothing else provides.
 
-Read each proposal on its merits rather than applying the run wholesale. Of the four
-rules that fired here, two were worth taking and two were not.
+Read each proposal on its merits rather than applying the run wholesale, and expect to
+reject some. Adding the PHPUnit code-quality set produced four rules over `tests/`, of
+which two were worth taking: `parent::setUp()` is kept here deliberately, and a
+`(string)` cast it suggests is already guaranteed by the declared types.

--- a/doc/development-setup.md
+++ b/doc/development-setup.md
@@ -115,7 +115,7 @@ Run it from a throwaway directory when the supported range moves, then throw the
 directory away:
 
 ```bash
-mkdir /tmp/rector && cd /tmp/rector
+mkdir -p /tmp/rector && cd /tmp/rector || exit
 composer require --dev rector/rector nextcloud/rector
 cat > rector.php <<'PHP'
 <?php

--- a/doc/development-setup.md
+++ b/doc/development-setup.md
@@ -106,3 +106,41 @@ in [tests/smoke/README.md](../tests/smoke/README.md).
 If the Docker daemon refuses to start with `error initializing graphdriver: driver not
 supported`, the kernel was updated without a reboot since — the modules of the running
 kernel are gone, so overlayfs cannot be loaded. Rebooting fixes it.
+
+## Rector, when the Nextcloud range moves
+
+Rector can rewrite calls that a new server renamed, but it is not part of this project:
+its Nextcloud sets for 33, 34 and 35 are the same file, and they change nothing here.
+Run it from a throwaway directory when the supported range moves, then throw the
+directory away:
+
+```bash
+mkdir /tmp/rector && cd /tmp/rector
+composer require --dev rector/rector nextcloud/rector
+cat > rector.php <<'PHP'
+<?php
+use Nextcloud\Rector\Set\NextcloudSets;
+use Rector\Config\RectorConfig;
+return RectorConfig::configure()
+	->withPaths(['/path/to/twofactor_email/lib'])
+	->withAutoloadPaths([
+		'/path/to/twofactor_email/vendor/autoload.php',
+		'/path/to/twofactor_email/tests/bootstrap.php',
+	])
+	->withSets([NextcloudSets::NEXTCLOUD_35]);
+PHP
+vendor/bin/rector process --dry-run
+```
+
+`--dry-run` prints the changes without writing them; read them before applying anything
+by hand.
+
+**Both autoload paths are required.** Without the app's own dependencies, Rector cannot
+see the classes the code inherits from, and a rule that needs that information proposes
+the wrong change with the same confidence as a right one — in one run it wanted to delete
+every `parent::setUp()` in the test suite. `nextcloud/ocp` ships no autoload section of
+its own, which is why `tests/bootstrap.php` belongs in the list: it registers the
+autoloader for `OCP\` and `NCU\` that nothing else provides.
+
+Read each proposal on its merits rather than applying the run wholesale. Of the four
+rules that fired here, two were worth taking and two were not.

--- a/doc/development-setup.md
+++ b/doc/development-setup.md
@@ -115,7 +115,7 @@ nothing at all. Run it from a throwaway directory when the supported range moves
 throw the directory away:
 
 ```bash
-mkdir -p /tmp/rector && cd /tmp/rector || exit
+mkdir -p /tmp/rector && cd /tmp/rector
 composer require --dev rector/rector nextcloud/rector
 cat > rector.php <<'PHP'
 <?php

--- a/psalm.xml
+++ b/psalm.xml
@@ -18,6 +18,27 @@
         </ignoreFiles>
     </extraFiles>
     <issueHandlers>
+        <!-- Nextcloud deprecates an interface long before it removes it, and errorLevel 3
+             files that warning as information nobody reads. Raised to an error, the
+             analysis against the newest OCP says which call has to move while there is
+             still time to move it. -->
+        <DeprecatedClass errorLevel="error"/>
+        <DeprecatedConstant errorLevel="error"/>
+        <DeprecatedInterface errorLevel="error"/>
+        <!-- Nextcloud 35 deprecates ISecureRandom::generate in favour of PHP's
+             Randomizer::getBytesFromString, which needs PHP 8.3. The app's floor is 8.2,
+             because Nextcloud 33 allows it, so the replacement is out of reach and the
+             deprecated call is the only way to generate the code. One method, named on
+             purpose: any other deprecated call still has to be an error.
+             CompatibilityShimsTest fails as soon as the floor reaches 8.3. -->
+        <DeprecatedMethod errorLevel="error">
+            <errorLevel type="suppress">
+                <referencedMethod name="OCP\Security\ISecureRandom::generate"/>
+            </errorLevel>
+        </DeprecatedMethod>
+        <DeprecatedProperty errorLevel="error"/>
+        <DeprecatedTrait errorLevel="error"/>
+
         <!-- One attribute, not one method: #[NoTwoFactorRequired] is @since 34 and the
              analysis also runs against the OCP of the oldest supported server, where it
              does not exist. A suppression in the docblock would have silenced every

--- a/psalm.xml
+++ b/psalm.xml
@@ -19,9 +19,11 @@
     </extraFiles>
     <issueHandlers>
         <!-- Nextcloud deprecates an interface long before it removes it, and errorLevel 3
-             files that warning as information nobody reads. Raised to an error, the
-             analysis against the newest OCP says which call has to move while there is
-             still time to move it. -->
+             files that warning as information nobody reads. Raised to errors, it becomes
+             visible in the run against the server's master branch — which is the Nextcloud
+             next workflow, and non-blocking on purpose. So this is a warning that arrives
+             early, not a gate; the gate follows when the version enters info.xml and the
+             ordinary psalm jobs analyse against it. -->
         <DeprecatedClass errorLevel="error"/>
         <DeprecatedConstant errorLevel="error"/>
         <DeprecatedInterface errorLevel="error"/>
@@ -38,6 +40,7 @@
         </DeprecatedMethod>
         <DeprecatedProperty errorLevel="error"/>
         <DeprecatedTrait errorLevel="error"/>
+        <DeprecatedFunction errorLevel="error"/>
 
         <!-- One attribute, not one method: #[NoTwoFactorRequired] is @since 34 and the
              analysis also runs against the OCP of the oldest supported server, where it

--- a/psalm.xml
+++ b/psalm.xml
@@ -42,10 +42,11 @@
         <!-- One attribute, not one method: #[NoTwoFactorRequired] is @since 34 and the
              analysis also runs against the OCP of the oldest supported server, where it
              does not exist. A suppression in the docblock would have silenced every
-             undefined attribute on that method, including a typo. This handler and the
-             findUnusedIssueHandlerSuppression attribute above are one unit and go
-             together when min-version reaches 34 — CompatibilityShimsTest fails until
-             they do. -->
+             undefined attribute on that method, including a typo. It goes when
+             min-version reaches 34 — CompatibilityShimsTest fails until it does.
+             The findUnusedIssueHandlerSuppression attribute above is not part of that
+             pair: it belongs to every suppression in this file, and goes with the last
+             of them. -->
         <UndefinedAttributeClass>
             <errorLevel type="suppress">
                 <referencedClass name="OCP\AppFramework\Http\Attribute\NoTwoFactorRequired"/>

--- a/tests/Unit/Activity/NotificationTest.php
+++ b/tests/Unit/Activity/NotificationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -11,7 +13,7 @@ use OCA\TwoFactorEMail\Activity\Notification;
 use OCA\TwoFactorEMail\Event\StateChangeActor;
 use PHPUnit\Framework\TestCase;
 
-class NotificationTest extends TestCase {
+final class NotificationTest extends TestCase {
 	public function testUserEnableMapsToEnabledByUser(): void {
 		$this->assertSame(Notification::ENABLED_BY_USER, Notification::fromStateChange(StateChangeActor::USER, true));
 	}

--- a/tests/Unit/Activity/ProviderTest.php
+++ b/tests/Unit/Activity/ProviderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * SPDX-FileCopyrightText: 2025 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -19,7 +21,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 
-class ProviderTest extends TestCase {
+final class ProviderTest extends TestCase {
 	private IFactory&MockObject $l10n;
 	private IURLGenerator&MockObject $urlGenerator;
 

--- a/tests/Unit/Activity/SettingTest.php
+++ b/tests/Unit/Activity/SettingTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * SPDX-FileCopyrightText: 2025 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -13,7 +15,7 @@ use OCP\IL10N;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 
-class SettingTest extends TestCase {
+final class SettingTest extends TestCase {
 	private IL10N&MockObject $l10n;
 
 	private Setting $setting;

--- a/tests/Unit/BackgroundJob/CleanUpExpiredCodesTest.php
+++ b/tests/Unit/BackgroundJob/CleanUpExpiredCodesTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
-class CleanUpExpiredCodesTest extends TestCase {
+final class CleanUpExpiredCodesTest extends TestCase {
 	/**
 	 * @throws Exception
 	 */

--- a/tests/Unit/Command/CleanUpTest.php
+++ b/tests/Unit/Command/CleanUpTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -15,7 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 
-class CleanUpTest extends TestCase {
+final class CleanUpTest extends TestCase {
 	private ICodeStorage&MockObject $codeStorage;
 
 	private CommandTester $tester;

--- a/tests/Unit/Command/DeleteCodesTest.php
+++ b/tests/Unit/Command/DeleteCodesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -18,7 +20,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Tester\CommandTester;
 
-class DeleteCodesTest extends TestCase {
+final class DeleteCodesTest extends TestCase {
 	private ICodeStorage&MockObject $codeStorage;
 
 	private IUserManager&MockObject $userManager;

--- a/tests/Unit/Command/SettingsTest.php
+++ b/tests/Unit/Command/SettingsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -16,7 +18,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 
-class SettingsTest extends TestCase {
+final class SettingsTest extends TestCase {
 	private IAppSettings&MockObject $appSettings;
 
 	private CommandTester $tester;

--- a/tests/Unit/CompatibilityShimsTest.php
+++ b/tests/Unit/CompatibilityShimsTest.php
@@ -26,10 +26,16 @@ use PHPUnit\Framework\TestCase;
 final class CompatibilityShimsTest extends TestCase {
 	private const ROOT = __DIR__ . '/../..';
 
+	/**
+	 * From psalm.xml, not from info.xml. The `<php min-version>` in info.xml is
+	 * maintained by hand and nothing checks it, while the psalm job verifies that
+	 * `phpVersion` equals the floor derived from the oldest supported server. Reading
+	 * the value CI already enforces makes this trigger as reliable as that check.
+	 */
 	private function minimumPhpVersion(): string {
-		$info = file_get_contents(self::ROOT . '/appinfo/info.xml');
-		self::assertIsString($info, 'appinfo/info.xml is not readable');
-		self::assertSame(1, preg_match('/<php[^>]*min-version="([0-9.]+)"/', $info, $m));
+		$psalm = file_get_contents(self::ROOT . '/psalm.xml');
+		self::assertIsString($psalm, 'psalm.xml is not readable');
+		self::assertSame(1, preg_match('/phpVersion="([0-9.]+)"/', $psalm, $m));
 		return $m[1];
 	}
 
@@ -44,9 +50,13 @@ final class CompatibilityShimsTest extends TestCase {
 		$psalm = file_get_contents(self::ROOT . '/psalm.xml');
 		self::assertIsString($psalm);
 
+		// The handler itself, not the comment beside it: a bare class name would also
+		// match the explanation and stay green after the handler was deleted.
+		$handler = '<referencedMethod name="OCP\Security\ISecureRandom::generate"/>';
+
 		if (version_compare($this->minimumPhpVersion(), '8.3', '>=')) {
 			$this->assertStringNotContainsString(
-				'ISecureRandom::generate',
+				$handler,
 				$psalm,
 				'PHP 8.2 is no longer supported: generate the code with '
 				. 'Random\Randomizer::getBytesFromString() and remove the suppression '
@@ -55,7 +65,7 @@ final class CompatibilityShimsTest extends TestCase {
 			return;
 		}
 
-		$this->assertStringContainsString('ISecureRandom::generate', $psalm);
+		$this->assertStringContainsString($handler, $psalm);
 	}
 
 	private function minimumNextcloudVersion(): int {
@@ -66,15 +76,15 @@ final class CompatibilityShimsTest extends TestCase {
 	}
 
 	/**
-	 * Three pieces, one reason: Nextcloud 33 reads the two-factor exemption from the
+	 * Two pieces, one reason: Nextcloud 33 reads the two-factor exemption from the
 	 * docblock annotation and does not know the attribute, which is @since 34. The
 	 * attribute therefore has to sit next to the annotation, and psalm has to be told
 	 * that this one class is missing when it analyses against the oldest supported
-	 * OCP — which in turn needs the unused-suppression check switched off, because
-	 * the same handler is by nature unused against the newest OCP.
+	 * OCP.
 	 *
-	 * Drop Nextcloud 33 and all three are dead weight around a security-relevant
-	 * route. Nobody would notice, so this test does.
+	 * Drop Nextcloud 33 and both are dead weight around a security-relevant route.
+	 * Nobody would notice, so this test does. The unused-suppression flag is not part
+	 * of this pair — it belongs to whichever suppressions exist, see below.
 	 */
 	public function testTheNextcloud33ExemptionShimGoesWhenNextcloud33Does(): void {
 		$controller = file_get_contents(self::ROOT . '/lib/Controller/ChallengeController.php');
@@ -95,20 +105,44 @@ final class CompatibilityShimsTest extends TestCase {
 				'Nextcloud 33 is no longer supported: remove the UndefinedAttributeClass handler '
 				. 'from psalm.xml. The attribute exists in every OCP the app is analysed against.',
 			);
-			$this->assertStringNotContainsString(
-				'findUnusedIssueHandlerSuppression',
+			return;
+		}
+
+		// While 33 is supported the two belong together: one without the other either
+		// breaks the resend route on 33 or turns one of the psalm runs red.
+		$this->assertStringContainsString('@NoTwoFactorRequired', $controller);
+		$this->assertStringContainsString('UndefinedAttributeClass', $psalm);
+	}
+
+	/**
+	 * Every suppression here exists for one end of a version range, and is therefore
+	 * unused at the other end — the analysis runs against the oldest and the newest
+	 * OCP. So the unused-suppression check has to stay off while any suppression is
+	 * left, and has to come back once none is. Tying it to one particular suppression
+	 * would be wrong the moment a second one exists, which is how this test earned
+	 * its own place.
+	 */
+	public function testTheUnusedSuppressionCheckFollowsTheSuppressions(): void {
+		$psalm = file_get_contents(self::ROOT . '/psalm.xml');
+		self::assertIsString($psalm);
+
+		if (str_contains($psalm, '<errorLevel type="suppress">')) {
+			$this->assertStringContainsString(
+				'findUnusedIssueHandlerSuppression="false"',
 				$psalm,
-				'Nextcloud 33 is no longer supported: remove findUnusedIssueHandlerSuppression '
-				. 'from psalm.xml. It existed only for the handler above, and without it a stale '
-				. 'suppression would go unreported.',
+				'psalm.xml still suppresses something, so findUnusedIssueHandlerSuppression '
+				. 'has to stay false: a suppression written for one end of the supported '
+				. 'range is by nature unused at the other, and the analysis would report it.',
 			);
 			return;
 		}
 
-		// While 33 is supported the three belong together: one without the others
-		// either breaks the resend route on 33 or turns one of the psalm runs red.
-		$this->assertStringContainsString('@NoTwoFactorRequired', $controller);
-		$this->assertStringContainsString('UndefinedAttributeClass', $psalm);
-		$this->assertStringContainsString('findUnusedIssueHandlerSuppression="false"', $psalm);
+		$this->assertStringNotContainsString(
+			'findUnusedIssueHandlerSuppression',
+			$psalm,
+			'Nothing is suppressed any more, so remove findUnusedIssueHandlerSuppression '
+			. 'from psalm.xml. Left in place, a suppression that outlived its reason would '
+			. 'go unreported.',
+		);
 	}
 }

--- a/tests/Unit/CompatibilityShimsTest.php
+++ b/tests/Unit/CompatibilityShimsTest.php
@@ -20,6 +20,38 @@ use PHPUnit\Framework\TestCase;
 final class CompatibilityShimsTest extends TestCase {
 	private const ROOT = __DIR__ . '/../..';
 
+	private function minimumPhpVersion(): string {
+		$info = file_get_contents(self::ROOT . '/appinfo/info.xml');
+		self::assertIsString($info, 'appinfo/info.xml is not readable');
+		self::assertSame(1, preg_match('/<php[^>]*min-version="([0-9.]+)"/', $info, $m));
+		return $m[1];
+	}
+
+	/**
+	 * Nextcloud 35 deprecates ISecureRandom::generate in favour of PHP's
+	 * Randomizer::getBytesFromString, which needs PHP 8.3. While the app supports
+	 * PHP 8.2 the replacement is out of reach, so psalm is told to accept that one
+	 * call. The moment the floor moves, the suppression hides a call that should
+	 * have changed — and nothing else would say so.
+	 */
+	public function testTheSecureRandomSuppressionGoesWhenPhp82Does(): void {
+		$psalm = file_get_contents(self::ROOT . '/psalm.xml');
+		self::assertIsString($psalm);
+
+		if (version_compare($this->minimumPhpVersion(), '8.3', '>=')) {
+			$this->assertStringNotContainsString(
+				'ISecureRandom::generate',
+				$psalm,
+				'PHP 8.2 is no longer supported: generate the code with '
+				. 'Random\Randomizer::getBytesFromString() and remove the suppression '
+				. 'for ISecureRandom::generate from psalm.xml.',
+			);
+			return;
+		}
+
+		$this->assertStringContainsString('ISecureRandom::generate', $psalm);
+	}
+
 	private function minimumNextcloudVersion(): int {
 		$info = file_get_contents(self::ROOT . '/appinfo/info.xml');
 		self::assertIsString($info, 'appinfo/info.xml is not readable');

--- a/tests/Unit/CompatibilityShimsTest.php
+++ b/tests/Unit/CompatibilityShimsTest.php
@@ -16,6 +16,12 @@ use PHPUnit\Framework\TestCase;
  * the version it served is dropped, it just sits there. This test makes the moment
  * loud instead — it fails as soon as the supported range moves past the version a
  * shim exists for, and names everything that has to go together.
+ *
+ * This class is the register of those workarounds, and it is meant to be complete.
+ * Anything the app only does because it spans several server or PHP versions belongs
+ * here with the condition that ends it: supporting one version per release removes
+ * all of them at once, and only a complete list makes that a sweep instead of a
+ * search.
  */
 final class CompatibilityShimsTest extends TestCase {
 	private const ROOT = __DIR__ . '/../..';

--- a/tests/Unit/CompatibilityShimsTest.php
+++ b/tests/Unit/CompatibilityShimsTest.php
@@ -48,7 +48,19 @@ final class CompatibilityShimsTest extends TestCase {
 	 */
 	public function testTheSecureRandomSuppressionGoesWhenPhp82Does(): void {
 		$psalm = file_get_contents(self::ROOT . '/psalm.xml');
+		$generator = file_get_contents(self::ROOT . '/lib/Service/NumericalCodeGenerator.php');
 		self::assertIsString($psalm);
+		self::assertIsString($generator);
+
+		// Both sides, like the Nextcloud 33 pair below. A suppression that outlives the
+		// call it was written for is not reported by psalm either, because the unused
+		// check is off — so it would sit here widening what is accepted, unseen.
+		$this->assertStringContainsString(
+			'secureRandom->generate(',
+			$generator,
+			'Nothing calls ISecureRandom::generate any more: remove its suppression from '
+			. 'psalm.xml and this test with it.',
+		);
 
 		// The handler itself, not the comment beside it: a bare class name would also
 		// match the explanation and stay green after the handler was deleted.
@@ -126,7 +138,12 @@ final class CompatibilityShimsTest extends TestCase {
 		$psalm = file_get_contents(self::ROOT . '/psalm.xml');
 		self::assertIsString($psalm);
 
-		if (str_contains($psalm, '<errorLevel type="suppress">')) {
+		// Both forms psalm accepts: the nested element and the attribute on the handler.
+		// Matching only the nested one would call a file "suppressing nothing" while a
+		// suppression written the other way is still in it.
+		$suppresses = preg_match('/(<errorLevel type="suppress">|errorLevel="suppress")/', $psalm) === 1;
+
+		if ($suppresses) {
 			$this->assertStringContainsString(
 				'findUnusedIssueHandlerSuppression="false"',
 				$psalm,

--- a/tests/Unit/CompatibilityShimsTest.php
+++ b/tests/Unit/CompatibilityShimsTest.php
@@ -55,8 +55,13 @@ final class CompatibilityShimsTest extends TestCase {
 		// Both sides, like the Nextcloud 33 pair below. A suppression that outlives the
 		// call it was written for is not reported by psalm either, because the unused
 		// check is off — so it would sit here widening what is accepted, unseen.
+		//
+		// The interface and the call, not the property name: renaming the property is a
+		// refactor that says nothing about the deprecation, and it must not read as
+		// "this carve-out can go".
+		self::assertStringContainsString('ISecureRandom', $generator);
 		$this->assertStringContainsString(
-			'secureRandom->generate(',
+			'->generate(',
 			$generator,
 			'Nothing calls ISecureRandom::generate any more: remove its suppression from '
 			. 'psalm.xml and this test with it.',
@@ -127,21 +132,27 @@ final class CompatibilityShimsTest extends TestCase {
 	}
 
 	/**
-	 * Every suppression here exists for one end of a version range, and is therefore
-	 * unused at the other end — the analysis runs against the oldest and the newest
-	 * OCP. So the unused-suppression check has to stay off while any suppression is
-	 * left, and has to come back once none is. Tying it to one particular suppression
-	 * would be wrong the moment a second one exists, which is how this test earned
-	 * its own place.
+	 * A suppression here exists because the app spans several versions, and in any one
+	 * analysis run it may simply not be triggered: the Nextcloud 33 one is idle against
+	 * the newest OCP, the ISecureRandom one against every OCP in the range until 35
+	 * enters it. Psalm would report each such run's idle suppression as unused, so the
+	 * check stays off while any suppression is left and comes back once none is. Tying
+	 * it to one particular suppression was wrong the moment a second one existed, which
+	 * is how this test earned its own place.
 	 */
 	public function testTheUnusedSuppressionCheckFollowsTheSuppressions(): void {
 		$psalm = file_get_contents(self::ROOT . '/psalm.xml');
 		self::assertIsString($psalm);
 
+		// Comments stripped first: this file explains every handler in prose, and an
+		// explanation quoting the syntax would otherwise count as a suppression and keep
+		// the flag alive after the last real one is gone.
+		$handlers = preg_replace('/<!--.*?-->/s', '', $psalm) ?? $psalm;
+
 		// Both forms psalm accepts: the nested element and the attribute on the handler.
 		// Matching only the nested one would call a file "suppressing nothing" while a
 		// suppression written the other way is still in it.
-		$suppresses = preg_match('/(<errorLevel type="suppress">|errorLevel="suppress")/', $psalm) === 1;
+		$suppresses = preg_match('/(<errorLevel type="suppress">|errorLevel="suppress")/', $handlers) === 1;
 
 		if ($suppresses) {
 			$this->assertStringContainsString(

--- a/tests/Unit/CompatibilityShimsTest.php
+++ b/tests/Unit/CompatibilityShimsTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
  * loud instead — it fails as soon as the supported range moves past the version a
  * shim exists for, and names everything that has to go together.
  */
-class CompatibilityShimsTest extends TestCase {
+final class CompatibilityShimsTest extends TestCase {
 	private const ROOT = __DIR__ . '/../..';
 
 	private function minimumNextcloudVersion(): int {

--- a/tests/Unit/Controller/AdminSettingsControllerTest.php
+++ b/tests/Unit/Controller/AdminSettingsControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -17,7 +19,7 @@ use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class AdminSettingsControllerTest extends TestCase {
+final class AdminSettingsControllerTest extends TestCase {
 	private IAppSettings&MockObject $appSettings;
 
 	private AdminSettingsController $controller;

--- a/tests/Unit/Controller/ChallengeControllerTest.php
+++ b/tests/Unit/Controller/ChallengeControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -22,7 +24,7 @@ use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class ChallengeControllerTest extends TestCase {
+final class ChallengeControllerTest extends TestCase {
 	private IUserSession&MockObject $userSession;
 	private ILoginChallenge&MockObject $challenge;
 	private IStateManager&MockObject $stateManager;

--- a/tests/Unit/Controller/StateControllerTest.php
+++ b/tests/Unit/Controller/StateControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * SPDX-FileCopyrightText: 2025 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -19,7 +21,7 @@ use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class StateControllerTest extends TestCase {
+final class StateControllerTest extends TestCase {
 	private IUserSession&MockObject $userSession;
 	private IStateManager&MockObject $stateManager;
 

--- a/tests/Unit/Event/StateChangedTest.php
+++ b/tests/Unit/Event/StateChangedTest.php
@@ -14,7 +14,7 @@ use OCA\TwoFactorEMail\Event\StateChanged;
 use OCP\IUser;
 use PHPUnit\Framework\MockObject\Exception;
 
-class StateChangedTest extends TestCase {
+final class StateChangedTest extends TestCase {
 	/**
 	 * @throws Exception
 	 */

--- a/tests/Unit/Listener/EMailDeletedTest.php
+++ b/tests/Unit/Listener/EMailDeletedTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class EMailDeletedTest extends TestCase {
+final class EMailDeletedTest extends TestCase {
 	private IStateManager&MockObject $stateManager;
 
 	private EMailDeleted $listener;

--- a/tests/Unit/Listener/StateChangeActivityTest.php
+++ b/tests/Unit/Listener/StateChangeActivityTest.php
@@ -21,7 +21,7 @@ use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 
-class StateChangeActivityTest extends TestCase {
+final class StateChangeActivityTest extends TestCase {
 
 	private StateChangeActivity $listener;
 

--- a/tests/Unit/Listener/StateChangeNotificationTest.php
+++ b/tests/Unit/Listener/StateChangeNotificationTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class StateChangeNotificationTest extends TestCase {
+final class StateChangeNotificationTest extends TestCase {
 	private IManager&MockObject $notificationManager;
 
 	private StateChangeNotification $listener;

--- a/tests/Unit/Listener/StateChangeRegistryUpdaterTest.php
+++ b/tests/Unit/Listener/StateChangeRegistryUpdaterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * SPDX-FileCopyrightText: 2025 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -17,7 +19,7 @@ use OCP\IUser;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 
-class StateChangeRegistryUpdaterTest extends TestCase {
+final class StateChangeRegistryUpdaterTest extends TestCase {
 
 	private StateChangeRegistryUpdater $listener;
 

--- a/tests/Unit/Mail/TemplateRendererTest.php
+++ b/tests/Unit/Mail/TemplateRendererTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -16,7 +18,7 @@ use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class TemplateRendererTest extends TestCase {
+final class TemplateRendererTest extends TestCase {
 	private const STRONG = '<strong style="font-family:monospace">%s</strong>';
 
 	private IUser&MockObject $user;

--- a/tests/Unit/Migration/RemovePersistedDefaultTemplateTest.php
+++ b/tests/Unit/Migration/RemovePersistedDefaultTemplateTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class RemovePersistedDefaultTemplateTest extends TestCase {
+final class RemovePersistedDefaultTemplateTest extends TestCase {
 	private const OLD_DEFAULT_TEMPLATE
 		= "Your two-factor authentication code is: {code}\n\n"
 		. 'If you tried to login, please enter that code on {cloud}. '

--- a/tests/Unit/Notification/NotifierTest.php
+++ b/tests/Unit/Notification/NotifierTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class NotifierTest extends TestCase {
+final class NotifierTest extends TestCase {
 	private Notifier $notifier;
 
 	/**

--- a/tests/Unit/Provider/TwoFactorEMailTest.php
+++ b/tests/Unit/Provider/TwoFactorEMailTest.php
@@ -30,7 +30,7 @@ use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Container\ContainerInterface;
 
-class TwoFactorEMailTest extends TestCase {
+final class TwoFactorEMailTest extends TestCase {
 	private ITemplateManager&MockObject $templateManager;
 	private IL10N&MockObject $l10n;
 	private IInitialState&MockObject $initialState;

--- a/tests/Unit/Service/AppSettingsTest.php
+++ b/tests/Unit/Service/AppSettingsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -15,7 +17,7 @@ use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class AppSettingsTest extends TestCase {
+final class AppSettingsTest extends TestCase {
 	private IAppConfig&MockObject $appConfig;
 
 	private AppSettings $settings;

--- a/tests/Unit/Service/CodeStorageTest.php
+++ b/tests/Unit/Service/CodeStorageTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -14,7 +16,7 @@ use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class CodeStorageTest extends TestCase {
+final class CodeStorageTest extends TestCase {
 	private IUserConfig&MockObject $config;
 
 	private CodeStorage $storage;

--- a/tests/Unit/Service/EMailAddressMaskerTest.php
+++ b/tests/Unit/Service/EMailAddressMaskerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -10,7 +12,7 @@ namespace OCA\TwoFactorEMail\Test\Unit\Service;
 use OCA\TwoFactorEMail\Service\EMailAddressMasker;
 use PHPUnit\Framework\TestCase;
 
-class EMailAddressMaskerTest extends TestCase {
+final class EMailAddressMaskerTest extends TestCase {
 	private EMailAddressMasker $masker;
 
 	protected function setUp(): void {

--- a/tests/Unit/Service/EMailSenderTest.php
+++ b/tests/Unit/Service/EMailSenderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -23,7 +25,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
-class EMailSenderTest extends TestCase {
+final class EMailSenderTest extends TestCase {
 	private IMailer&MockObject $mailer;
 	private Defaults&MockObject $defaults;
 	private IURLGenerator&MockObject $urlGenerator;

--- a/tests/Unit/Service/LoginChallengeTest.php
+++ b/tests/Unit/Service/LoginChallengeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -22,7 +24,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
-class LoginChallengeTest extends TestCase {
+final class LoginChallengeTest extends TestCase {
 	private ICodeGenerator&MockObject $codeGenerator;
 	private ICodeStorage&MockObject $codeStorage;
 	private IEMailSender&MockObject $emailSender;

--- a/tests/Unit/Service/StateManagerTest.php
+++ b/tests/Unit/Service/StateManagerTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class StateManagerTest extends TestCase {
+final class StateManagerTest extends TestCase {
 	private IRegistry&MockObject $registry;
 
 	private StateManager $stateManager;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /** @noinspection PhpIncludeInspection */
 
 /*


### PR DESCRIPTION
Psalm reports a deprecated Nextcloud API as information, so CI stays green while
the window for moving off it passes. Raised to errors.

It found one immediately: Nextcloud 35 deprecates `ISecureRandom::generate`, the
call that produces the one-time code, in favour of PHP's
`Randomizer::getBytesFromString()`, which needs PHP 8.3 — out of reach while the
floor is 8.2 for Nextcloud 33. Deprecated is not removed, so that one method is
accepted by name, and `CompatibilityShimsTest` fails when the floor moves. That
class is now the register of such carve-outs, so supporting one server version
per release becomes a sweep rather than a search.

Also: test classes made final and strict, and a note on why there is no Rector
configuration.

The `strict_types` work in `lib/` that used to be here moved to #197, together
with the conversion it exposes and the smoke coverage for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
