### PR TITLE
Run the tests on every pull request, not only against main

### DIFF
--- a/.github/workflows/nextcloud-next.yml
+++ b/.github/workflows/nextcloud-next.yml
@@ -24,9 +24,9 @@ permissions:
   contents: read
 
 on:
+  # No branch filter: a pull request against release/3.3, or against another
+  # pull request's branch, is a change that has to be tested just the same.
   pull_request:
-    branches:
-      - main
   schedule:
     # Weekly, so upstream breakage surfaces even in a week without a pull request
     - cron: '19 6 * * 1'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,9 @@ permissions:
   pull-requests: write
 
 on:
+  # No branch filter: a pull request against release/3.3, or against another
+  # pull request's branch, is a change that has to be tested just the same.
   pull_request:
-    branches:
-      - main
 
 concurrency:
   group: test-${{ github.head_ref || github.run_id }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,9 @@ treating them as background noise, and re-check whether the existing pins and
   are globbed, so a new root file has to be added there by hand.
 - **GitHub Actions are pinned to a commit SHA** with a version comment, and every
   checkout sets `persist-credentials: false`. Follow the existing workflows.
+- **A `pull_request` trigger carries no branch filter.** A pull request based on
+  another pull request's branch is still a change that has to be tested, and it is the
+  one where a missing check goes unnoticed.
 - **A method that overrides or implements anything carries `#[\Override]`** — an
   interface, an abstract class, a parent method, whether from OCP, Symfony or this app.
   Psalm requires it (`ensureOverrideAttribute`) and names every method missing one. It


### PR DESCRIPTION
`test.yml` and `nextcloud-next.yml` only triggered on pull requests against
`main`. A pull request against `release/3.3` therefore ran neither the
server-and-PHP matrix nor the jobs watching the server's master branch — that
line is maintained and gets its own releases, and its pull requests were the
least covered of any.

A pull request based on another pull request's branch is in the same position,
except that GitHub's stacked pull requests appear to evaluate the filter against
the stack's base and so run the matrix anyway. Not relying on that is the point:
without a filter the coverage does not depend on a preview feature behaving a
particular way.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
