### PR TITLE
Pass the audit workflow's npm version through the environment

### DIFF
--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -51,8 +51,12 @@ jobs:
         with:
           node-version: ${{ steps.versions.outputs.nodeVersion }}
 
+      # The version comes from a file rather than from this workflow, so it reaches
+      # the shell as data. REVIEW.md says why the pull request workflows differ.
       - name: Set up npm ${{ steps.versions.outputs.npmVersion }}
-        run: npm i -g 'npm@${{ steps.versions.outputs.npmVersion }}'
+        env:
+          NPM_VERSION: ${{ steps.versions.outputs.npmVersion }}
+        run: npm i -g "npm@$NPM_VERSION"
 
       # The lock file is what a release ships, and needs no install to be judged.
       - name: Audit

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -92,6 +92,15 @@ factor be skipped, accepted twice or brute-forced outweighs any question of styl
   chain has a fix, and none of it reaches the built bundle. Likewise the `EBADENGINE`
   warnings, which appear because the `@nextcloud/*` packages have not declared Node 26
   yet.
+- **The inline `${{ ... }}` versions in the workflows that pull requests trigger, and
+  CodeQL's cache poisoning alerts.** `npm-audit.yml` passes the npm version through the
+  environment because it audits a branch other than the default one. The other workflows
+  keep the template's inline form on purpose: they run on `pull_request`, where a fork
+  gets a read-only token and no secrets, and they execute the pull request's own code
+  anyway — `npm ci` and the build, or the `psalm` script from its `composer.json`.
+  Injection wins nothing there. The two `actions/cache-poisoning/poisonable-step` alerts
+  on `npm-audit.yml` are dismissed for that reason and a stronger one: no workflow in
+  this repository writes or restores an Actions cache, so there is nothing to poison.
 - **Formatting.** `php-cs-fixer` with `nextcloud/coding-standard` owns it, ESLint and
   Stylelint own the frontend. Tabs, brace placement and import order are not review
   material.


### PR DESCRIPTION
`npm-audit.yml` reads the node and npm versions from the `package.json` of the branch it audits, and that branch is not the default branch. The npm version went straight into the command line, so a manipulated `package.json` could have run its own commands in a job whose runtime token may write Actions cache entries for the default branch. It now travels as an environment variable, which the shell never parses.

The workflows that pull requests trigger keep the template's inline form. They run with a read-only token and without secrets, and they execute the pull request's own code anyway — `npm ci` and the build, or the `psalm` script from its `composer.json` — so injection wins nothing there. That answer, and the dismissal of CodeQL's two `actions/cache-poisoning/poisonable-step` alerts on the audit workflow, now stand in `REVIEW.md`: no workflow in this repository writes or restores an Actions cache, so there is nothing to poison, and GitHub's dismissal comment is capped at 280 characters and invisible to anyone reading the repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
