### PR TITLE
Stop reporting a code as sent when the mailer refuses it (3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- A code was reported as sent when the mail server refused the address (#202)
+
 ## 3.3.2 (2026-08-11)
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - A code was reported as sent when the mail server refused the address (#202)
+- Reloading the challenge page no longer retries a failing mail server without limit
 
 ## 3.3.2 (2026-08-11)
 

--- a/lib/Controller/ChallengeController.php
+++ b/lib/Controller/ChallengeController.php
@@ -17,6 +17,7 @@ namespace OCA\TwoFactorEMail\Controller;
 use OCA\TwoFactorEMail\Exception\EMailNotSet;
 use OCA\TwoFactorEMail\Exception\ResendTooSoon;
 use OCA\TwoFactorEMail\Exception\SendEMailFailed;
+use OCA\TwoFactorEMail\Exception\SendRateLimited;
 use OCA\TwoFactorEMail\Service\ILoginChallenge;
 use OCA\TwoFactorEMail\Service\IStateManager;
 use OCP\AppFramework\Http;
@@ -83,6 +84,13 @@ final class ChallengeController extends ALoginSetupController {
 			);
 			$response->throttle(['action' => self::BRUTE_FORCE_ACTION]);
 			return $response;
+		} catch (SendRateLimited $e) {
+			// No brute-force strike: the app declined to send, the request itself was
+			// legitimate, and this endpoint already allows only one of them a minute.
+			return new JSONResponse(
+				['error' => 'too-soon', 'retryAfter' => $e->retryAfterSeconds],
+				Http::STATUS_TOO_MANY_REQUESTS,
+			);
 		} catch (EMailNotSet) {
 			return new JSONResponse(['error' => 'no-email'], Http::STATUS_BAD_REQUEST);
 		} catch (SendEMailFailed) {

--- a/lib/Exception/SendEMailFailed.php
+++ b/lib/Exception/SendEMailFailed.php
@@ -11,5 +11,9 @@ namespace OCA\TwoFactorEMail\Exception;
 
 use Exception;
 
-final class SendEMailFailed extends Exception {
+/**
+ * Not final: SendRateLimited is the one case that needs to be told apart while
+ * still being treated as a failed send everywhere a code was expected.
+ */
+class SendEMailFailed extends Exception {
 }

--- a/lib/Exception/SendRateLimited.php
+++ b/lib/Exception/SendRateLimited.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Exception;
+
+use Throwable;
+
+/**
+ * The account asked the app to contact the mail server too often, so it was not
+ * asked again. A failed send for everyone who only wants to know whether a code
+ * went out, and its own type for the log and for the resend endpoint, which
+ * would otherwise blame the mail server for something it was never asked to do.
+ */
+final class SendRateLimited extends SendEMailFailed {
+	public function __construct(
+		public readonly int $retryAfterSeconds,
+		?Throwable $previous = null,
+	) {
+		parent::__construct("Send rate limit reached, retry after {$retryAfterSeconds}s", previous: $previous);
+	}
+}

--- a/lib/Service/EMailSender.php
+++ b/lib/Service/EMailSender.php
@@ -52,10 +52,19 @@ final class EMailSender implements IEMailSender {
 		$message->useTemplate($template);
 
 		try {
-			$this->mailer->send($message);
+			$failedRecipients = $this->mailer->send($message);
 		} catch (Exception $e) {
 			$this->logger->error('failed sending email message to user ' . $user->getUID() . '.', ['exception' => $e]);
 			throw new SendEMailFailed(previous: $e);
+		}
+
+		// Nextcloud does not throw when it cannot deliver: it catches the transport error
+		// and returns the addresses it refused. Without this check the app would store
+		// the code and report it as sent while nothing went out.
+		if ($failedRecipients !== []) {
+			// Deliberately without the address (data minimization)
+			$this->logger->error('failed sending email message to user ' . $user->getUID() . ': the mailer refused the recipient.');
+			throw new SendEMailFailed('The mailer refused the recipient address');
 		}
 	}
 }

--- a/lib/Service/EMailSender.php
+++ b/lib/Service/EMailSender.php
@@ -12,17 +12,33 @@ namespace OCA\TwoFactorEMail\Service;
 use Exception;
 use OCA\TwoFactorEMail\Exception\EMailNotSet;
 use OCA\TwoFactorEMail\Exception\SendEMailFailed;
+use OCA\TwoFactorEMail\Exception\SendRateLimited;
 use OCA\TwoFactorEMail\Mail\TemplateRenderer;
 use OCP\IUser;
 use OCP\Mail\IMailer;
+use OCP\Security\RateLimiting\ILimiter;
+use OCP\Security\RateLimiting\IRateLimitExceededException;
 use Psr\Log\LoggerInterface;
 
 final class EMailSender implements IEMailSender {
+	/**
+	 * How often one account may make the app open a connection to the mail
+	 * server, and over which period in seconds. The period is what makes the cap
+	 * reachable while a mail server hangs: Nextcloud waits `mail_smtptimeout`
+	 * seconds for one, ten by default, so ten attempts take about a hundred
+	 * seconds and a shorter window would expire before the tenth. Ten in five
+	 * minutes is out of reach for anyone logging in.
+	 */
+	private const SEND_LIMIT = 10;
+	private const SEND_PERIOD = 300;
+	private const SEND_LIMIT_IDENTIFIER = 'twofactor_email-send';
+
 	public function __construct(
 		private readonly LoggerInterface $logger,
 		private readonly IMailer $mailer,
 		private readonly IAppSettings $appSettings,
 		private readonly TemplateRenderer $templateRenderer,
+		private readonly ILimiter $limiter,
 	) {
 	}
 
@@ -51,6 +67,8 @@ final class EMailSender implements IEMailSender {
 		$message->setTo([$email => $user->getDisplayName()]);
 		$message->useTemplate($template);
 
+		$this->throttle($user);
+
 		try {
 			$failedRecipients = $this->mailer->send($message);
 		} catch (Exception $e) {
@@ -65,6 +83,41 @@ final class EMailSender implements IEMailSender {
 			// Deliberately without the address (data minimization)
 			$this->logger->error('failed sending email message to user ' . $user->getUID() . ': the mailer refused the recipient.');
 			throw new SendEMailFailed('The mailer refused the recipient address');
+		}
+	}
+
+	/**
+	 * Caps how often one account can make the app open a connection to the mail
+	 * server. This cap counts under its own identifier; the rate limit on the
+	 * resend endpoint is a separate budget, even though both are kept by the same
+	 * Nextcloud limiter.
+	 *
+	 * A code that was sent is stored, and a stored code stops the challenge page
+	 * from sending another, so a working mail path passes here about once per
+	 * validity period. A mail server that refuses or cannot be reached leaves
+	 * nothing stored, and every reload of the page would open another connection:
+	 * the page is one of Nextcloud's own routes and carries no rate limit.
+	 *
+	 * This sits after the address check on purpose. Counting an account that has
+	 * no address at all would spend the budget on a send that never happens, and
+	 * would then report a missing address as a mail server that did not answer.
+	 *
+	 * @throws SendRateLimited when the account has reached the cap. The whole
+	 *                         period is the longest it can have to wait, so it is
+	 *                         a safe answer to give without asking the limiter.
+	 * @throws SendEMailFailed when the limiter cannot answer at all
+	 */
+	private function throttle(IUser $user): void {
+		try {
+			$this->limiter->registerUserRequest(self::SEND_LIMIT_IDENTIFIER, self::SEND_LIMIT, self::SEND_PERIOD, $user);
+		} catch (IRateLimitExceededException $e) {
+			throw new SendRateLimited(self::SEND_PERIOD, previous: $e);
+		} catch (Exception $e) {
+			// The limiter counts in the database and fails with it. Every caller here
+			// handles a failed send; an error from the counter would reach the login
+			// page as an exception instead of the message that no code went out.
+			$this->logger->error('failed to check the send rate limit for user ' . $user->getUID() . '.', ['exception' => $e]);
+			throw new SendEMailFailed(previous: $e);
 		}
 	}
 }

--- a/lib/Service/IEMailSender.php
+++ b/lib/Service/IEMailSender.php
@@ -11,6 +11,7 @@ namespace OCA\TwoFactorEMail\Service;
 
 use OCA\TwoFactorEMail\Exception\EMailNotSet;
 use OCA\TwoFactorEMail\Exception\SendEMailFailed;
+use OCA\TwoFactorEMail\Exception\SendRateLimited;
 use OCP\IUser;
 
 interface IEMailSender {
@@ -18,6 +19,8 @@ interface IEMailSender {
 	 * @param IUser $user
 	 * @param string $code
 	 * @throws EMailNotSet
+	 * @throws SendRateLimited if the account reached the cap on how often the app
+	 *                         opens a connection to the mail server
 	 * @throws SendEMailFailed
 	 */
 	public function sendChallengeEMail(IUser $user, string $code): void;

--- a/lib/Service/ILoginChallenge.php
+++ b/lib/Service/ILoginChallenge.php
@@ -12,6 +12,7 @@ namespace OCA\TwoFactorEMail\Service;
 use OCA\TwoFactorEMail\Exception\EMailNotSet;
 use OCA\TwoFactorEMail\Exception\ResendTooSoon;
 use OCA\TwoFactorEMail\Exception\SendEMailFailed;
+use OCA\TwoFactorEMail\Exception\SendRateLimited;
 use OCP\IUser;
 
 interface ILoginChallenge {
@@ -22,6 +23,8 @@ interface ILoginChallenge {
 	 * @return bool true if a new code was sent
 	 *
 	 * @throws EMailNotSet
+	 * @throws SendRateLimited if the account reached the send cap. The login page
+	 *                         reports it as a failed send like any other.
 	 * @throws SendEMailFailed
 	 */
 	public function sendChallenge(IUser $user): bool;
@@ -33,6 +36,9 @@ interface ILoginChallenge {
 	 * @param IUser $user UID
 	 *
 	 * @throws ResendTooSoon if the cooldown has not elapsed yet
+	 * @throws SendRateLimited if the account may not contact the mail server again
+	 *                         yet, which callers can report as "too often" rather
+	 *                         than as a failed send
 	 * @throws EMailNotSet
 	 * @throws SendEMailFailed
 	 */

--- a/lib/Service/LoginChallenge.php
+++ b/lib/Service/LoginChallenge.php
@@ -12,6 +12,7 @@ namespace OCA\TwoFactorEMail\Service;
 use OCA\TwoFactorEMail\Exception\EMailNotSet;
 use OCA\TwoFactorEMail\Exception\ResendTooSoon;
 use OCA\TwoFactorEMail\Exception\SendEMailFailed;
+use OCA\TwoFactorEMail\Exception\SendRateLimited;
 use OCP\IUser;
 use OCP\Security\IHasher;
 use Psr\Log\LoggerInterface;
@@ -39,11 +40,11 @@ final class LoginChallenge implements ILoginChallenge {
 		$storedCodeHash = $this->codeStorage->readCode($user->getUID());
 
 		/**
-		 * Login retry throttling is done by Nextcloud, but re-loading the form would generate and send new codes.
-		 * This is not handled by the brute force protection. We could skip sending emails once a rate limit is reached,
-		 * see https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/security.html#rate-limiting
-		 * Instead, we don't generate and send a new code as long as we can read a code from the user's preferences.
-		 * We can only successfully read a code if there is one stored and while that one is still valid.
+		 * Nextcloud throttles login retries, but not a reload of the challenge page,
+		 * which would otherwise generate and send a new code every time. A stored code
+		 * stops that: it can only be read while one exists and is still valid. Because
+		 * a send that failed stores nothing, that alone is not enough, so EMailSender
+		 * also asks Nextcloud's rate limiter before it opens a connection.
 		 */
 		if (!is_null($storedCodeHash)) {
 			return false;
@@ -124,6 +125,12 @@ final class LoginChallenge implements ILoginChallenge {
 			$this->codeStorage->writeCode($user->getUID(), $this->hasher->hash($generatedCode));
 		} catch (EMailNotSet $e) {
 			$this->logger->warning('Could not send 2FA challenge: No email address configured for user.', [
+				'exception' => $e,
+				'app' => 'twofactor_email',
+			]);
+			throw $e;
+		} catch (SendRateLimited $e) {
+			$this->logger->warning('Not sending a 2FA challenge email: the account reached the send rate limit.', [
 				'exception' => $e,
 				'app' => 'twofactor_email',
 			]);

--- a/tests/Unit/Controller/ChallengeControllerTest.php
+++ b/tests/Unit/Controller/ChallengeControllerTest.php
@@ -12,6 +12,7 @@ use OCA\TwoFactorEMail\Controller\ChallengeController;
 use OCA\TwoFactorEMail\Exception\EMailNotSet;
 use OCA\TwoFactorEMail\Exception\ResendTooSoon;
 use OCA\TwoFactorEMail\Exception\SendEMailFailed;
+use OCA\TwoFactorEMail\Exception\SendRateLimited;
 use OCA\TwoFactorEMail\Service\ILoginChallenge;
 use OCA\TwoFactorEMail\Service\IStateManager;
 use OCP\AppFramework\Http;
@@ -129,5 +130,24 @@ class ChallengeControllerTest extends TestCase {
 
 		$this->assertEquals(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
 		$this->assertEquals(['error' => 'send-failed'], $response->getData());
+		$this->assertTrue($response->isThrottled());
+	}
+
+	/**
+	 * A capped send is a decision of the app, not a failure of the mail server and
+	 * not a suspicious request, so it is answered like the cooldown but without the
+	 * brute-force strike that a real attempt earns.
+	 *
+	 * @throws Exception
+	 */
+	public function testResendReportsTheSendCapAsTooManyRequests(): void {
+		$this->withEnabledUser();
+		$this->challenge->method('resendChallenge')->willThrowException(new SendRateLimited(300));
+
+		$response = $this->controller->resend();
+
+		$this->assertEquals(Http::STATUS_TOO_MANY_REQUESTS, $response->getStatus());
+		$this->assertEquals(['error' => 'too-soon', 'retryAfter' => 300], $response->getData());
+		$this->assertFalse($response->isThrottled());
 	}
 }

--- a/tests/Unit/Service/EMailSenderTest.php
+++ b/tests/Unit/Service/EMailSenderTest.php
@@ -9,15 +9,19 @@ namespace OCA\TwoFactorEMail\Test\Unit\Service;
 
 use OCA\TwoFactorEMail\Exception\EMailNotSet;
 use OCA\TwoFactorEMail\Exception\SendEMailFailed;
+use OCA\TwoFactorEMail\Exception\SendRateLimited;
 use OCA\TwoFactorEMail\Mail\TemplateRenderer;
 use OCA\TwoFactorEMail\Service\EMailSender;
 use OCA\TwoFactorEMail\Service\IAppSettings;
+use OCP\DB\Exception as DbException;
 use OCP\Defaults;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\Mail\IEMailTemplate;
 use OCP\Mail\IMailer;
 use OCP\Mail\IMessage;
+use OCP\Security\RateLimiting\ILimiter;
+use OCP\Security\RateLimiting\IRateLimitExceededException;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -30,6 +34,7 @@ class EMailSenderTest extends TestCase {
 	private IAppSettings&MockObject $appSettings;
 	private IEMailTemplate&MockObject $template;
 	private LoggerInterface&MockObject $logger;
+	private ILimiter&MockObject $limiter;
 
 	private EMailSender $sender;
 
@@ -45,6 +50,7 @@ class EMailSenderTest extends TestCase {
 		$this->appSettings = $this->createMock(IAppSettings::class);
 		$this->template = $this->createMock(IEMailTemplate::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->limiter = $this->createMock(ILimiter::class);
 
 		$this->defaults->method('getName')->willReturn('Example Cloud');
 		$this->appSettings->method('getCodeValidMinutes')->willReturn(10);
@@ -57,7 +63,13 @@ class EMailSenderTest extends TestCase {
 			$this->mailer,
 			$this->appSettings,
 			new TemplateRenderer($this->defaults, $this->urlGenerator, $this->appSettings),
+			$this->limiter,
 		);
+	}
+
+	private function rateLimitExceeded(): IRateLimitExceededException {
+		return new class extends \RuntimeException implements IRateLimitExceededException {
+		};
 	}
 
 	/**
@@ -222,5 +234,95 @@ class EMailSenderTest extends TestCase {
 		$this->expectException(SendEMailFailed::class);
 
 		$this->sender->sendChallengeEMail($this->mockUser('jane@example.com'), '123456');
+	}
+
+	/**
+	 * @throws SendEMailFailed
+	 * @throws EMailNotSet
+	 * @throws Exception
+	 */
+	public function testAsksTheRateLimiterBeforeContactingTheMailServer(): void {
+		$this->mockSendableMail();
+		$user = $this->mockUser('jane@example.org');
+
+		$this->limiter->expects($this->once())
+			->method('registerUserRequest')
+			->with('twofactor_email-send', 10, 300, $user);
+
+		$this->sender->sendChallengeEMail($user, '123456');
+	}
+
+	/**
+	 * @throws EMailNotSet
+	 * @throws Exception
+	 */
+	public function testSendsNothingOnceTheRateLimitIsReached(): void {
+		$this->mockMailer();
+		$this->limiter->method('registerUserRequest')->willThrowException($this->rateLimitExceeded());
+
+		$this->mailer->expects($this->never())->method('send');
+
+		$this->expectException(SendRateLimited::class);
+
+		$this->sender->sendChallengeEMail($this->mockUser('jane@example.org'), '123456');
+	}
+
+	/**
+	 * The whole period is the longest the account can have to wait, and the resend
+	 * dialog counts down from it.
+	 *
+	 * @throws EMailNotSet
+	 * @throws Exception
+	 */
+	public function testNamesHowLongTheCapLasts(): void {
+		$this->mockMailer();
+		$this->limiter->method('registerUserRequest')->willThrowException($this->rateLimitExceeded());
+
+		try {
+			$this->sender->sendChallengeEMail($this->mockUser('jane@example.org'), '123456');
+			$this->fail('the capped send has to throw');
+		} catch (SendRateLimited $e) {
+			$this->assertSame(300, $e->retryAfterSeconds);
+		}
+	}
+
+	/**
+	 * The limiter counts in the database and fails with it. Every caller of this
+	 * service handles a failed send, and nothing else — an error from the counter
+	 * would reach the login page instead of the message that no code went out.
+	 *
+	 * @throws EMailNotSet
+	 * @throws Exception
+	 */
+	public function testReportsAFailedSendWhenTheLimiterCannotAnswer(): void {
+		$this->mockMailer();
+		$this->limiter->method('registerUserRequest')->willThrowException(new DbException());
+
+		$this->mailer->expects($this->never())->method('send');
+
+		try {
+			$this->sender->sendChallengeEMail($this->mockUser('jane@example.org'), '123456');
+			$this->fail('a limiter that cannot answer has to be reported as a failed send');
+		} catch (SendRateLimited) {
+			$this->fail('a limiter that cannot answer is not a cap that was reached');
+		} catch (SendEMailFailed $e) {
+			$this->assertInstanceOf(DbException::class, $e->getPrevious());
+		}
+	}
+
+	/**
+	 * An account without an address never reaches the mail server, so counting it
+	 * would spend the budget on nothing and turn a missing address into a mail
+	 * server that did not answer.
+	 *
+	 * @throws SendEMailFailed
+	 * @throws Exception
+	 */
+	public function testSpendsNoLimitWhenNoEmailIsSet(): void {
+		$this->limiter->expects($this->never())->method('registerUserRequest');
+
+		$this->expectException(EMailNotSet::class);
+
+		$this->sender->sendChallengeEMail($this->mockUser(null), '123456');
 	}
 }

--- a/tests/Unit/Service/EMailSenderTest.php
+++ b/tests/Unit/Service/EMailSenderTest.php
@@ -29,6 +29,7 @@ class EMailSenderTest extends TestCase {
 	private IURLGenerator&MockObject $urlGenerator;
 	private IAppSettings&MockObject $appSettings;
 	private IEMailTemplate&MockObject $template;
+	private LoggerInterface&MockObject $logger;
 
 	private EMailSender $sender;
 
@@ -43,6 +44,7 @@ class EMailSenderTest extends TestCase {
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->appSettings = $this->createMock(IAppSettings::class);
 		$this->template = $this->createMock(IEMailTemplate::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 
 		$this->defaults->method('getName')->willReturn('Example Cloud');
 		$this->appSettings->method('getCodeValidMinutes')->willReturn(10);
@@ -51,7 +53,7 @@ class EMailSenderTest extends TestCase {
 		// the full rendering pipeline. The localized default texts come from
 		// the mocked IAppSettings (their real content is tested in AppSettingsTest).
 		$this->sender = new EMailSender(
-			$this->createMock(LoggerInterface::class),
+			$this->logger,
 			$this->mailer,
 			$this->appSettings,
 			new TemplateRenderer($this->defaults, $this->urlGenerator, $this->appSettings),
@@ -71,10 +73,16 @@ class EMailSenderTest extends TestCase {
 	/**
 	 * @throws Exception
 	 */
-	private function expectMailWithTemplate(): void {
-		$message = $this->createMock(IMessage::class);
+	private function mockMailer(): void {
 		$this->mailer->method('createEMailTemplate')->willReturn($this->template);
-		$this->mailer->method('createMessage')->willReturn($message);
+		$this->mailer->method('createMessage')->willReturn($this->createMock(IMessage::class));
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	private function expectMailWithTemplate(): void {
+		$this->mockMailer();
 		$this->mailer->expects($this->once())->method('send');
 	}
 
@@ -172,5 +180,47 @@ class EMailSenderTest extends TestCase {
 				'Use >>> 123456 <<< on Example Cloud within 10 minutes.',
 			],
 		], $bodyTexts);
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	private function mockSendableMail(): void {
+		$this->mockMailer();
+		$this->appSettings->method('getEMailSubject')->willReturn('Code {code}');
+		$this->appSettings->method('getEMailTemplate')->willReturn('Use {code}.');
+	}
+
+	/**
+	 * @throws EMailNotSet
+	 * @throws Exception
+	 */
+	public function testReportsAFailureWhenTheMailerThrows(): void {
+		$this->mockSendableMail();
+		$this->mailer->method('send')->willThrowException(new \RuntimeException('smtp is down'));
+		$this->logger->expects($this->once())->method('error');
+
+		$this->expectException(SendEMailFailed::class);
+
+		$this->sender->sendChallengeEMail($this->mockUser('jane@example.com'), '123456');
+	}
+
+	/**
+	 * A refused recipient comes back as a return value, not as an exception.
+	 *
+	 * @throws EMailNotSet
+	 * @throws Exception
+	 */
+	public function testReportsAFailureWhenTheMailerRefusesTheRecipient(): void {
+		$this->mockSendableMail();
+		$this->mailer->method('send')->willReturn(['jane@example.com']);
+		// The refused address must not reach the log
+		$this->logger->expects($this->once())
+			->method('error')
+			->with($this->logicalNot($this->stringContains('jane@example.com')));
+
+		$this->expectException(SendEMailFailed::class);
+
+		$this->sender->sendChallengeEMail($this->mockUser('jane@example.com'), '123456');
 	}
 }

--- a/tests/Unit/Service/LoginChallengeTest.php
+++ b/tests/Unit/Service/LoginChallengeTest.php
@@ -181,6 +181,22 @@ class LoginChallengeTest extends TestCase {
 	}
 
 	/**
+	 * @throws EMailNotSet
+	 * @throws Exception
+	 */
+	public function testSendChallengeStoresNoCodeWhenSendingFails(): void {
+		$user = $this->mockUser();
+		$this->codeStorage->method('readCode')->with('alice')->willReturn(null);
+		$this->codeGenerator->method('generateChallengeCode')->willReturn('123456');
+		$this->emailSender->method('sendChallengeEMail')->willThrowException(new SendEMailFailed());
+		$this->codeStorage->expects($this->never())->method('writeCode');
+
+		$this->expectException(SendEMailFailed::class);
+
+		$this->challenge->sendChallenge($user);
+	}
+
+	/**
 	 * @throws SendEMailFailed
 	 * @throws EMailNotSet
 	 * @throws Exception

--- a/tests/Unit/Service/LoginChallengeTest.php
+++ b/tests/Unit/Service/LoginChallengeTest.php
@@ -10,6 +10,7 @@ namespace OCA\TwoFactorEMail\Test\Unit\Service;
 use OCA\TwoFactorEMail\Exception\EMailNotSet;
 use OCA\TwoFactorEMail\Exception\ResendTooSoon;
 use OCA\TwoFactorEMail\Exception\SendEMailFailed;
+use OCA\TwoFactorEMail\Exception\SendRateLimited;
 use OCA\TwoFactorEMail\Service\IAppSettings;
 use OCA\TwoFactorEMail\Service\ICodeGenerator;
 use OCA\TwoFactorEMail\Service\ICodeStorage;
@@ -192,6 +193,25 @@ class LoginChallengeTest extends TestCase {
 		$this->codeStorage->expects($this->never())->method('writeCode');
 
 		$this->expectException(SendEMailFailed::class);
+
+		$this->challenge->sendChallenge($user);
+	}
+
+	/**
+	 * The cap lives in EMailSender, at the connection it protects. What matters
+	 * here is that a capped send is not turned into a mailer error on the way out.
+	 *
+	 * @throws EMailNotSet
+	 * @throws Exception
+	 */
+	public function testSendChallengeStoresNoCodeWhenTheSendWasCapped(): void {
+		$user = $this->mockUser();
+		$this->codeStorage->method('readCode')->with('alice')->willReturn(null);
+		$this->codeGenerator->method('generateChallengeCode')->willReturn('123456');
+		$this->emailSender->method('sendChallengeEMail')->willThrowException(new SendRateLimited(300));
+		$this->codeStorage->expects($this->never())->method('writeCode');
+
+		$this->expectException(SendRateLimited::class);
 
 		$this->challenge->sendChallenge($user);
 	}


### PR DESCRIPTION
`Mailer::send()` does not throw when it cannot deliver. It catches the transport
error and the unparsable address and returns the recipients it refused. This app
ignored that return value, stored the code and told the user one had been sent.

## The fix (#202)

A non-empty return value is now a failed send, and nothing is stored. The
challenge page says so, and the log names which of the two cases it was.

That matters beyond the wrong message. A stored code is what stops the challenge
page from sending another one, so a code stored for a mail that never went out
left the user waiting for the whole validity period with nothing to do: no code
to enter, and no new one to ask for.

## Why the cap comes with it

The stored code was also the only cap on how often the page could ask the mail
server. `GET /login/challenge/{provider}` carries no rate limit — core puts
`UserRateLimit` on the POST beside it and nothing on the page itself, and an app
cannot add an attribute to a controller it does not own. A failed send stores
nothing, and the failed page shows neither the form nor the resend link, so
reloading is the only thing left to do, and every reload opens another
connection. A mail server that refuses the address costs little; one that cannot
be reached costs an SMTP attempt per reload, each holding a worker until the
timeout.

So `EMailSender` registers every send with `OCP\Security\RateLimiting\ILimiter`,
ten in five minutes per account. The limiter has been in the OCP since server 28,
so it is available on Nextcloud 32 as well, and it keeps no state of its own. The
count has an identifier of its own: the resend endpoint carries a rate limit too,
but that is a separate budget kept by the same limiter, and changing one does not
move the other.

**Five minutes, not one.** The window is what makes the cap reachable in the case
it exists for. Nextcloud waits `mail_smtptimeout` seconds for a server that hangs,
ten by default, so serial reloads arrive at most every ten seconds — a one-minute
window would expire before the tenth attempt, and exactly the slow failure the cap
is meant to bound would slip through it. Over five minutes, ten attempts take
about a hundred seconds and the cap bites.

**Ten, and not three.** The limiter cannot give a slot back, and a successful
login spends one — a code is deleted once it is used, so the next login sends
again. A working mail path passes here about once per validity period, because a
stored code suppresses further sends, so ten is out of reach for anyone logging in.

**After the address check, not before.** An account without an address never
reaches the mail server. Counting it would spend the budget on nothing, and would
report a missing address as a mail server that did not answer.

## What a user sees when the cap is reached

The challenge page reports a failed send, like any other. The resend endpoint
answers with 429 and the seconds to wait, the way it already answers for the
resend cooldown, and it records no brute-force attempt: the app declined to send,
and the request itself was legitimate. The existing frontend already turns a
429 into the countdown, so nothing changes there.

The limiter counts in the database and fails with it. A lost connection or a
deadlock is a failed send like any other, not an exception page in the middle of
a login.

## What this line does not carry

The comment in `sendChallenge()` used to say that skipping the send once a rate
limit is reached was an option not taken. It now describes what the code does.

Both changes are backports from `main`, adapted to this line: no `#[\Override]`
and no readonly classes, because it still builds against PHP 8.1. `main` also
gained a threat model entry, an admin documentation section and two smoke test
sections; this line has none of those files, so it carries the code and its unit
tests only.

## Checks

156 PHPUnit tests, php-cs-fixer and Psalm run clean locally. Psalm runs on PHP
8.3 here, because the bundled version refuses 8.5; the taint pass is not part of
this line. The frontend is unchanged, and so is every dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
