### PR TITLE
Stop deleting a code that was never stored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A stored text that puts a placeholder inside a web address no longer blocks occ from setting an unrelated key
 - The admin settings page refuses to save while a stored text puts a placeholder inside a web address
 - Count the subject and body length limits in characters, not bytes
+- Skip the database writes that cleared a code no user had stored
 
 ### Fixed
 

--- a/lib/Service/CodeStorage.php
+++ b/lib/Service/CodeStorage.php
@@ -54,6 +54,19 @@ final readonly class CodeStorage implements ICodeStorage {
 	#[\Override]
 	public function deleteCode(string $userId): bool {
 		$existed = $this->config->getValueString($userId, Application::APP_ID, self::KEY_CODE) !== '';
+		// A timestamp without a code still has to go: deleteExpired() finds users by
+		// their timestamp alone, and would otherwise report a removal that never
+		// happened. Reads are cached, the two deletes below are not, and readCode()
+		// lands here for every user who has no code at all — a missing timestamp
+		// reads as 0, which always counts as expired. Asking whether the key exists is
+		// what separates that from a stored 0: deleteExpired() finds users by key
+		// existence, so a stored 0 has to be deletable or it would be counted as
+		// removed on every run and never go away.
+		$hasTimestamp = $this->config->hasKey($userId, Application::APP_ID, self::KEY_CREATED_AT);
+		if (!$existed && !$hasTimestamp) {
+			return false;
+		}
+
 		$this->config->deleteUserConfig($userId, Application::APP_ID, self::KEY_CODE);
 		$this->config->deleteUserConfig($userId, Application::APP_ID, self::KEY_CREATED_AT);
 		return $existed;

--- a/tests/Unit/Service/CodeStorageTest.php
+++ b/tests/Unit/Service/CodeStorageTest.php
@@ -66,6 +66,45 @@ final class CodeStorageTest extends TestCase {
 		$this->assertFalse($this->storage->deleteCode('alice'));
 	}
 
+	public function testDeleteCodeTouchesNothingWhenNothingIsStored(): void {
+		$this->config->method('getValueString')->willReturn('');
+		$this->config->method('hasKey')->willReturn(false);
+		$this->config->expects($this->never())->method('deleteUserConfig');
+
+		$this->assertFalse($this->storage->deleteCode('alice'));
+	}
+
+	/**
+	 * A timestamp stored as 0 is not the same as no timestamp at all, and only the
+	 * stored one is a row: deleteExpired() finds users by key existence, counts it as
+	 * expired, and would count it again on every run if deleting it did nothing.
+	 */
+	public function testDeleteCodeRemovesATimestampStoredAsZero(): void {
+		$this->config->method('getValueString')->willReturn('');
+		$this->config->method('hasKey')->willReturn(true);
+		$this->config->expects($this->exactly(2))->method('deleteUserConfig');
+
+		$this->assertFalse($this->storage->deleteCode('alice'));
+	}
+
+	/**
+	 * readCode() deletes what it finds expired, and a timestamp with no code is what
+	 * an interrupted write or a hand-edited setting leaves behind. deleteExpired()
+	 * finds such a user by the timestamp alone, so it has to be removable.
+	 */
+	public function testDeleteCodeRemovesATimestampLeftWithoutACode(): void {
+		$this->config->method('getValueString')->willReturn('');
+		$this->config->method('hasKey')->willReturn(true);
+		$deletedKeys = [];
+		$this->config->expects($this->exactly(2))->method('deleteUserConfig')
+			->willReturnCallback(function (string $userId, string $app, string $key) use (&$deletedKeys): void {
+				$deletedKeys[] = $key;
+			});
+
+		$this->assertFalse($this->storage->deleteCode('alice'));
+		$this->assertSame(['code', 'code_created_at'], $deletedKeys);
+	}
+
 	public function testDeleteExpiredReturnsRemovedCount(): void {
 		// validity is 10 minutes: created_at 0 is expired, a fresh one is not
 		$this->config->method('getValuesByUsers')->willReturn(['old' => 0, 'fresh' => time()]);
@@ -102,8 +141,11 @@ final class CodeStorageTest extends TestCase {
 	}
 
 	public function testReadCodeReturnsNullAndClearsAnExpiredCode(): void {
-		// created_at 0 is far older than the validity window → expired
-		$this->config->method('getValueInt')->willReturn(0);
+		// A real expired code: one is stored, and its timestamp is an hour old against
+		// a ten-minute validity. Zero would mean "never written" instead, which is the
+		// case deleteCode() now leaves untouched.
+		$this->config->method('getValueInt')->willReturn(time() - 3600);
+		$this->config->method('getValueString')->willReturn('hashed-code');
 		$this->config->expects($this->atLeastOnce())->method('deleteUserConfig');
 
 		$this->assertNull($this->storage->readCode('alice'));


### PR DESCRIPTION
Every login challenge asks `CodeStorage` for the current code, and a user who has none
reads a timestamp of `0` — which always counts as expired, so `readCode()` called
`deleteCode()`, which issued two DELETE statements against `oc_preferences` for rows
that do not exist. Nextcloud's `deleteUserConfig()` always sends the statement; it does
not check its own cache first. Every first login attempt of every account paid for two
writes that could not change anything.

The deletes are skipped when nothing is stored. Deciding that needs the difference
between a missing timestamp and one stored as `0`, and `getValueInt()` answers both
with `0`: `deleteExpired()` finds users through `getValuesByUsers()`, which lists them
by key existence, so a row holding a timestamp of `0` and no code — what a hand-edited
setting or an interrupted write leaves behind — has to stay deletable. Otherwise it
would be counted as expired on every run and never go away, which is exactly the
"removal that never happened" this guard exists to avoid. `hasKey()` separates the two.

## Why this PR no longer carries a listener

An earlier revision of this branch added an event listener that dropped a pending code,
which is where the old title came from. It is not in the diff any more, and this is why —
kept here because the PR was reviewed under that shape.

The listener reacted to `UserChangedEvent` and dropped a pending code. Measuring it
showed that it cannot carry that promise, and that it does harm on the way:

- The event reports the **system** address. Delivery follows `getEMailAddress()`, which
  prefers `settings/primary_email` when one is set. So the event fires for changes that
  leave delivery exactly where it was — and on such an account the listener throws away
  a code that is still correct, costing the person mid-login a fresh code and one of the
  ten mail-server connections per account.
- It stays silent for the changes that *do* move delivery: picking or removing a
  notification address writes that user value directly and fires nothing.

The replacement binds a code to a fingerprint of the address it was sent to, which
answers the question the event cannot — see the follow-up PR. What is deliberately given
up with the listener is the early cleanup: a code now goes away at the next read or
through `CleanUpExpiredCodes`, not in the moment of the change.

**`release/3.3` keeps the listener** (#217). The fingerprint is not going there, so the
listener is the only thing that helps on that line, and its false positive is the
smaller evil. The two lines differ on purpose.

## Checked

- unit tests for both cases the guard now separates, including the stored zero
- psalm, psalm taint, php-cs-fixer and the unit suite clean

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
