### PR TITLE
Name the address the code was sent to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Administrator documentation for occ, enforcement, email addresses and a FAQ
 - Contributing guidelines, a code of conduct and an overview of the licences used
 - Fresh screenshots in the documentation
+- The login screen names the masked address the code was sent to
 
 ### Security
 
@@ -21,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reject an email subject or body that puts a placeholder inside a web address
 - Report email texts that no longer work as intended, and reset one that is not valid text, on upgrade
 - A code is only accepted for the address it was sent to, whether or not Nextcloud reports the change
+- The address was not masked in rare cases
 
 ### Changed
 

--- a/lib/Provider/TwoFactorEMail.php
+++ b/lib/Provider/TwoFactorEMail.php
@@ -100,7 +100,7 @@ class TwoFactorEMail implements IProvider, IProvidesIcons, IProvidesPersonalSett
 		}
 
 		$template->assign('codeLength', $this->settings->getCodeLength());
-		$template->assign('maskedEmail', $this->emailAddressMasker->maskForUI($user->getEMailAddress() ?? ''));
+		$template->assign('maskedEmail', $this->nameableMask($user));
 		$template->assign('newCodeWasSent', $newCodeWasSent);
 		$template->assign('error', $error);
 		$template->assign('resendCooldown', $this->settings->getResendCooldownSeconds());
@@ -163,8 +163,19 @@ class TwoFactorEMail implements IProvider, IProvidesIcons, IProvidesPersonalSett
 	 */
 	#[\Override]
 	public function getLoginSetup(IUser $user): ILoginSetupProvider {
-		$maskedEmail = $this->emailAddressMasker->maskForUI($this->addressSource->getAddress($user) ?? '');
-		$this->initialStateService->provideInitialState('maskedEmail', $maskedEmail);
+		$this->initialStateService->provideInitialState('maskedEmail', $this->nameableMask($user));
 		return $this->container->get(LoginSetup::class);
+	}
+
+	/**
+	 * The user's masked address, or an empty string when the mask names none.
+	 *
+	 * Both screens that show the address need that distinction: a mask that names
+	 * nothing is not worth showing, and the empty string is what tells them to use
+	 * the wording that names no address instead.
+	 */
+	private function nameableMask(IUser $user): string {
+		$masked = $this->emailAddressMasker->maskForUI($this->addressSource->getAddress($user) ?? '');
+		return $masked === IEMailAddressMasker::HIDDEN ? '' : $masked;
 	}
 }

--- a/lib/Provider/TwoFactorEMail.php
+++ b/lib/Provider/TwoFactorEMail.php
@@ -100,6 +100,7 @@ class TwoFactorEMail implements IProvider, IProvidesIcons, IProvidesPersonalSett
 		}
 
 		$template->assign('codeLength', $this->settings->getCodeLength());
+		$template->assign('maskedEmail', $this->emailAddressMasker->maskForUI($user->getEMailAddress() ?? ''));
 		$template->assign('newCodeWasSent', $newCodeWasSent);
 		$template->assign('error', $error);
 		$template->assign('resendCooldown', $this->settings->getResendCooldownSeconds());

--- a/lib/Service/EMailAddressMasker.php
+++ b/lib/Service/EMailAddressMasker.php
@@ -13,7 +13,13 @@ final class EMailAddressMasker implements IEMailAddressMasker {
 	#[\Override]
 	public function maskForUI(string $emailAddress): string {
 		if (!preg_match('/^([^@\s]+)@([^@\s]+)$/', $emailAddress, $m)) {
-			return $emailAddress;
+			// Anything this cannot take apart is hidden whole. A quoted local
+			// part may hold a space or a second '@', and an address written
+			// through occ passes no validation at all — neither may end up
+			// readable on the login screen. An empty address stays empty, so
+			// that callers can tell "no address" from "an address we cannot
+			// name": only the first of the two is worth a message of its own.
+			return $emailAddress === '' ? '' : self::HIDDEN;
 		}
 
 		$local = $m[1];

--- a/lib/Service/IEMailAddressMasker.php
+++ b/lib/Service/IEMailAddressMasker.php
@@ -10,5 +10,11 @@ declare(strict_types=1);
 namespace OCA\TwoFactorEMail\Service;
 
 interface IEMailAddressMasker {
+	/**
+	 * What maskForUI() returns for an address it cannot take apart. It names no
+	 * address, so a caller that wants to show one has nothing to show.
+	 */
+	public const HIDDEN = '*@*';
+
 	public function maskForUI(string $emailAddress): string;
 }

--- a/src/components/LoginSetup.test.js
+++ b/src/components/LoginSetup.test.js
@@ -40,6 +40,17 @@ describe('LoginSetup', () => {
 		expect(wrapper.find('button').text()).toBe('Proceed')
 	})
 
+	it('names no address when the mask cannot take one apart', async () => {
+		store.maskedEmail = ''
+
+		const wrapper = mount(LoginSetup)
+		await flushPromises()
+
+		expect(wrapper.text()).toContain('Codes will be sent to your primary email address.')
+		expect(wrapper.text()).not.toContain('Codes will be sent to your primary email address:')
+		expect(wrapper.text()).not.toContain('*@*')
+	})
+
 	it('shows a spinner while enabling is still in flight', async () => {
 		let release
 		store.enable.mockReturnValue(new Promise((resolve) => {

--- a/src/components/LoginSetup.vue
+++ b/src/components/LoginSetup.vue
@@ -18,8 +18,11 @@
 		<div v-else-if="loading" class="loading" style="min-height: 50px" />
 		<div v-else>
 			<p>{{ t('twofactor_email', 'Two-factor authentication via email was enabled.') }}</p>
-			<p>
+			<p v-if="store.maskedEmail">
 				{{ t('twofactor_email', 'Codes will be sent to your primary email address:') }} <b>{{ store.maskedEmail }}</b>
+			</p>
+			<p v-else>
+				{{ t('twofactor_email', 'Codes will be sent to your primary email address.') }}
 			</p>
 			<form method="POST">
 				<button>{{ t('twofactor_email', 'Proceed') }}</button>

--- a/templates/LoginChallenge.php
+++ b/templates/LoginChallenge.php
@@ -26,6 +26,7 @@ if (!empty($codeLength)) {
 }
 
 $newCodeWasSent = $_['newCodeWasSent']; // provided in Provider/TwoFactorEMail.php
+$maskedEmail = $_['maskedEmail'] ?? ''; // provided in Provider/TwoFactorEMail.php
 $error = $_['error'] ?? null; // caught and passed in Provider/TwoFactorEMail.php
 $resendCooldown = (int)($_['resendCooldown'] ?? 0); // full cooldown in seconds
 $resendAvailableIn = (int)($_['resendAvailableIn'] ?? 0); // seconds left before a resend is allowed
@@ -43,10 +44,16 @@ $resendAvailableIn = (int)($_['resendAvailableIn'] ?? 0); // seconds left before
 	</p>
 <?php else: ?>
 	<p><?php
+		// The address is part of the sentence, not a line of its own: a translator
+		// needs the whole sentence to put it in the right place and the right case.
 		if ($newCodeWasSent) {
-			p($l->t('A new authentication code was just sent. Please enter it:'));
+			p($maskedEmail !== ''
+				? $l->t('A new authentication code was just sent to %s. Please enter it:', [$maskedEmail])
+				: $l->t('A new authentication code was just sent. Please enter it:'));
 		} else {
-			p($l->t('Enter the authentication code that was sent to you:'));
+			p($maskedEmail !== ''
+				? $l->t('Enter the authentication code that was sent to %s:', [$maskedEmail])
+				: $l->t('Enter the authentication code that was sent to you:'));
 		}
 	?></p>
 	<form method="POST" class="twofactor_email-challenge-form">

--- a/tests/Unit/Provider/TwoFactorEMailTest.php
+++ b/tests/Unit/Provider/TwoFactorEMailTest.php
@@ -203,6 +203,21 @@ final class TwoFactorEMailTest extends TestCase {
 	/**
 	 * @throws Exception
 	 */
+	public function testGetTemplateNamesTheMaskedAddress(): void {
+		$assigns = [];
+		$user = $this->createMock(IUser::class);
+		$user->method('getEMailAddress')->willReturn('alice@example.com');
+		$this->templateManager->method('getTemplate')->willReturn($this->templateCapturing($assigns));
+		$this->masker->method('maskForUI')->with('alice@example.com')->willReturn('a*@*.com');
+
+		$this->provider->getTemplate($user);
+
+		self::assertSame('a*@*.com', $assigns['maskedEmail']);
+	}
+
+	/**
+	 * @throws Exception
+	 */
 	public function testGetTemplateReportsNoEmailWhenTheAddressIsMissing(): void {
 		$assigns = [];
 		$user = $this->createMock(IUser::class);

--- a/tests/Unit/Provider/TwoFactorEMailTest.php
+++ b/tests/Unit/Provider/TwoFactorEMailTest.php
@@ -218,6 +218,21 @@ final class TwoFactorEMailTest extends TestCase {
 	/**
 	 * @throws Exception
 	 */
+	public function testGetTemplateNamesNoAddressWhenTheMaskHidesItWhole(): void {
+		$assigns = [];
+		$user = $this->createMock(IUser::class);
+		$user->method('getEMailAddress')->willReturn('"jo hn"@example.com');
+		$this->templateManager->method('getTemplate')->willReturn($this->templateCapturing($assigns));
+		$this->masker->method('maskForUI')->willReturn(IEMailAddressMasker::HIDDEN);
+
+		$this->provider->getTemplate($user);
+
+		self::assertSame('', $assigns['maskedEmail']);
+	}
+
+	/**
+	 * @throws Exception
+	 */
 	public function testGetTemplateReportsNoEmailWhenTheAddressIsMissing(): void {
 		$assigns = [];
 		$user = $this->createMock(IUser::class);
@@ -256,6 +271,19 @@ final class TwoFactorEMailTest extends TestCase {
 		$this->container->method('get')->with(LoginSetup::class)->willReturn($loginSetup);
 
 		self::assertSame($loginSetup, $this->provider->getLoginSetup($user));
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testGetLoginSetupNamesNoAddressWhenTheMaskHidesItWhole(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getEMailAddress')->willReturn('"jo hn"@example.com');
+		$this->masker->method('maskForUI')->willReturn(IEMailAddressMasker::HIDDEN);
+		$this->initialState->expects($this->once())->method('provideInitialState')->with('maskedEmail', '');
+		$this->container->method('get')->willReturn($this->createMock(ILoginSetupProvider::class));
+
+		$this->provider->getLoginSetup($user);
 	}
 
 	/**

--- a/tests/Unit/Service/EMailAddressMaskerTest.php
+++ b/tests/Unit/Service/EMailAddressMaskerTest.php
@@ -32,12 +32,16 @@ final class EMailAddressMaskerTest extends TestCase {
 		$this->assertSame('u*@*', $this->masker->maskForUI('user@localhost'));
 	}
 
-	public function testReturnsInputWithoutAnAtSignUnchanged(): void {
-		$this->assertSame('notanemail', $this->masker->maskForUI('notanemail'));
+	public function testHidesInputWithoutAnAtSignWhole(): void {
+		$this->assertSame('*@*', $this->masker->maskForUI('notanemail'));
 	}
 
-	public function testReturnsInputWithMultipleAtSignsUnchanged(): void {
-		$this->assertSame('a@b@c', $this->masker->maskForUI('a@b@c'));
+	public function testHidesInputWithMultipleAtSignsWhole(): void {
+		$this->assertSame('*@*', $this->masker->maskForUI('a@b@c'));
+	}
+
+	public function testHidesAQuotedLocalPartWhole(): void {
+		$this->assertSame('*@*', $this->masker->maskForUI('"jo hn"@example.com'));
 	}
 
 	public function testReturnsEmptyInputUnchanged(): void {

--- a/tests/smoke/smoke.sh
+++ b/tests/smoke/smoke.sh
@@ -177,6 +177,15 @@ run_checks() {
 	is "challenge page" "$status" "200"
 	grep -q twofactor_email "$TMP/challenge.html" \
 		&& ok "challenge page loads the app assets" || bad "challenge page has no app assets"
+	# The page names the address, but only the masked form of it. Both halves matter:
+	# without the second, a refactor that assigns the raw address passes unnoticed.
+	# Keep the two together and in this order. The second asks for the ABSENCE of a
+	# string, which an empty or failed fetch would satisfy as well; what rules that
+	# out is the first one failing loudly on the same file just above.
+	grep -qF 'a*@*.org' "$TMP/challenge.html" \
+		&& ok "challenge page names the masked address" || bad "challenge page names no masked address"
+	grep -qF 'admin@example.org' "$TMP/challenge.html" \
+		&& bad "challenge page shows the full address" || ok "challenge page keeps the full address off the screen"
 	is "exactly one mail was sent" "$(mail_count)" "1"
 
 	echo "-- challenge/resend"


### PR DESCRIPTION
The login challenge said that a code had been sent, but not where to. A user who
receives nothing could not tell whether the account carries the right address at
all — the one question the screen has to answer before anyone reaches for their
mailbox. It now names the address in the same masked form the personal settings
use: `a*@*.org`.

The address sits inside the two existing sentences rather than on a line of its
own. A separate line would state the same fact twice, and as a bare fragment it
gives a translator no subject and no verb to make the address agree with; several
languages need it inside the sentence to inflect it at all.

Showing the address made a second thing urgent. `EMailAddressMasker` used to
return anything it could not parse **unchanged** — harmless while only the
settings read it, a disclosure once a login screen prints it. An address whose local part is quoted —
`"jo hn"@example.org`, which the standard allows — may hold a space or a second
`@` and is delivered normally, and an address written
through `occ` passes no validation at all. Such a value is now hidden whole. The
placeholder for it names no address, so both screens that show one — the login
challenge and the enrolment step — turn it into the empty string and use the
wording that names no address instead.

## Translations lag behind, on purpose

**Three** strings are new: the two sentences that name the address, and the
enrolment screen's variant without one (`Codes will be sent to your primary email
address.`, with a full stop where the existing one has a colon). Until Transifex has
them, a non-English instance renders them in English while every other string
stays translated — including the fallback sentences, which are unchanged and keep
their existing translations. This is the normal case, not an edge case, so expect
it to be visible.

The l10n bot runs almost daily, but it only sees strings that reached `main`.
**Merging a few days before a release rather than on the day of it is what closes
this**; there is nothing to fix in the code.

## Not to be merged alone

Once the page names the address, a code that stays valid across an address change
would make that line name the wrong mailbox. `security/drop-the-code-when-the-address-changes`
is what closes that. Merge it first, or both together.

## Checked

- 96 smoke checks green against Nextcloud 33.0.7 and 34.0.2 (`tests/smoke/smoke.sh`)
- unit, psalm, psalm taint, php-cs-fixer, eslint, stylelint and the Vitest suite green
- browser pass on a German instance through all four screen states: address named,
  reload, an address the mask cannot take apart, and no address at all
- the two new smoke assertions forced red by handing the template the raw address —
  exactly those two turned, and nothing else

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
