### PR TITLE
Call the resend link what it says on the screen

### DIFF
--- a/doc/users.md
+++ b/doc/users.md
@@ -20,7 +20,7 @@ The app then emails you a short one-time code and shows the code-entry screen. Y
 
 ![Entering the emailed code on the login screen](../screenshots/challenge.png)
 
-If the email does not arrive, request a fresh one with **Resend** after a short cooldown. Each code is single-use and only one is valid at a time, so reloading the page never floods your inbox.
+If the email does not arrive, request a fresh one with **Send a new code** after a short cooldown. Each code is single-use and only one is valid at a time, so reloading the page never floods your inbox.
 
 ## Desktop and mobile apps
 


### PR DESCRIPTION
The user guide told people to look for **Resend**. The link has read **Send a new
code** for as long as it has existed, so anyone following the guide was looking for
a word that is not on the page.

One line in `doc/users.md`. Found while following up a review comment on
`feature/name-the-masked-address`; kept separate because it has nothing to do with
that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
