### PR TITLE
Stop accepting a code once the address changes (3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Contributing guidelines, a code of conduct and an overview of the licences used
 
+### Changed
+
+- Skip the database writes that cleared a code no user had stored
+
 ### Fixed
 
 - A code was reported as sent when the mail server refused the address (#202)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A code was reported as sent when the mail server refused the address (#202)
 - Reloading the challenge page no longer retries a failing mail server without limit
 
+### Security
+
+- Changing or clearing the account email address now drops a pending code
+
 ## 3.3.2 (2026-08-11)
 
 ### Security

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\TwoFactorEMail\AppInfo;
 
 use OCA\TwoFactorEMail\Event\StateChanged;
+use OCA\TwoFactorEMail\Listener\EMailChanged;
 use OCA\TwoFactorEMail\Listener\EMailDeleted;
 use OCA\TwoFactorEMail\Listener\StateChangeActivity;
 use OCA\TwoFactorEMail\Listener\StateChangeNotification;
@@ -59,6 +60,9 @@ final class Application extends App implements IBootstrap {
 		$context->registerEventListener(StateChanged::class, StateChangeRegistryUpdater::class);
 		$context->registerEventListener(StateChanged::class, StateChangeActivity::class);
 		$context->registerEventListener(StateChanged::class, StateChangeNotification::class);
+		// Drop the code first: the dispatcher stops at a listener that throws, and
+		// EMailDeleted writes to the registry and notifies, so it has more to fail at.
+		$context->registerEventListener(UserChangedEvent::class, EMailChanged::class);
 		$context->registerEventListener(UserChangedEvent::class, EMailDeleted::class);
 
 		$context->registerNotifierService(Notifier::class);

--- a/lib/Listener/EMailChanged.php
+++ b/lib/Listener/EMailChanged.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Listener;
+
+use OCA\TwoFactorEMail\Service\ICodeStorage;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\User\Events\UserChangedEvent;
+
+/**
+ * Drops a stored code when the address for delivery changes.
+ *
+ * A code stays valid for minutes, and it was mailed to the address in force at
+ * the time. Once that address changes, the mailbox that holds the code may
+ * belong to someone else — a typo being corrected is enough — so the code must
+ * stop being accepted. The user simply receives a new one at the new address.
+ *
+ * Trigger: UserChangedEvent for the 'eMailAddress' feature, the same event
+ * EMailDeleted listens to. Clearing the address ends here as well: no address
+ * means no delivery, so a code left behind could only ever be a leftover.
+ *
+ * @template-implements IEventListener<UserChangedEvent>
+ */
+final class EMailChanged implements IEventListener {
+
+	public function __construct(
+		private readonly ICodeStorage $codeStorage,
+	) {
+	}
+
+	/**
+	 * @psalm-suppress DocblockTypeContradiction Deliberate fail-closed guard:
+	 *   the generic narrows $event to UserChangedEvent, but we still verify it
+	 *   at runtime rather than trust the dispatcher registration.
+	 */
+	public function handle(Event $event): void {
+		if (!$event instanceof UserChangedEvent || $event->getFeature() !== 'eMailAddress') {
+			return;
+		}
+		if ((string)$event->getValue() === (string)$event->getOldValue()) {
+			// Rewriting the same address must never break a login in progress. The cast
+			// is what makes that true: the emitter compares against null for an address
+			// that was never set, so clearing an already empty one does fire, with ''
+			// against null. Such an account may still receive mail through its primary
+			// address, which this event says nothing about.
+			return;
+		}
+		$this->codeStorage->deleteCode($event->getUser()->getUID());
+	}
+}

--- a/lib/Service/CodeStorage.php
+++ b/lib/Service/CodeStorage.php
@@ -49,6 +49,16 @@ final class CodeStorage implements ICodeStorage {
 
 	public function deleteCode(string $userId): bool {
 		$existed = $this->config->getValueString($userId, Application::APP_ID, self::KEY_CODE) !== '';
+		// A timestamp without a code still has to go: deleteExpired() finds users by
+		// their timestamp alone, and would otherwise report a removal that never
+		// happened. Reads are cached, the two deletes below are not, and readCode()
+		// lands here for every user who has no code at all — a missing timestamp
+		// reads as 0, which always counts as expired.
+		$hasTimestamp = $this->config->getValueInt($userId, Application::APP_ID, self::KEY_CREATED_AT) !== 0;
+		if (!$existed && !$hasTimestamp) {
+			return false;
+		}
+
 		$this->config->deleteUserConfig($userId, Application::APP_ID, self::KEY_CODE);
 		$this->config->deleteUserConfig($userId, Application::APP_ID, self::KEY_CREATED_AT);
 		return $existed;

--- a/tests/Unit/Listener/EMailChangedTest.php
+++ b/tests/Unit/Listener/EMailChangedTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Test\Unit\Listener;
+
+use OCA\TwoFactorEMail\Listener\EMailChanged;
+use OCA\TwoFactorEMail\Service\ICodeStorage;
+use OCP\EventDispatcher\Event;
+use OCP\IUser;
+use OCP\User\Events\UserChangedEvent;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class EMailChangedTest extends TestCase {
+	private ICodeStorage&MockObject $codeStorage;
+
+	private EMailChanged $listener;
+
+	/**
+	 * @throws Exception
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->codeStorage = $this->createMock(ICodeStorage::class);
+
+		$this->listener = new EMailChanged($this->codeStorage);
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	private function mockUser(): IUser&MockObject {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		return $user;
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testDropsTheCodeWhenTheAddressChanges(): void {
+		$this->codeStorage->expects($this->once())->method('deleteCode')->with('alice');
+
+		$this->listener->handle(new UserChangedEvent($this->mockUser(), 'eMailAddress', 'new@example.com', 'old@example.com'));
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testDropsTheCodeWhenTheAddressIsCleared(): void {
+		$this->codeStorage->expects($this->once())->method('deleteCode')->with('alice');
+
+		$this->listener->handle(new UserChangedEvent($this->mockUser(), 'eMailAddress', '', 'old@example.com'));
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testKeepsTheCodeWhenTheAddressIsWrittenUnchanged(): void {
+		$this->codeStorage->expects($this->never())->method('deleteCode');
+
+		$this->listener->handle(new UserChangedEvent($this->mockUser(), 'eMailAddress', 'same@example.com', 'same@example.com'));
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	/**
+	 * The emitter compares against null for an address that was never set, so clearing
+	 * an already empty one fires with '' against null. Such an account may still be
+	 * reachable through its primary address, and its pending code has to survive.
+	 *
+	 * @throws Exception
+	 */
+	public function testKeepsTheCodeWhenAnAlreadyEmptyAddressIsCleared(): void {
+		$this->codeStorage->expects($this->never())->method('deleteCode');
+
+		$this->listener->handle(new UserChangedEvent($this->mockUser(), 'eMailAddress', '', null));
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testIgnoresAnotherFeatureOfTheSameEvent(): void {
+		$this->codeStorage->expects($this->never())->method('deleteCode');
+
+		$this->listener->handle(new UserChangedEvent($this->mockUser(), 'displayName', 'New Name', 'Old Name'));
+	}
+
+	public function testIgnoresAnUnrelatedEvent(): void {
+		$this->codeStorage->expects($this->never())->method('deleteCode');
+
+		$this->listener->handle(new Event());
+	}
+}

--- a/tests/Unit/Service/CodeStorageTest.php
+++ b/tests/Unit/Service/CodeStorageTest.php
@@ -64,6 +64,32 @@ class CodeStorageTest extends TestCase {
 		$this->assertFalse($this->storage->deleteCode('alice'));
 	}
 
+	public function testDeleteCodeTouchesNothingWhenNothingIsStored(): void {
+		$this->config->method('getValueString')->willReturn('');
+		$this->config->method('getValueInt')->willReturn(0);
+		$this->config->expects($this->never())->method('deleteUserConfig');
+
+		$this->assertFalse($this->storage->deleteCode('alice'));
+	}
+
+	/**
+	 * readCode() deletes what it finds expired, and a timestamp with no code is what
+	 * an interrupted write or a hand-edited setting leaves behind. deleteExpired()
+	 * finds such a user by the timestamp alone, so it has to be removable.
+	 */
+	public function testDeleteCodeRemovesATimestampLeftWithoutACode(): void {
+		$this->config->method('getValueString')->willReturn('');
+		$this->config->method('getValueInt')->willReturn(1234567890);
+		$deletedKeys = [];
+		$this->config->expects($this->exactly(2))->method('deleteUserConfig')
+			->willReturnCallback(function (string $userId, string $app, string $key) use (&$deletedKeys): void {
+				$deletedKeys[] = $key;
+			});
+
+		$this->assertFalse($this->storage->deleteCode('alice'));
+		$this->assertSame(['code', 'code_created_at'], $deletedKeys);
+	}
+
 	public function testDeleteExpiredReturnsRemovedCount(): void {
 		// validity is 10 minutes: created_at 0 is expired, a fresh one is not
 		$this->config->method('getValuesByUsers')->willReturn(['old' => 0, 'fresh' => time()]);
@@ -91,8 +117,11 @@ class CodeStorageTest extends TestCase {
 	}
 
 	public function testReadCodeReturnsNullAndClearsAnExpiredCode(): void {
-		// created_at 0 is far older than the validity window → expired
-		$this->config->method('getValueInt')->willReturn(0);
+		// A real expired code: one is stored, and its timestamp is an hour old against
+		// a ten-minute validity. Zero would mean "never written" instead, which is the
+		// case deleteCode() now leaves untouched.
+		$this->config->method('getValueInt')->willReturn(time() - 3600);
+		$this->config->method('getValueString')->willReturn('hashed-code');
 		$this->config->expects($this->atLeastOnce())->method('deleteUserConfig');
 
 		$this->assertNull($this->storage->readCode('alice'));


### PR DESCRIPTION
The 3.3 twin of #214. Same change, same reasoning; this text
repeats what matters so the pull request stands on its own.

A one-time code is mailed to whatever address the account carries at that moment.
If the address then changes, the mailbox holding that code may belong to someone
else — and until now the code stayed valid, so whoever held it could finish the
login. Changing or clearing the address now drops any pending code.

The app listens for Nextcloud's `UserChangedEvent`, which every documented way of
writing the address emits. An unchanged value is ignored so that rewriting the same
address cannot break a login in progress; that comparison casts both sides to
string, because for an address that was never set the emitter compares against
`null`, and clearing an already empty address would otherwise drop a code that is
still deliverable through the account's primary address.

Carried along is a database write that was never needed: every login challenge asks
for the current code, and a user who has none reads a timestamp of `0`, which always
counts as expired — so two DELETE statements went out for rows that do not exist.
They are skipped now, while a timestamp left behind without a code is still removed,
because the cleanup command finds such users by their timestamp alone.

**What is deliberately missing here:** the smoke test. This line has no
`tests/smoke/`, so the end-to-end proof exists only on the main line.

## Checked

- unit tests per path, php-cs-fixer clean
- psalm clean — on this line it needs `php-legacy`, because Psalm 6.8.2 refuses to
  run on PHP 8.5

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
