### PR TITLE
Name the address the code was sent to (3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Contributing guidelines, a code of conduct and an overview of the licences used
+- The login screen names the masked address the code was sent to
 
 ### Changed
 
@@ -23,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - Changing or clearing the account email address now drops a pending code
+- The address was not masked in rare cases
 
 ## 3.3.2 (2026-08-11)
 

--- a/lib/Provider/TwoFactorEMail.php
+++ b/lib/Provider/TwoFactorEMail.php
@@ -90,6 +90,7 @@ class TwoFactorEMail implements IProvider, IProvidesIcons, IProvidesPersonalSett
 		}
 
 		$template->assign('codeLength', $this->settings->getCodeLength());
+		$template->assign('maskedEmail', $this->emailAddressMasker->maskForUI($user->getEMailAddress() ?? ''));
 		$template->assign('newCodeWasSent', $newCodeWasSent);
 		$template->assign('error', $error);
 		$template->assign('resendCooldown', $this->settings->getResendCooldownSeconds());

--- a/lib/Provider/TwoFactorEMail.php
+++ b/lib/Provider/TwoFactorEMail.php
@@ -90,7 +90,7 @@ class TwoFactorEMail implements IProvider, IProvidesIcons, IProvidesPersonalSett
 		}
 
 		$template->assign('codeLength', $this->settings->getCodeLength());
-		$template->assign('maskedEmail', $this->emailAddressMasker->maskForUI($user->getEMailAddress() ?? ''));
+		$template->assign('maskedEmail', $this->nameableMask($user));
 		$template->assign('newCodeWasSent', $newCodeWasSent);
 		$template->assign('error', $error);
 		$template->assign('resendCooldown', $this->settings->getResendCooldownSeconds());
@@ -145,8 +145,19 @@ class TwoFactorEMail implements IProvider, IProvidesIcons, IProvidesPersonalSett
 	 * @throws ContainerExceptionInterface
 	 */
 	public function getLoginSetup(IUser $user): ILoginSetupProvider {
-		$maskedEmail = $this->emailAddressMasker->maskForUI($user->getEMailAddress() ?? '');
-		$this->initialStateService->provideInitialState('maskedEmail', $maskedEmail);
+		$this->initialStateService->provideInitialState('maskedEmail', $this->nameableMask($user));
 		return $this->container->get(LoginSetup::class);
+	}
+
+	/**
+	 * The user's masked address, or an empty string when the mask names none.
+	 *
+	 * Both screens that show the address need that distinction: a mask that names
+	 * nothing is not worth showing, and the empty string is what tells them to use
+	 * the wording that names no address instead.
+	 */
+	private function nameableMask(IUser $user): string {
+		$masked = $this->emailAddressMasker->maskForUI($user->getEMailAddress() ?? '');
+		return $masked === IEMailAddressMasker::HIDDEN ? '' : $masked;
 	}
 }

--- a/lib/Service/EMailAddressMasker.php
+++ b/lib/Service/EMailAddressMasker.php
@@ -12,7 +12,13 @@ namespace OCA\TwoFactorEMail\Service;
 final class EMailAddressMasker implements IEMailAddressMasker {
 	public function maskForUI(string $emailAddress): string {
 		if (!preg_match('/^([^@\s]+)@([^@\s]+)$/', $emailAddress, $m)) {
-			return $emailAddress;
+			// Anything this cannot take apart is hidden whole. A quoted local
+			// part may hold a space or a second '@', and an address written
+			// through occ passes no validation at all — neither may end up
+			// readable on the login screen. An empty address stays empty, so
+			// that callers can tell "no address" from "an address we cannot
+			// name": only the first of the two is worth a message of its own.
+			return $emailAddress === '' ? '' : self::HIDDEN;
 		}
 
 		$local = $m[1];

--- a/lib/Service/IEMailAddressMasker.php
+++ b/lib/Service/IEMailAddressMasker.php
@@ -8,5 +8,11 @@
 namespace OCA\TwoFactorEMail\Service;
 
 interface IEMailAddressMasker {
+	/**
+	 * What maskForUI() returns for an address it cannot take apart. It names no
+	 * address, so a caller that wants to show one has nothing to show.
+	 */
+	public const HIDDEN = '*@*';
+
 	public function maskForUI(string $emailAddress): string;
 }

--- a/src/components/LoginSetup.test.js
+++ b/src/components/LoginSetup.test.js
@@ -40,6 +40,17 @@ describe('LoginSetup', () => {
 		expect(wrapper.find('button').text()).toBe('Proceed')
 	})
 
+	it('names no address when the mask cannot take one apart', async () => {
+		store.maskedEmail = ''
+
+		const wrapper = mount(LoginSetup)
+		await flushPromises()
+
+		expect(wrapper.text()).toContain('Codes will be sent to your primary email address.')
+		expect(wrapper.text()).not.toContain('Codes will be sent to your primary email address:')
+		expect(wrapper.text()).not.toContain('*@*')
+	})
+
 	it('shows a spinner while enabling is still in flight', async () => {
 		let release
 		store.enable.mockReturnValue(new Promise((resolve) => {

--- a/src/components/LoginSetup.vue
+++ b/src/components/LoginSetup.vue
@@ -18,8 +18,11 @@
 		<div v-else-if="loading" class="loading" style="min-height: 50px" />
 		<div v-else>
 			<p>{{ t('twofactor_email', 'Two-factor authentication via email was enabled.') }}</p>
-			<p>
+			<p v-if="store.maskedEmail">
 				{{ t('twofactor_email', 'Codes will be sent to your primary email address:') }} <b>{{ store.maskedEmail }}</b>
+			</p>
+			<p v-else>
+				{{ t('twofactor_email', 'Codes will be sent to your primary email address.') }}
 			</p>
 			<form method="POST">
 				<button>{{ t('twofactor_email', 'Proceed') }}</button>

--- a/templates/LoginChallenge.php
+++ b/templates/LoginChallenge.php
@@ -26,6 +26,7 @@ if (!empty($codeLength)) {
 }
 
 $newCodeWasSent = $_['newCodeWasSent']; // provided in Provider/TwoFactorEMail.php
+$maskedEmail = $_['maskedEmail'] ?? ''; // provided in Provider/TwoFactorEMail.php
 $error = $_['error'] ?? null; // caught and passed in Provider/TwoFactorEMail.php
 $resendCooldown = (int)($_['resendCooldown'] ?? 0); // full cooldown in seconds
 $resendAvailableIn = (int)($_['resendAvailableIn'] ?? 0); // seconds left before a resend is allowed
@@ -43,10 +44,16 @@ $resendAvailableIn = (int)($_['resendAvailableIn'] ?? 0); // seconds left before
 	</p>
 <?php else: ?>
 	<p><?php
+		// The address is part of the sentence, not a line of its own: a translator
+		// needs the whole sentence to put it in the right place and the right case.
 		if ($newCodeWasSent) {
-			p($l->t('A new authentication code was just sent. Please enter it:'));
+			p($maskedEmail !== ''
+				? $l->t('A new authentication code was just sent to %s. Please enter it:', [$maskedEmail])
+				: $l->t('A new authentication code was just sent. Please enter it:'));
 		} else {
-			p($l->t('Enter the authentication code that was sent to you:'));
+			p($maskedEmail !== ''
+				? $l->t('Enter the authentication code that was sent to %s:', [$maskedEmail])
+				: $l->t('Enter the authentication code that was sent to you:'));
 		}
 	?></p>
 	<form method="POST" class="twofactor_email-challenge-form">

--- a/tests/Unit/Provider/TwoFactorEMailTest.php
+++ b/tests/Unit/Provider/TwoFactorEMailTest.php
@@ -202,6 +202,21 @@ class TwoFactorEMailTest extends TestCase {
 	/**
 	 * @throws Exception
 	 */
+	public function testGetTemplateNamesTheMaskedAddress(): void {
+		$assigns = [];
+		$user = $this->createMock(IUser::class);
+		$user->method('getEMailAddress')->willReturn('alice@example.com');
+		$this->templateManager->method('getTemplate')->willReturn($this->templateCapturing($assigns));
+		$this->masker->method('maskForUI')->with('alice@example.com')->willReturn('a*@*.com');
+
+		$this->provider->getTemplate($user);
+
+		self::assertSame('a*@*.com', $assigns['maskedEmail']);
+	}
+
+	/**
+	 * @throws Exception
+	 */
 	public function testGetTemplateReportsNoEmailWhenTheAddressIsMissing(): void {
 		$assigns = [];
 		$user = $this->createMock(IUser::class);

--- a/tests/Unit/Provider/TwoFactorEMailTest.php
+++ b/tests/Unit/Provider/TwoFactorEMailTest.php
@@ -217,6 +217,21 @@ class TwoFactorEMailTest extends TestCase {
 	/**
 	 * @throws Exception
 	 */
+	public function testGetTemplateNamesNoAddressWhenTheMaskHidesItWhole(): void {
+		$assigns = [];
+		$user = $this->createMock(IUser::class);
+		$user->method('getEMailAddress')->willReturn('"jo hn"@example.com');
+		$this->templateManager->method('getTemplate')->willReturn($this->templateCapturing($assigns));
+		$this->masker->method('maskForUI')->willReturn(IEMailAddressMasker::HIDDEN);
+
+		$this->provider->getTemplate($user);
+
+		self::assertSame('', $assigns['maskedEmail']);
+	}
+
+	/**
+	 * @throws Exception
+	 */
 	public function testGetTemplateReportsNoEmailWhenTheAddressIsMissing(): void {
 		$assigns = [];
 		$user = $this->createMock(IUser::class);
@@ -255,6 +270,19 @@ class TwoFactorEMailTest extends TestCase {
 		$this->container->method('get')->with(LoginSetup::class)->willReturn($loginSetup);
 
 		self::assertSame($loginSetup, $this->provider->getLoginSetup($user));
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function testGetLoginSetupNamesNoAddressWhenTheMaskHidesItWhole(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getEMailAddress')->willReturn('"jo hn"@example.com');
+		$this->masker->method('maskForUI')->willReturn(IEMailAddressMasker::HIDDEN);
+		$this->initialState->expects($this->once())->method('provideInitialState')->with('maskedEmail', '');
+		$this->container->method('get')->willReturn($this->createMock(ILoginSetupProvider::class));
+
+		$this->provider->getLoginSetup($user);
 	}
 
 	/**

--- a/tests/Unit/Service/EMailAddressMaskerTest.php
+++ b/tests/Unit/Service/EMailAddressMaskerTest.php
@@ -30,12 +30,16 @@ class EMailAddressMaskerTest extends TestCase {
 		$this->assertSame('u*@*', $this->masker->maskForUI('user@localhost'));
 	}
 
-	public function testReturnsInputWithoutAnAtSignUnchanged(): void {
-		$this->assertSame('notanemail', $this->masker->maskForUI('notanemail'));
+	public function testHidesInputWithoutAnAtSignWhole(): void {
+		$this->assertSame('*@*', $this->masker->maskForUI('notanemail'));
 	}
 
-	public function testReturnsInputWithMultipleAtSignsUnchanged(): void {
-		$this->assertSame('a@b@c', $this->masker->maskForUI('a@b@c'));
+	public function testHidesInputWithMultipleAtSignsWhole(): void {
+		$this->assertSame('*@*', $this->masker->maskForUI('a@b@c'));
+	}
+
+	public function testHidesAQuotedLocalPartWhole(): void {
+		$this->assertSame('*@*', $this->masker->maskForUI('"jo hn"@example.com'));
 	}
 
 	public function testReturnsEmptyInputUnchanged(): void {


### PR DESCRIPTION
The 3.3 twin of #215. Same change, same reasoning; this text repeats
what matters so the pull request stands on its own.

The login challenge said that a code had been sent, but not where to. A user who
receives nothing could not tell whether the account carries the right address at
all. It now names the address in the same masked form the personal settings use:
`a*@*.org`. The address sits inside the two existing sentences rather than on a
line of its own — a separate line would state the same fact twice, and as a bare
fragment it gives a translator no subject and no verb to make the address agree
with.

Showing the address made a second thing urgent. `EMailAddressMasker` used to
return anything it could not parse **unchanged** — harmless while only the
settings read it, a disclosure once a login screen prints it. An address whose local part is quoted —
`"jo hn"@example.org`, which the standard allows — may hold a space or a second
`@` and is delivered normally, and an address written
through `occ` passes no validation at all. Such a value is now hidden whole, and
because that placeholder names no address, both screens that show one turn it into
the empty string and use the wording that names none.

## Why the whole change, not only the hardening

This line normally takes security fixes only, and of the two commits just the
`EMailAddressMasker` hardening is one. Carrying the naming as well is a deliberate
decision: the two belong together — the hardening exists *because* the screen
names the address — and splitting them would leave 3.3 with a fail-closed masker
whose only caller does nothing with it, plus a diff that no longer matches the
main line. Keeping the lines identical here is worth more than the smaller change.

## Translations lag behind, on purpose

**Three** strings are new: the two sentences that name the address, and the
enrolment screen's variant without one (`Codes will be sent to your primary email
address.`, with a full stop where the existing one has a colon). Until Transifex has
them, a non-English instance renders them in English while every other string
stays translated — the fallback sentences are unchanged and keep their existing
translations. The l10n bot only sees strings that reached the repository, so merge
a few days before a release rather than on the day of it.

## Checked

- unit (160), Vitest (78), php-cs-fixer and eslint green
- psalm green — on this line it needs `php-legacy`, because Psalm 6.8.2 refuses to
  run on PHP 8.5
- the equivalent change on the main line additionally passed 96 smoke checks on
  Nextcloud 33 and 34 and a browser pass through all four screen states

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
