### PR TITLE
Say which address change actually fires the event

### DIFF
--- a/lib/Listener/EMailDeleted.php
+++ b/lib/Listener/EMailDeleted.php
@@ -21,10 +21,29 @@ use OCP\User\Events\UserChangedEvent;
  * password-only.
  *
  * Trigger: UserChangedEvent for the 'eMailAddress' feature. Every path that
- * clears the address used for delivery goes through IUser::setSystemEMailAddress()
+ * clears the *system* address goes through IUser::setSystemEMailAddress()
  * (personal settings, the users page, the provisioning API, `occ user:setting`),
- * which fires this event. Account-only changes (additional emails,
- * `occ user:profile`) leave getEMailAddress() intact and are correctly ignored.
+ * which fires this event. Changes to an account's additional emails, and
+ * `occ user:profile`, do not fire it — they normally leave getEMailAddress()
+ * intact, and are then correctly ignored.
+ *
+ * Delivery can still change without a usable event, in two shapes. Deleting the
+ * additional address a user had picked as their notification address calls
+ * IUser::setPrimaryEMailAddress(''), which drops 'settings/primary_email', so
+ * getEMailAddress() falls back to the system address — or returns null, when the
+ * account has none. Writing that user value instead, as `occ user:setting <uid>
+ * settings primary_email` does, redirects delivery to another address just as
+ * silently. Neither dispatches anything the app could use: the delete does emit
+ * UserUpdatedEvent from the account data, but before the reset, so
+ * getEMailAddress() still reads the old address there — EMailDeletedTest pins that
+ * this listener ignores that event.
+ *
+ * Only the drop to null concerns this listener, and missing it is never a downgrade:
+ * the listener does not run, so the provider stays enabled — stricter than the
+ * disable below while another factor remains, and the same fail-closed state when
+ * email is the sole factor. A silent redirect is a different risk, and the one
+ * doc/threat-model.md carries where it states what the app promises, and does not
+ * promise, about the notification address.
  *
  * Once the address is gone and the provider is still enabled:
  *   - another active provider remains → disable, no protection is lost;


### PR DESCRIPTION
The class docblock of `EMailDeleted` claimed that **every** path clearing the address used for delivery goes through `IUser::setSystemEMailAddress()` and therefore reaches this listener. It does not, and the claim contradicted the app's own threat model.

Two paths change the delivery address without dispatching anything usable:

* Deleting the additional address a user had picked as their notification address calls `IUser::setPrimaryEMailAddress('')` (`apps/provisioning_api/lib/Controller/UsersController.php`, branch `COLLECTION_EMAIL`), which only removes the `settings/primary_email` user value.
* `occ user:setting <uid> settings primary_email` writes or deletes that user value directly — only `email` and `display_name` are special-cased in `core/Command/User/Setting.php`.

After either, `getEMailAddress()` falls back to the system address, or returns `null` when the account has none. The account data does emit `UserUpdatedEvent` on the first path, but before the primary address is reset, so `getEMailAddress()` read from it still yields the old address. That event is no hook for this, which is why the listener ignores it — a behaviour `EMailDeletedTest` already pins.

**No behaviour changes.** There is nothing to react to, and a listener that never runs leaves the provider enabled. That is stricter than disabling it, never a downgrade to password-only.

The docblock now limits itself to the system address, names the two paths that get past it, and points at the threat model entry *"A code outlives a changed notification address"*, so the two texts do not drift apart again.

**Merge after #214.** That entry reaches `main` with it; this branch touches no file #214 touches, so there is no conflict, only an order.

Every claim above was verified against a local checkout of nextcloud/server.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.