### PR TITLE
Do not count backup codes as the other second factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Keep email 2FA on when the only other factor is backup codes, which Nextcloud does not accept alone
 - Require the second factor for the admin settings routes while an admin is still being set up
 - Check the finished email and fall back to the default text if the one-time code ended up in a web address
 - Reject an email subject or body that puts a placeholder inside a web address

--- a/lib/Listener/EMailDeleted.php
+++ b/lib/Listener/EMailDeleted.php
@@ -29,7 +29,9 @@ use OCP\User\Events\UserChangedEvent;
  * Once the address is gone and the provider is still enabled:
  *   - another active provider remains → disable, no protection is lost;
  *   - email was the sole factor → keep it enabled (fail-closed), whoever
- *     cleared the address.
+ *     cleared the address. Backup codes are not such a factor: Nextcloud does
+ *     not accept them alone, so an account holding only those keeps email
+ *     enabled and its user logs in with a backup code.
  *
  * Disabling the sole factor would drop the account to password-only. That would
  * skip the password confirmation which turning 2FA off directly requires

--- a/lib/Service/IStateManager.php
+++ b/lib/Service/IStateManager.php
@@ -22,6 +22,8 @@ interface IStateManager {
 	/**
 	 * Whether the user has another active 2FA provider besides email, i.e.
 	 * disabling email would not leave the account without a second factor.
+	 * Backup codes do not count: Nextcloud does not accept them as the only
+	 * second factor, so an account left with nothing else is password-only.
 	 */
 	public function hasOtherActiveProvider(IUser $user): bool;
 }

--- a/lib/Service/StateManager.php
+++ b/lib/Service/StateManager.php
@@ -24,6 +24,13 @@ final readonly class StateManager implements IStateManager {
 
 	private const PROVIDER_ID = 'email';
 
+	/**
+	 * Nextcloud does not accept backup codes as the only second factor: its own
+	 * check for an account being two-factor protected leaves them out. So they
+	 * cannot stand in for this provider either.
+	 */
+	private const BACKUP_CODES_PROVIDER_ID = 'backup_codes';
+
 	public function __construct(
 		private IEventDispatcher $eventDispatcher,
 		private IRegistry $registry,
@@ -48,7 +55,7 @@ final readonly class StateManager implements IStateManager {
 	#[\Override]
 	public function hasOtherActiveProvider(IUser $user): bool {
 		foreach ($this->registry->getProviderStates($user) as $providerId => $enabled) {
-			if ($enabled && $providerId !== self::PROVIDER_ID) {
+			if ($enabled && $providerId !== self::PROVIDER_ID && $providerId !== self::BACKUP_CODES_PROVIDER_ID) {
 				return true;
 			}
 		}

--- a/tests/Unit/Service/StateManagerTest.php
+++ b/tests/Unit/Service/StateManagerTest.php
@@ -59,6 +59,18 @@ final class StateManagerTest extends TestCase {
 		$this->assertFalse($this->stateManager->hasOtherActiveProvider($user));
 	}
 
+	public function testHasOtherActiveProviderIsTrueForBackupCodesBesideARealProvider(): void {
+		$user = $this->withProviderStates(['email' => true, 'backup_codes' => true, 'totp' => true]);
+
+		$this->assertTrue($this->stateManager->hasOtherActiveProvider($user));
+	}
+
+	public function testHasOtherActiveProviderIsFalseForBackupCodesAlone(): void {
+		$user = $this->withProviderStates(['email' => true, 'backup_codes' => true]);
+
+		$this->assertFalse($this->stateManager->hasOtherActiveProvider($user));
+	}
+
 	public function testHasOtherActiveProviderIsFalseWithoutAnyProviders(): void {
 		$user = $this->withProviderStates([]);
 


### PR DESCRIPTION
When the address a code is mailed to disappears, `EMailDeleted` switches this provider
off if the account still has another second factor, and leaves it on otherwise. It asked
the registry for any enabled provider other than `email`, and backup codes answered that
question with yes.

Nextcloud itself does not. `IManager::isTwoFactorAuthenticated()` takes `backup_codes`
out of the list before deciding whether an account is protected, because they are a way
back in, not a factor to log in with every day. An account with email 2FA and backup
codes therefore came out of a deleted address as password-only — the one outcome this
listener exists to prevent, and reachable by anyone who may edit a user's address.

`hasOtherActiveProvider()` now ignores them. Such an account keeps email 2FA enabled, so
the login still asks for a second factor, and the user can pick backup codes at the
provider selection to get in while an administrator restores the address. The change
moves the decision strictly in the fail-closed direction and has one caller.

`'backup_codes'` is written out in this app because the server's constant lives in
`lib/private`, not in `OCP`. There is nothing to pin it to, so a rename upstream would
silently restore the old behaviour — worth a look whenever the supported server range
moves.

Tests: an account with backup codes alone must not count as protected, and backup codes
*beside* a real provider still must. Both fail without the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
