### PR TITLE
Do not count backup codes as the other second factor (3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Keep email 2FA on when the only other factor is backup codes, which Nextcloud does not accept alone
 - Changing or clearing the account email address now drops a pending code
 - The address was not masked in rare cases
 

--- a/lib/Listener/EMailDeleted.php
+++ b/lib/Listener/EMailDeleted.php
@@ -47,7 +47,9 @@ use OCP\User\Events\UserChangedEvent;
  * Once the address is gone and the provider is still enabled:
  *   - another active provider remains → disable, no protection is lost;
  *   - email was the sole factor → keep it enabled (fail-closed), whoever
- *     cleared the address.
+ *     cleared the address. Backup codes are not such a factor: Nextcloud does
+ *     not accept them alone, so an account holding only those keeps email
+ *     enabled and its user logs in with a backup code.
  *
  * Disabling the sole factor would drop the account to password-only. That would
  * skip the password confirmation which turning 2FA off directly requires

--- a/lib/Service/IStateManager.php
+++ b/lib/Service/IStateManager.php
@@ -22,6 +22,8 @@ interface IStateManager {
 	/**
 	 * Whether the user has another active 2FA provider besides email, i.e.
 	 * disabling email would not leave the account without a second factor.
+	 * Backup codes do not count: Nextcloud does not accept them as the only
+	 * second factor, so an account left with nothing else is password-only.
 	 */
 	public function hasOtherActiveProvider(IUser $user): bool;
 }

--- a/lib/Service/StateManager.php
+++ b/lib/Service/StateManager.php
@@ -24,6 +24,13 @@ final class StateManager implements IStateManager {
 
 	private const PROVIDER_ID = 'email';
 
+	/**
+	 * Nextcloud does not accept backup codes as the only second factor: its own
+	 * check for an account being two-factor protected leaves them out. So they
+	 * cannot stand in for this provider either.
+	 */
+	private const BACKUP_CODES_PROVIDER_ID = 'backup_codes';
+
 	public function __construct(
 		private readonly IEventDispatcher $eventDispatcher,
 		private readonly IRegistry $registry,
@@ -44,7 +51,7 @@ final class StateManager implements IStateManager {
 
 	public function hasOtherActiveProvider(IUser $user): bool {
 		foreach ($this->registry->getProviderStates($user) as $providerId => $enabled) {
-			if ($enabled && $providerId !== self::PROVIDER_ID) {
+			if ($enabled && $providerId !== self::PROVIDER_ID && $providerId !== self::BACKUP_CODES_PROVIDER_ID) {
 				return true;
 			}
 		}

--- a/tests/Unit/Service/StateManagerTest.php
+++ b/tests/Unit/Service/StateManagerTest.php
@@ -59,6 +59,18 @@ class StateManagerTest extends TestCase {
 		$this->assertFalse($this->stateManager->hasOtherActiveProvider($user));
 	}
 
+	public function testHasOtherActiveProviderIsTrueForBackupCodesBesideARealProvider(): void {
+		$user = $this->withProviderStates(['email' => true, 'backup_codes' => true, 'totp' => true]);
+
+		$this->assertTrue($this->stateManager->hasOtherActiveProvider($user));
+	}
+
+	public function testHasOtherActiveProviderIsFalseForBackupCodesAlone(): void {
+		$user = $this->withProviderStates(['email' => true, 'backup_codes' => true]);
+
+		$this->assertFalse($this->stateManager->hasOtherActiveProvider($user));
+	}
+
 	public function testHasOtherActiveProviderIsFalseWithoutAnyProviders(): void {
 		$user = $this->withProviderStates([]);
 


### PR DESCRIPTION
Same change as on `main`, for the 3.3 line.

When the address a code is mailed to disappears, `EMailDeleted` switches this provider
off if the account still has another second factor. It counted backup codes as such a
factor, while Nextcloud's own `isTwoFactorAuthenticated()` takes them out of the list
before deciding whether an account is protected. An account with email 2FA and backup
codes therefore came out of a deleted address as password-only.

`hasOtherActiveProvider()` now ignores them, so the account keeps email 2FA enabled and
its user logs in with a backup code while an administrator restores the address.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
