### PR TITLE
Say who reviews, and let a sister pull request say it too

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,13 +2,21 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 # A review is requested automatically where a change can weaken the second factor
-# or the checks that guard it. Everything else stays a deliberate choice per pull
+# or the checks that guard it — this list included, because an edit that drops an
+# owner is such a change. Everything else stays a deliberate choice per pull
 # request.
 #
 # All of lib/ counts: this app is a login guard, so its listeners, migrations,
 # background jobs and occ commands are as security-relevant as its controllers.
+#
+# The same change is often carried into both supported lines, as a pair of pull
+# requests. Whether a request is triggered automatically depends on the paths
+# listed below, as they stand in the branch a pull request targets, and the two
+# lines do not list the same paths. So whichever of the pair triggers a request
+# sets the reviewer, and the other one gets that same reviewer added by hand.
 
 /lib/                  @seyfahni @nursoda
+/.github/CODEOWNERS    @seyfahni @nursoda
 /appinfo/info.xml      @seyfahni @nursoda
 /.github/workflows/    @seyfahni @nursoda
 /SECURITY.md           @seyfahni @nursoda


### PR DESCRIPTION
Two gaps in `.github/CODEOWNERS`, both found while a docblock fix travelled through both supported lines.

**The file did not own itself.** Deciding who is asked to review a change to the second factor is such a change, so a pull request that rewrites this list requested no review at all. It is now listed.

**The automatic request follows the base branch.** GitHub reads `CODEOWNERS` from the branch a pull request targets, and the two lines do not list the same paths — `release/3.3` still carries the first, narrow version. The same change, carried into both lines, therefore arrives with a reviewer on one and without one on the other, purely because of where it points. #219 and #220 are exactly that pair.

The rule now written into the file is that whichever pull request of a pair triggers a request sets the reviewer, and the other gets that same reviewer added by hand — so the choice is made once and read from the pair, not from whichever branch happened to trigger the automation.

The sister pull request carries the full list into `release/3.3`.

Nothing here makes a review mandatory. `main`'s ruleset carries only `non_fast_forward` and `deletion`, so `CODEOWNERS` does what its first line says: it asks. Whether an approval is required is a branch protection setting and not part of this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.