### PR TITLE
Say who reviews, and let a sister pull request say it too (3.3)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,22 @@
-/appinfo/info.xml   @datenschutz-individuell/twofactor_email
+# SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# A review is requested automatically where a change can weaken the second factor
+# or the checks that guard it — this list included, because an edit that drops an
+# owner is such a change. Everything else stays a deliberate choice per pull
+# request.
+#
+# All of lib/ counts: this app is a login guard, so its listeners, migrations,
+# background jobs and occ commands are as security-relevant as its controllers.
+#
+# The same change is often carried into both supported lines, as a pair of pull
+# requests. Whether a request is triggered automatically depends on the paths
+# listed below, as they stand in the branch a pull request targets, and the two
+# lines do not list the same paths. So whichever of the pair triggers a request
+# sets the reviewer, and the other one gets that same reviewer added by hand.
+
+/lib/                  @seyfahni @nursoda
+/.github/CODEOWNERS    @seyfahni @nursoda
+/appinfo/info.xml      @seyfahni @nursoda
+/.github/workflows/    @seyfahni @nursoda
+/SECURITY.md           @seyfahni @nursoda

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -6,7 +6,7 @@ SPDX-PackageSupplier = "Two-Factor email Support <twofactor-email@datenschutz-in
 SPDX-PackageDownloadLocation = "https://github.com/datenschutz-individuell/twofactor_email"
 
 [[annotations]]
-path = [".github/CODEOWNERS", ".github/renovate.json",
+path = [".github/renovate.json",
     "CHANGELOG.md", "CONTRIBUTORS.md", "README.md", "SECURITY.md",
     "composer.json", "composer.lock", "package.json", "package-lock.json",
     "vendor-bin/cs-fixer/composer.json", "vendor-bin/cs-fixer/composer.lock",


### PR DESCRIPTION
Sister pull request of #225.

This line still had the first, narrow version of `.github/CODEOWNERS`: only `appinfo/info.xml` had an owner. A change to `lib/` — the listeners, the challenge, the code storage — therefore reached a pull request with no review requested at all, while the same change on `main` did request one. #217 and #218 are open right now under exactly that gap.

The list is the one `main` carries, minus `/doc/threat-model.md`, which does not exist here. Two deliberate differences:

* Ownership of `appinfo/info.xml` moves from the team to the two people the rest of the list names, so every entry says the same thing.
* The file drops out of the `REUSE.toml` annotation. It carries an SPDX header now, and the convention here is one or the other, not both — which is also how `main` has it.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.