### PR TITLE
Say when no new code went out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Count the subject and body length limits in characters, not bytes
 - Skip the database writes that cleared a code no user had stored
 - Send a new code at once when the notification address changed, instead of waiting for the old one to expire
+- The challenge page says when it sent no new code, instead of leaving the user waiting for mail
 
 ### Fixed
 

--- a/src/LoginChallenge.css
+++ b/src/LoginChallenge.css
@@ -27,3 +27,10 @@
 .twofactor_email-resend {
     cursor: pointer;
 }
+
+/* The line that says no new code went out: an explanation, not a warning, so it
+   stays quieter than the sentence it belongs to. */
+.twofactor_email-code-age-hint {
+    font-size: 90%;
+    opacity: .8;
+}

--- a/src/LoginChallenge.js
+++ b/src/LoginChallenge.js
@@ -112,6 +112,10 @@ document.addEventListener('DOMContentLoaded', () => {
 				input.value = ''
 				input.focus()
 			}
+			// The server-rendered line explaining that no new code went out is now wrong:
+			// one just did. It is removed rather than hidden, so a later render is the
+			// only thing that can bring it back.
+			document.querySelector('.twofactor_email-code-age-hint')?.remove()
 			startCountdown(cooldown, t('twofactor_email', 'A new code was sent. Only the new code is valid now.'))
 		} catch (error) {
 			/** @type {{ error?: string, retryAfter?: number } | undefined} */

--- a/src/LoginChallenge.test.js
+++ b/src/LoginChallenge.test.js
@@ -24,6 +24,7 @@ function render({ cooldown = 60, availableIn = 0 } = {}) {
 			<a class="twofactor_email-resend" href="#">Send a new code</a>
 			<span class="twofactor_email-resend-status"></span>
 		</div>
+		<p class="twofactor_email-code-age-hint">No new code was sent, because an earlier one is still valid.</p>
 		<form class="twofactor_email-challenge-form">
 			<input name="challenge" value="123456">
 		</form>
@@ -70,6 +71,27 @@ describe('LoginChallenge resend', () => {
 		expect(input.value).toBe('')
 		expect(link.hidden).toBe(true)
 		expect(status.textContent).toContain('new code was sent')
+	})
+
+	it('removes the line about the earlier code once a new one was sent', async () => {
+		Axios.post.mockResolvedValue({})
+		const { link } = render({ availableIn: 0 })
+		expect(document.querySelector('.twofactor_email-code-age-hint')).not.toBeNull()
+
+		link.click()
+		await vi.advanceTimersByTimeAsync(0)
+
+		expect(document.querySelector('.twofactor_email-code-age-hint')).toBeNull()
+	})
+
+	it('keeps the line about the earlier code when the send failed', async () => {
+		Axios.post.mockRejectedValue({ response: { status: 500, data: {} } })
+		const { link } = render({ availableIn: 0 })
+
+		link.click()
+		await vi.advanceTimersByTimeAsync(0)
+
+		expect(document.querySelector('.twofactor_email-code-age-hint')).not.toBeNull()
 	})
 
 	it('keeps the confirmation readable before the countdown takes over', async () => {

--- a/templates/LoginChallenge.php
+++ b/templates/LoginChallenge.php
@@ -56,6 +56,23 @@ $resendAvailableIn = (int)($_['resendAvailableIn'] ?? 0); // seconds left before
 				: $l->t('Enter the authentication code that was sent to you:'));
 		}
 	?></p>
+<?php
+// A sentence of its own, so the one above keeps the translations it already has.
+//
+// This covers every render that sent no code, and the most frequent one is a mistyped
+// code: the stored code is kept on purpose so it can be retried, so none goes out. The
+// sentence holds there too — it says why no new mail arrived, and its second half is a
+// condition, not a claim that nothing was received. Telling the two apart would need
+// the provider to know that the render follows a failed submission, which Nextcloud
+// does not pass on.
+if (!$newCodeWasSent): ?>
+	<p class="twofactor_email-code-age-hint">
+		<?php
+		// The link is named through a placeholder, so the sentence and the link keep
+		// saying the same thing in every translation.
+		p($l->t('No new code was sent, because an earlier one is still valid. If it did not arrive, use "%s" below.', [$l->t('Send a new code')])); ?>
+	</p>
+<?php endif; ?>
 	<form method="POST" class="twofactor_email-challenge-form">
 		<input type="text"<?= $minmax ?> name="challenge" required="required" autofocus autocomplete="one-time-code"
 			   inputmode="numeric" autocapitalize="off" placeholder="<?php p($l->t('Authentication code')) ?>">

--- a/tests/smoke/smoke.sh
+++ b/tests/smoke/smoke.sh
@@ -186,6 +186,16 @@ run_checks() {
 		&& ok "challenge page names the masked address" || bad "challenge page names no masked address"
 	grep -qF 'admin@example.org' "$TMP/challenge.html" \
 		&& bad "challenge page shows the full address" || ok "challenge page keeps the full address off the screen"
+	# A reload sends no second code, and has to say so — otherwise someone whose mail
+	# is slow waits for one that is not coming. The first load must not say it, or the
+	# sentence would be there whatever happened. The mail count below is the other half
+	# of the same statement: the reload really did send nothing.
+	grep -qF 'No new code was sent' "$TMP/challenge.html" \
+		&& bad "the first challenge page already claims an earlier code" \
+		|| ok "the first challenge page reports the code it just sent"
+	curl -s -b "$TMP/jar" -c "$TMP/jar" -o "$TMP/reloaded.html" "$BASE/login/challenge/email"
+	grep -qF 'No new code was sent' "$TMP/reloaded.html" \
+		&& ok "a reload says that no new code went out" || bad "a reload leaves the user waiting for mail"
 	is "exactly one mail was sent" "$(mail_count)" "1"
 
 	echo "-- challenge/resend"


### PR DESCRIPTION
The challenge page sends a code only when none is stored, so a reload does not mail a
new one every time. What the page does not say is that this happened. It reads *"Enter
the authentication code that was sent to a\*@\*.org:"*, which is true of a code from
several minutes ago just as much as of one sent a second ago — so someone whose mail is
slow, or who never received the earlier one, waits for a mail that is not coming.

One sentence appears now whenever no new code went out:

> No new code was sent, because an earlier one is still valid. If it did not arrive, ask
> for a new one.

The resend link right below it is what that last half refers to; while its cooldown runs,
the same line shows the countdown, so the way out is visible either way.

It is a sentence of its own rather than a longer version of the one above it. That one is
translated into twenty-odd languages, and rewording it would drop every one of those
translations back to English for a string that is not wrong — only incomplete.

## Two things worth knowing

The sentence names the resend link by the words it carries, through a placeholder, so the
two cannot drift apart in a translation. During the cooldown that link is hidden and a
countdown stands in its place, so for up to a minute the sentence points at something not
yet on the page — the countdown right there says when it will be. Accepted rather than
worked around: hiding the explanation for that minute would leave the user with no reason
at all for the missing mail.

Once a resend succeeds the line is wrong — a new code just went out — so the click
handler removes it. A failed send leaves it standing, because then the earlier code is
still the only one. Both branches have a test.

## Checked

- shown against a real Nextcloud 34: the line appears on the second load of the challenge
  page and not on the first
- stylelint and php-cs-fixer clean

## Merge order

Based on #215, whose wording it extends, so that one goes first. The 3.3 counterpart is
a separate PR on #218; there the sentence matters more, because that line keeps the event
listener and cannot notice a changed notification address at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
