### PR TITLE
Say when no new code went out (3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Contributing guidelines, a code of conduct and an overview of the licences used
 - The login screen names the masked address the code was sent to
+- The login screen says when it sent no new code, instead of leaving the user waiting for mail
 
 ### Changed
 

--- a/src/LoginChallenge.css
+++ b/src/LoginChallenge.css
@@ -27,3 +27,10 @@
 .twofactor_email-resend {
     cursor: pointer;
 }
+
+/* The line that says no new code went out: an explanation, not a warning, so it
+   stays quieter than the sentence it belongs to. */
+.twofactor_email-code-age-hint {
+    font-size: 90%;
+    opacity: .8;
+}

--- a/src/LoginChallenge.js
+++ b/src/LoginChallenge.js
@@ -81,6 +81,10 @@ document.addEventListener('DOMContentLoaded', () => {
 				input.value = ''
 				input.focus()
 			}
+			// The server-rendered line explaining that no new code went out is now wrong:
+			// one just did. It is removed rather than hidden, so a later render is the
+			// only thing that can bring it back.
+			document.querySelector('.twofactor_email-code-age-hint')?.remove()
 			startCountdown(cooldown, t('twofactor_email', 'A new code was sent. Only the new code is valid now.'))
 		} catch (error) {
 			/** @type {{ error?: string, retryAfter?: number } | undefined} */

--- a/src/LoginChallenge.test.js
+++ b/src/LoginChallenge.test.js
@@ -24,6 +24,7 @@ function render({ cooldown = 60, availableIn = 0 } = {}) {
 			<a class="twofactor_email-resend" href="#">Send a new code</a>
 			<span class="twofactor_email-resend-status"></span>
 		</div>
+		<p class="twofactor_email-code-age-hint">No new code was sent, because an earlier one is still valid.</p>
 		<form class="twofactor_email-challenge-form">
 			<input name="challenge" value="123456">
 		</form>
@@ -70,6 +71,27 @@ describe('LoginChallenge resend', () => {
 		expect(input.value).toBe('')
 		expect(link.hidden).toBe(true)
 		expect(status.textContent).toContain('new code was sent')
+	})
+
+	it('removes the line about the earlier code once a new one was sent', async () => {
+		Axios.post.mockResolvedValue({})
+		const { link } = render({ availableIn: 0 })
+		expect(document.querySelector('.twofactor_email-code-age-hint')).not.toBeNull()
+
+		link.click()
+		await vi.advanceTimersByTimeAsync(0)
+
+		expect(document.querySelector('.twofactor_email-code-age-hint')).toBeNull()
+	})
+
+	it('keeps the line about the earlier code when the send failed', async () => {
+		Axios.post.mockRejectedValue({ response: { status: 500, data: {} } })
+		const { link } = render({ availableIn: 0 })
+
+		link.click()
+		await vi.advanceTimersByTimeAsync(0)
+
+		expect(document.querySelector('.twofactor_email-code-age-hint')).not.toBeNull()
 	})
 
 	it('shows a countdown when the server reports the cooldown (429)', async () => {

--- a/templates/LoginChallenge.php
+++ b/templates/LoginChallenge.php
@@ -56,6 +56,23 @@ $resendAvailableIn = (int)($_['resendAvailableIn'] ?? 0); // seconds left before
 				: $l->t('Enter the authentication code that was sent to you:'));
 		}
 	?></p>
+<?php
+// A sentence of its own, so the one above keeps the translations it already has.
+//
+// This covers every render that sent no code, and the most frequent one is a mistyped
+// code: the stored code is kept on purpose so it can be retried, so none goes out. The
+// sentence holds there too — it says why no new mail arrived, and its second half is a
+// condition, not a claim that nothing was received. Telling the two apart would need
+// the provider to know that the render follows a failed submission, which Nextcloud
+// does not pass on.
+if (!$newCodeWasSent): ?>
+	<p class="twofactor_email-code-age-hint">
+		<?php
+		// The link is named through a placeholder, so the sentence and the link keep
+		// saying the same thing in every translation.
+		p($l->t('No new code was sent, because an earlier one is still valid. If it did not arrive, use "%s" below.', [$l->t('Send a new code')])); ?>
+	</p>
+<?php endif; ?>
 	<form method="POST" class="twofactor_email-challenge-form">
 		<input type="text"<?= $minmax ?> name="challenge" required="required" autofocus autocomplete="one-time-code"
 			   inputmode="numeric" autocapitalize="off" placeholder="<?php p($l->t('Authentication code')) ?>">


### PR DESCRIPTION
The 3.3 counterpart of the change on main, with one difference that is worth stating.

The challenge page sends a code only when none is stored, so a reload does not mail a
new one every time — and it never said so. *"Enter the authentication code that was sent
to a\*@\*.org:"* is true of a code from nine minutes ago just as much as of one sent a
second ago, so someone whose mail is slow, or who never received the earlier one, waits
for a mail that is not coming. One sentence now appears whenever no new code went out,
naming the reason and pointing at the resend link below it.

It is a sentence of its own rather than a longer version of the one above, so that the
translations that sentence already has are not dropped for a string that is not wrong,
only incomplete.

**The line carries further here than on main.** There, a code is bound to the address it
was sent to, so a changed address sends a fresh code by itself. This line keeps the event
listener instead, which cannot see a changed notification address — on such an account
this sentence is the only thing that tells the user to ask for a new code.

## Two things worth knowing

The sentence names the resend link by the words it carries, through a placeholder, so the
two cannot drift apart in a translation. During the cooldown that link is hidden and a
countdown stands in its place, so for up to a minute the sentence points at something not
yet on the page — the countdown right there says when it will be. Accepted rather than
worked around: hiding the explanation for that minute would leave the user with no reason
at all for the missing mail.

Once a resend succeeds the line is wrong — a new code just went out — so the click
handler removes it. A failed send leaves it standing, because then the earlier code is
still the only one. Both branches have a test.

## Checked

- php-cs-fixer and stylelint clean; there is no smoke test on this line

## Merge order

Based on #218, whose wording it extends, so that one goes first.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
