### PR TITLE
Make the new community files agree with the rest of the repo

### DIFF
--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -13,6 +13,8 @@
 /build
 /.claude
 /CLAUDE.md
+/CODE_OF_CONDUCT.md
+/CONTRIBUTING.md
 /REVIEW.md
 /codecov.yml
 /doc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Administrator documentation for occ, enforcement, email addresses and a FAQ
+- Contributing guidelines, a code of conduct and an overview of the licences used
 - Fresh screenshots in the documentation
 
 ### Security

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,18 +2,31 @@
 
 ## Commitment
 
-This is a community effort, maintained by volunteers. We want everyone to feel comfortable contributing — whether through code, bug reports, feature requests, documentation, or discussion. This Code of Conduct outlines how we expect people to treat one another here.
+This is a community effort, maintained by volunteers. We want everyone to feel
+comfortable contributing — whether through code, bug reports, feature requests,
+documentation, or discussion. This Code of Conduct outlines how we expect people
+to treat one another here.
 
 ## Standards
 
-- **Communicate respectfully.** Treat others with courtesy and kindness, even when you disagree.
-- **Value different opinions.** People have different backgrounds, needs, and perspectives. Listen to other viewpoints and give them fair consideration.
-- **Be constructive.** Suggestions, questions, and answers should aim to move things forward — offer reasoning, be specific, and focus on the issue rather than the person.
-- **De-escalate.** If a discussion gets heated or the tone turns harsh, take a step back, stay calm, and help bring the conversation back to a constructive level.
-- **Own your mistakes.** Everyone makes mistakes. If you get something wrong or cause offense, acknowledge it, apologize, and aim to avoid making the same mistake again.
-- **Accept decisions.** In any project, decisions have to be made. Maintainers listen to concerns but have the final say. Respect that. Feel free to fork if you don't agree.
+- **Communicate respectfully.** Treat others with courtesy and kindness, even
+  when you disagree.
+- **Value different opinions.** People have different backgrounds, needs, and
+  perspectives. Listen to other viewpoints and give them fair consideration.
+- **Be constructive.** Suggestions, questions, and answers should aim to move
+  things forward — offer reasoning, be specific, and focus on the issue rather
+  than the person.
+- **De-escalate.** If a discussion gets heated or the tone turns harsh, take a
+  step back, stay calm, and help bring the conversation back to a constructive
+  level.
+- **Own your mistakes.** Everyone makes mistakes. If you get something wrong or
+  cause offence, acknowledge it, apologise, and aim to avoid making the same
+  mistake again.
+- **Accept decisions.** In any project, decisions have to be made. Maintainers
+  listen to concerns but have the final say. Respect that. Feel free to fork if
+  you don't agree.
 
-## Unacceptable Behavior
+## Unacceptable behaviour
 
 - Personal attacks, insults, or demeaning comments
 - Harassment, intimidation, or discrimination in any form
@@ -22,12 +35,19 @@ This is a community effort, maintained by volunteers. We want everyone to feel c
 
 ## Scope
 
-This Code of Conduct applies to all project-related communication and publications — including issue trackers, pull requests, discussions, chats, and emails — and to everyone involved in the project, including the maintainers.
+This Code of Conduct applies to all project-related communication and
+publications — including issue trackers, pull requests, discussions, chats, and
+emails — and to everyone involved in the project, including the maintainers.
 
 ## Enforcement
 
-Instances of unacceptable behavior may be reported to the project maintainers. All complaints will be reviewed and handled fairly and with discretion. In response to violations of this Code of Conduct, maintainers may take any action they deem appropriate.
+Instances of unacceptable behaviour may be reported to the project maintainers.
+All complaints will be reviewed and handled fairly and with discretion. In
+response to violations of this Code of Conduct, maintainers may take any action
+they deem appropriate.
 
 ## Attribution
 
-This Code of Conduct was written for this project and kept intentionally short and practical. It draws inspiration from common open-source community guidelines.
+This Code of Conduct was written for this project and kept intentionally short
+and practical. It draws inspiration from common open-source community
+guidelines.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -20,7 +20,7 @@ config, lockfiles, screenshots, translations).
 | --- | --- | --- |
 | GNU Affero General Public License v3.0 or later | [`AGPL-3.0-or-later`](LICENSES/AGPL-3.0-or-later.txt) | The project's default license: application source code and most other files, either via their own header or, where a header isn't possible, via `REUSE.toml` (docs, config, lockfiles, screenshots, translations) |
 | Apache License 2.0 | [`Apache-2.0`](LICENSES/Apache-2.0.txt) | `img/app.svg` and `img/app-dark.svg` (© Google LLC) |
-| MIT License | [`MIT`](LICENSES/MIT.txt) | The project's own GitHub Actions workflows and `codecov.yml`, kept permissive so other projects can freely reuse this CI setup |
+| MIT License | [`MIT`](LICENSES/MIT.txt) | Most GitHub Actions workflows and `codecov.yml`, kept permissive so other projects can freely reuse this CI setup. The app-specific `smoke.yml` and the remaining files under `.github` stay AGPL |
 | Creative Commons Zero v1.0 Universal | [`CC0-1.0`](LICENSES/CC0-1.0.txt) | `.github/workflows/reuse.yml`, the REUSE-compliance check template provided by the FSFE |
 
 Every file decides its own license. The table above is a quick overview, not

--- a/README.md
+++ b/README.md
@@ -27,13 +27,9 @@ The code is stable now. There are plans for further enhancements. See open tasks
 
 ## Contributions welcome
 
-This app is a community effort. Any offers to help are welcome, whether it's code enhancements, refactoring, better test coverage, new features, security audits, translations or good documentation, examples, etc.
+This app is a community effort. Help of any kind is welcome — code, tests, documentation, translations, bug reports and ideas.
 
-Prior to creating a PR, please discuss your idea in the [idea collection](https://github.com/datenschutz-individuell/twofactor_email/issues/8). Make sure your PR sticks to ONE change (so that we may review it cleanly), and that it doesn't break existing functionality. We will do our best to timely review and comment PRs.
-
-This app takes advantage of the transifex Nextcloud community. If the app is not yet available in your language, please consider creating a transifex account and join the [Nextcloud translators community](https://explore.transifex.com/nextcloud/).
-
-If you have any questions, please contact [the current maintainers](https://github.com/datenschutz-individuell/CONTRIBUTORS.md).
+[CONTRIBUTING.md](CONTRIBUTING.md) explains how to get started; [CONTRIBUTORS.md](CONTRIBUTORS.md) lists who to ask.
 
 ## Building yourself
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ We only support the latest released version of the app for any Nextcloud version
 
 ## Reporting a Vulnerability
 
-You may create an issue in GitHub to report security vulnerabilities unless you think that it is not easily fixable and would affect many users. In this case, please email Olav directly using olav at seyfarth dot de. My OpenPGP key 0x6AE1EF56 is available on [the website](https://seyfarth.de/gnupg/6AE1EF56.asc) as well as on the [OpenPGP keyserver](https://keys.openpgp.org/search?q=olav%40seyfarth.de).
+You may create an issue in GitHub to report security vulnerabilities unless you think that it is not easily fixable and would affect many users. In this case, please email Olav directly using olav at seyfarth dot de. Olav's OpenPGP key 0x6AE1EF56 is available on [the website](https://seyfarth.de/gnupg/6AE1EF56.asc) as well as on the [OpenPGP keyserver](https://keys.openpgp.org/search?q=olav%40seyfarth.de).
 
 We will timely review your report and fix it if we know how and if it's not an upstream issue. Please provide contact details so that we may get in touch with you. Once we publish the fixed code, we would like to pay credits to you. So please also include details on how we shall mention you. See [CONTRIBUTORS](https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md) for examples.
 

--- a/doc/developers.md
+++ b/doc/developers.md
@@ -55,4 +55,4 @@ What these mechanisms promise, and against whom, is bounded by the [threat model
 
 ## Licensing
 
-The app is licensed [AGPL-3.0-or-later](../LICENSES/) and is [REUSE](https://reuse.software/)/SPDX compliant: every file carries clear copyright and licence metadata, inline or via `REUSE.toml`, and CI verifies it. Bundled assets keep their own licences (e.g. the app icon).
+The app is licensed [AGPL-3.0-or-later](../LICENSES/AGPL-3.0-or-later.txt); bundled assets keep their own licences (e.g. the app icon). [LICENSE.md](../LICENSE.md) lists every licence used here and how the REUSE/SPDX metadata is applied. Add an SPDX header to each new file, or an entry in `REUSE.toml` where a header is impossible; CI verifies it.


### PR DESCRIPTION
The community files added last week state a few things the repository does not
back up, and repeat a few things it already says elsewhere.

- **`LICENSE.md`** claimed MIT for "the project's own GitHub Actions workflows".
  `smoke.yml` is AGPL, as are `CODEOWNERS`, `dependabot.yml` and the issue
  templates. The table now says which files the MIT row really covers.
- **`SECURITY.md`** switched from "I" to "we" but kept one "My OpenPGP key"
  next to a sentence that names Olav in the third person.
- **`README.md`** linked to
  `https://github.com/datenschutz-individuell/CONTRIBUTORS.md` — the repository
  name is missing, so the link is a 404. The section also repeated the idea
  collection, Transifex and the maintainer contact, all of which `CONTRIBUTING.md`
  now covers, so it is two sentences and a link. `doc/developers.md` likewise
  points at `LICENSE.md` instead of restating the REUSE paragraph.
- **`CODE_OF_CONDUCT.md`** used US spelling ("behavior", "offense", "apologize")
  where the repository uses British spelling throughout, and was the only new
  file with unwrapped lines.
- **`.nextcloudignore`** now keeps `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
  out of the release package; neither is of any use inside an installed app.
  `LICENSE.md` stays in, because it describes the `LICENSES/` that do ship.

`reuse lint` stays green at 307/307.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.