### PR TITLE
Bring the 3.3 line in step with main

### DIFF
--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -12,6 +12,8 @@
 /.tx
 /build
 /.claude
+/CODE_OF_CONDUCT.md
+/CONTRIBUTING.md
 /codecov.yml
 /composer.*
 /krankerl.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Contributing guidelines, a code of conduct and an overview of the licences used
+
 ### Fixed
 
 - A code was reported as sent when the mail server refused the address (#202)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,53 @@
+# Code of Conduct
+
+## Commitment
+
+This is a community effort, maintained by volunteers. We want everyone to feel
+comfortable contributing — whether through code, bug reports, feature requests,
+documentation, or discussion. This Code of Conduct outlines how we expect people
+to treat one another here.
+
+## Standards
+
+- **Communicate respectfully.** Treat others with courtesy and kindness, even
+  when you disagree.
+- **Value different opinions.** People have different backgrounds, needs, and
+  perspectives. Listen to other viewpoints and give them fair consideration.
+- **Be constructive.** Suggestions, questions, and answers should aim to move
+  things forward — offer reasoning, be specific, and focus on the issue rather
+  than the person.
+- **De-escalate.** If a discussion gets heated or the tone turns harsh, take a
+  step back, stay calm, and help bring the conversation back to a constructive
+  level.
+- **Own your mistakes.** Everyone makes mistakes. If you get something wrong or
+  cause offence, acknowledge it, apologise, and aim to avoid making the same
+  mistake again.
+- **Accept decisions.** In any project, decisions have to be made. Maintainers
+  listen to concerns but have the final say. Respect that. Feel free to fork if
+  you don't agree.
+
+## Unacceptable behaviour
+
+- Personal attacks, insults, or demeaning comments
+- Harassment, intimidation, or discrimination in any form
+- Dismissing or belittling others' viewpoints or contributions
+- Sustained disruption of discussions or project work
+
+## Scope
+
+This Code of Conduct applies to all project-related communication and
+publications — including issue trackers, pull requests, discussions, chats, and
+emails — and to everyone involved in the project, including the maintainers.
+
+## Enforcement
+
+Instances of unacceptable behaviour may be reported to the project maintainers.
+All complaints will be reviewed and handled fairly and with discretion. In
+response to violations of this Code of Conduct, maintainers may take any action
+they deem appropriate.
+
+## Attribution
+
+This Code of Conduct was written for this project and kept intentionally short
+and practical. It draws inspiration from common open-source community
+guidelines.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing
+
+Thanks for your interest in improving this app! It's a community effort, and
+contributions of all kinds are welcome — code, tests, documentation,
+translations, bug reports, and ideas.
+
+By participating, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Before you start
+
+Please discuss non-trivial ideas in the
+[idea collection](https://github.com/datenschutz-individuell/twofactor_email/issues/8)
+before opening a pull request, so nobody spends time on something that won't
+be merged.
+
+Note that this branch is the maintenance line for the 3.3 releases. New
+features go to `main`; here we take fixes and the changes that keep both lines
+in step.
+
+## Pull requests
+
+1. **Keep one topic per pull request.** A focused change can be reviewed
+   properly; a mixed one usually cannot.
+2. **Run the checks locally before opening the pull request** — CI runs the
+   same ones, but finding it out yourself is faster:
+   ```
+   composer test:unit:dev && composer psalm && composer cs:check
+   npm run lint && npm run stylelint && npm test && npm run build
+   ```
+   `composer cs:fix` applies the style fixes automatically.
+3. **Add SPDX headers to new files.** The project is
+   [REUSE](https://reuse.software/) compliant and CI enforces it; files that
+   cannot carry a header are annotated centrally in `REUSE.toml`. See
+   [LICENSE.md](LICENSE.md) for the licenses in use.
+4. **Describe *why* in the commit message**, not *what* — the diff already
+   shows what changed.
+5. **CI is the gate.** All checks have to pass; a red run will not be merged.
+
+Building the app is described in the README under
+[Building yourself](README.md#building-yourself).
+
+## Translations
+
+This app uses Transifex. If it's not yet available in your language, join the
+[Nextcloud translators community](https://explore.transifex.com/nextcloud/).
+
+## Security issues
+
+Please don't report security vulnerabilities as public issues if they could
+affect many users — see [SECURITY.md](SECURITY.md) for how to report them
+responsibly.
+
+## Questions
+
+If you have any questions, reach out to the maintainers listed in
+[CONTRIBUTORS.md](CONTRIBUTORS.md).

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,29 @@
+# License
+
+This project is [REUSE](https://reuse.software/) compliant: every file carries
+clear copyright and license metadata, either inline (in its own header) or
+via [`REUSE.toml`](REUSE.toml) for files that cannot carry a header (e.g.
+binaries, lockfiles). This is verified in CI. Full license texts are in
+[`/LICENSES`](LICENSES).
+
+## Code
+
+Unless stated otherwise in a file's own header, the application is licensed
+under the **GNU Affero General Public License v3.0 or later
+([AGPL-3.0-or-later](LICENSES/AGPL-3.0-or-later.txt))**. This is also the
+default applied via `REUSE.toml` to files that cannot carry a header (config,
+lockfiles, translations).
+
+## Other licenses used in this repository
+
+| License | SPDX identifier | Used for |
+| --- | --- | --- |
+| GNU Affero General Public License v3.0 or later | [`AGPL-3.0-or-later`](LICENSES/AGPL-3.0-or-later.txt) | The project's default license: application source code and most other files, either via their own header or, where a header isn't possible, via `REUSE.toml` (config, lockfiles, translations) |
+| Apache License 2.0 | [`Apache-2.0`](LICENSES/Apache-2.0.txt) | `img/app.svg` and `img/app-dark.svg` (© Google LLC) |
+| MIT License | [`MIT`](LICENSES/MIT.txt) | Every GitHub Actions workflow except `reuse.yml`, plus `codecov.yml`, kept permissive so other projects can freely reuse this CI setup. The remaining files under `.github` stay AGPL |
+| Creative Commons Zero v1.0 Universal | [`CC0-1.0`](LICENSES/CC0-1.0.txt) | `.github/workflows/reuse.yml`, the REUSE-compliance check template provided by the FSFE |
+
+Every file decides its own license. The table above is a quick overview, not
+a substitute for checking the file itself. To see exactly which license
+applies to a given file, check its header, or run `reuse spdx` for a full,
+file-by-file report.

--- a/README.md
+++ b/README.md
@@ -57,22 +57,11 @@ behaviour changed or was enhanced.
 
 ## Contributions welcome
 
-This app is a community effort. Any offers to help are welcome, whether it's
-code enhancements, refactoring, better test coverage, new features, security
-audits, translations or good documentation, examples, etc.
+This app is a community effort. Help of any kind is welcome — code, tests,
+documentation, translations, bug reports and ideas.
 
-Prior to creating a PR, please discuss your idea in
-the [idea collection](https://github.com/datenschutz-individuell/twofactor_email/issues/8).
-Make sure your PR sticks to ONE change (so that we may review it cleanly), and
-that it doesn't break existing functionality. We will do our best to timely
-review and comment PRs.
-
-This app takes advantage of the transifex Nextcloud community. If the app is
-not yet available in your language, please consider creating a transifex
-account and join the [Nextcloud translators community](https://explore.transifex.com/nextcloud/).
-
-If you have any questions, please
-contact [the current maintainers](https://github.com/datenschutz-individuell/CONTRIBUTORS.md).
+[CONTRIBUTING.md](CONTRIBUTING.md) explains how to get started;
+[CONTRIBUTORS.md](CONTRIBUTORS.md) lists who to ask.
 
 ## Building yourself
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -7,7 +7,8 @@ SPDX-PackageDownloadLocation = "https://github.com/datenschutz-individuell/twofa
 
 [[annotations]]
 path = [".github/renovate.json",
-    "CHANGELOG.md", "CONTRIBUTORS.md", "README.md", "SECURITY.md",
+    "CHANGELOG.md", "CODE_OF_CONDUCT.md", "CONTRIBUTING.md", "CONTRIBUTORS.md",
+    "LICENSE.md", "README.md", "SECURITY.md",
     "composer.json", "composer.lock", "package.json", "package-lock.json",
     "vendor-bin/cs-fixer/composer.json", "vendor-bin/cs-fixer/composer.lock",
     "psalm.xml"]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,14 +2,15 @@
 
 ## Supported Versions
 
-I only support the latest released version of the app for any Nextcloud version that still has official (not extended)
+We only support the latest released version of the app for any Nextcloud version that still has official (not extended)
 support.
 
 ## Reporting a Vulnerability
 
 You may create an issue in GitHub to report security vulnerabilities unless you think that it is not easily fixable and
-would affect many users. In this case, please email me directly using olav at seyfarth dot de. There is an OpenPGP key
-available for this address on the [OpenPGP keyserver](https://keys.openpgp.org/) that you may use.
+would affect many users. In this case, please email Olav directly using olav at seyfarth dot de. Olav's OpenPGP key
+0x6AE1EF56 is available on [the website](https://seyfarth.de/gnupg/6AE1EF56.asc) as well as on the
+[OpenPGP keyserver](https://keys.openpgp.org/search?q=olav%40seyfarth.de).
 
 We will timely review your report and fix it if we know how and if it's not an upstream issue. Please provide contact
 details so that we may get in touch with you. Once we publish the fixed code, we would like to pay credits to you. So
@@ -18,7 +19,7 @@ See [CONTRIBUTORS](https://github.com/datenschutz-individuell/twofactor_email/bl
 
 ## Bounty
 
-I cannot provide any bounty for reporting. But if you feel that it would affect many users or Nextcloud as a platform,
+We cannot provide any bounty for reporting. But if you feel that it would affect many users or Nextcloud as a platform,
 you may use their channel to report it, see the [security](https://nextcloud.com/security/) on the Nextcloud website. They used to use Hacker One
 as a reporting platform and provide a bounty if the report met their criteria. Due to too many AI generated reports,
-they abandoned that programme.
+they abandoned it.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@nextcloud/logger": "^3.0.3",
         "@nextcloud/password-confirmation": "^6.1.0",
         "@nextcloud/router": "^3.1.0",
-        "@nextcloud/vue": "^9.9.0",
+        "@nextcloud/vue": "^9.10.0",
         "pinia": "^4.0.3",
         "vue": "^3.5.41"
       },
@@ -30,7 +30,7 @@
         "@vitejs/plugin-vue": "^6.0.8",
         "@vitest/coverage-v8": "^4.1.11",
         "@vue/test-utils": "^2.4.11",
-        "eslint": "^10.9.0",
+        "eslint": "^10.9.1",
         "happy-dom": "^20.11.6",
         "vite": "^7.3.6",
         "vitest": "^4.1.11"
@@ -1726,9 +1726,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.9.0.tgz",
-      "integrity": "sha512-TmKnBWp6Aiw+cm+WamwX5cMkhkpJqLSUKrTUB5I5Y9RDt2S0TUlwRaTe9vltBIV3qmKParhpZQ3/ewWHgEQlrQ==",
+      "version": "9.10.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.10.0.tgz",
+      "integrity": "sha512-Za9O6ZpRNmjMuKPgiUDg98lY4+sFasemaPY6h7rti4H4An9VglKjL7l/YZh3criJLfhoDL6ACMwZiNcvFV626A==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",
@@ -1745,19 +1745,19 @@
         "@nextcloud/sharing": "^0.4.0",
         "@nextcloud/vue-select": "^4.1.0",
         "@vuepic/vue-datepicker": "^11.0.3",
-        "@vueuse/components": "^14.3.0",
-        "@vueuse/core": "^14.3.0",
+        "@vueuse/components": "^14.4.0",
+        "@vueuse/core": "^14.4.0",
         "blurhash": "^2.0.5",
         "clone": "^2.1.2",
         "debounce": "^3.0.0",
-        "dompurify": "^3.4.12",
+        "dompurify": "^3.4.14",
         "emoji-mart-vue-fast": "^15.0.5",
         "escape-html": "^1.0.3",
         "floating-vue": "^5.2.2",
         "focus-trap": "^8.2.2",
         "linkifyjs": "^4.3.3",
         "mdast-util-to-string": "^4.0.0",
-        "p-queue": "^9.3.1",
+        "p-queue": "^9.3.3",
         "rehype-external-links": "^3.0.0",
         "rehype-highlight": "^7.0.2",
         "rehype-react": "^8.0.0",
@@ -1774,7 +1774,7 @@
         "unist-builder": "^4.0.0",
         "unist-util-visit-parents": "^6.0.2",
         "vue": "^3.5.18",
-        "vue-router": "^5.1.0"
+        "vue-router": "^5.2.0"
       },
       "engines": {
         "node": "^20.11.0 || ^22 || ^24"
@@ -5627,9 +5627,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.9.0.tgz",
-      "integrity": "sha512-5KeEOJZBfEVA47boFiBsf+6MmmJpffM7qEBg4pLla2e4nlKgdKlqCW0oSLOGsT8Wl5uCGJptLV1bkaiShj90Gw==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.9.1.tgz",
+      "integrity": "sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==",
       "dev": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@nextcloud/logger": "^3.0.3",
     "@nextcloud/password-confirmation": "^6.1.0",
     "@nextcloud/router": "^3.1.0",
-    "@nextcloud/vue": "^9.9.0",
+    "@nextcloud/vue": "^9.10.0",
     "pinia": "^4.0.3",
     "vue": "^3.5.41"
   },
@@ -80,7 +80,7 @@
     "@vitejs/plugin-vue": "^6.0.8",
     "@vitest/coverage-v8": "^4.1.11",
     "@vue/test-utils": "^2.4.11",
-    "eslint": "^10.9.0",
+    "eslint": "^10.9.1",
     "happy-dom": "^20.11.6",
     "vite": "^7.3.6",
     "vitest": "^4.1.11"

--- a/vendor-bin/cs-fixer/composer.lock
+++ b/vendor-bin/cs-fixer/composer.lock
@@ -106,16 +106,16 @@
         },
         {
             "name": "php-cs-fixer/shim",
-            "version": "v3.95.21",
+            "version": "v3.95.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/shim.git",
-                "reference": "7e679e720ecd5295899681d9e9ce584a281757a2"
+                "reference": "2fa4d097607e1e9d016be2a665bc94ba86586216"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/shim/zipball/7e679e720ecd5295899681d9e9ce584a281757a2",
-                "reference": "7e679e720ecd5295899681d9e9ce584a281757a2",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/shim/zipball/2fa4d097607e1e9d016be2a665bc94ba86586216",
+                "reference": "2fa4d097607e1e9d016be2a665bc94ba86586216",
                 "shasum": ""
             },
             "require": {
@@ -152,7 +152,7 @@
             "description": "A tool to automatically fix PHP code style",
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/shim/issues",
-                "source": "https://github.com/PHP-CS-Fixer/shim/tree/v3.95.21"
+                "source": "https://github.com/PHP-CS-Fixer/shim/tree/v3.95.22"
             },
             "funding": [
                 {
@@ -160,7 +160,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-21T17:04:23+00:00"
+            "time": "2026-08-24T10:38:12+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
The 3.3 line is maintained alongside `main` for the time being, so what landed
there this week lands here too.

**Community files.** `LICENSE.md`, `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`
did not exist on this branch. They are adapted where the branches genuinely
differ: this branch has no `doc/` directory, so `CONTRIBUTING.md` carries the
pull request rules itself and points at the README for building, and
`LICENSE.md` describes this branch's own split — here every workflow except
`reuse.yml` is MIT. `REUSE.toml` lists all three by name, since the annotation
block on this branch globs nothing that would catch them.

**`SECURITY.md`** gets the switch from "I" to "we" and the OpenPGP key details
`main` already carries.

**`README.md`** no longer repeats what `CONTRIBUTING.md` now says, and its link
to the maintainers is gone — the URL was missing the repository name and
answered 404.

**`.nextcloudignore`** keeps `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` out of
the release package. `LICENSE.md` stays in, because it describes the `LICENSES/`
that do ship.

**Dependencies.** Dependabot only watches the default branch, so eslint 10.9.1,
@nextcloud/vue 9.10.0 and php-cs-fixer/shim v3.95.22 arrived on `main` alone.
The @nextcloud/vue bump changes declarations only: every dependency whose range
it widens is already installed at a satisfying version, so the lock file records
the new ranges and nothing else moves. Verified with a clean `npm ci`.

Checked locally: `composer cs:check` (0 of 75), eslint, stylelint, 77 Vitest
tests, `npm run build` and `reuse lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.