### PR TITLE
Let Dependabot watch the 3.3 line as well

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,3 +46,33 @@ updates:
       interval: "weekly"
       day: "saturday"
 
+  # The 3.3 line is maintained alongside main for the time being. Dependabot
+  # reads this file from the default branch only, so each ecosystem needs a
+  # second entry that targets the maintenance branch explicitly.
+  - package-ecosystem: "composer"
+    directory: "/"
+    target-branch: "release/3.3"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+
+  - package-ecosystem: "composer"
+    directory: "/vendor-bin/cs-fixer"
+    target-branch: "release/3.3"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: "release/3.3"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "release/3.3"
+    schedule:
+      interval: "weekly"
+      day: "saturday"


### PR DESCRIPTION
Dependabot reads its configuration from the default branch and, without
`target-branch`, opens pull requests against that branch alone. That is why
eslint, @nextcloud/vue and php-cs-fixer/shim landed on `main` this week and had
to be carried over to `release/3.3` by hand (#235).

Each of the four ecosystems now has a second entry naming the maintenance
branch, so both lines are tracked.

This doubles the number of update pull requests on a Saturday. That is the price
of keeping the lines in step; the entries go when the 3.3 line is retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.