### PR TITLE
Record why the npm-audit checkout is not hardened, and what CodeQL actually scans

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -106,6 +106,14 @@ factor be skipped, accepted twice or brute-forced outweighs any question of styl
   Injection wins nothing there. The two `actions/cache-poisoning/poisonable-step` alerts
   on `npm-audit.yml` are dismissed for that reason and a stronger one: no workflow in
   this repository writes or restores an Actions cache, so there is nothing to poison.
+  Hardening the checkout was considered and rejected: a `sparse-checkout` does not
+  close the path. `package.json` has to stay, because the version step reads it, and
+  its `engines.npm` is what reaches `npm i -g`; keeping a root-level `.npmrc` off the
+  runner would need `sparse-checkout-cone-mode: false` on top, because cone mode always
+  materialises the repository root. Both refs are branches of this repository anyway —
+  whoever could poison one could edit this workflow instead — and the alert would stay,
+  because the rule follows the ref, not the files on disk. Revisit if this job ever
+  gains a secret, writes or restores a cache, or runs on a fork trigger.
 - **Formatting.** `php-cs-fixer` with `nextcloud/coding-standard` owns it, ESLint and
   Stylelint own the frontend. Tabs, brace placement and import order are not review
   material.

--- a/doc/developers.md
+++ b/doc/developers.md
@@ -50,7 +50,7 @@ What these mechanisms promise, and against whom, is bounded by the [threat model
 
 - **Static analysis:** Psalm (errorLevel 3) plus **Psalm taint analysis** (source-to-sink SAST, added in 3.4.0) — currently **no findings**. Taint rides on the annotations shipped in [`nextcloud/ocp`](https://github.com/nextcloud-deps/ocp), so it needs no extra stubs.
 - **Tests:** PHPUnit for the PHP services, Vitest for the frontend logic and components.
-- **Frontend SAST:** CodeQL (JavaScript) via the repository's default setup.
+- **SAST beyond PHP:** CodeQL via the repository's default setup, covering the frontend JavaScript and the GitHub Actions workflows.
 - **Supply chain:** `roave/security-advisories` blocks known-vulnerable composer packages; Dependabot tracks npm/composer updates; the release package ships only runtime files.
 
 ## Licensing


### PR DESCRIPTION
CodeQL's `actions/cache-poisoning/poisonable-step` flags the `npm i -g` step in
`npm-audit.yml`, because the job runs in the context of the default branch while
checking out a ref from the matrix. `REVIEW.md` already recorded why the alert is
dismissed. It did not record why the obvious hardening — a `sparse-checkout` narrowed
to the two files the job reads — was not applied, so the suggestion comes back at
every scan.

It comes back for a reason that turns out to be stronger than expected: a sparse
checkout does not close the path at all. `package.json` has to stay, because the
version step reads it, and its `engines.npm` is the value that reaches `npm i -g`.
The only thing a sparse checkout could remove is a root-level `.npmrc`, and even that
needs `sparse-checkout-cone-mode: false`, since cone mode always materialises the
repository root.

The same alert exposed a second inaccuracy: `doc/developers.md` called the default
setup frontend SAST for JavaScript, when it also runs the GitHub Actions queries — the
very ones that produced this finding. The second commit corrects that line.

Documentation only; no workflow or runtime file changes. The conditions that would
make the hardening worth revisiting are recorded next to the decision: a secret in
the job, an Actions cache, or a fork trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
