### PR TITLE
Raise the fast-uri floor to the fully patched 3.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5699,9 +5699,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
-      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "node": "^24.0.0 || ^26.0.0"
   },
   "overrides": {
+    "fast-uri": "^3.1.7",
     "glob": "^13"
   },
   "devDependencies": {


### PR DESCRIPTION
This tree sat on `fast-uri` 3.1.6, which covers the four advisories the v2 branch just closed (nursoda/twofactor_email#468) but not the two that landed after it: GHSA-qw65-cvwx-89v3 (authority injection via an unvalidated port) and GHSA-58mr-gqgx-xq4g (host confusion via unbalanced or misplaced IP-literal brackets). No Dependabot alert fired here for those two — the gap came out of comparing the installed version against the advisories, not out of the alert list, which is empty.

`fast-uri` arrives transitively (stylelint → table → ajv, which asks for `^3.0.1`), so a bump alone would not hold: an `overrides` entry pins the floor at 3.1.7, next to the `glob` one that is already there.

Development dependency only — it never reaches the bundle a Nextcloud server runs, so this is build-time hygiene and needs no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)