### PR TITLE
Drop the fast-uri override, which no longer changes anything

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,9 +60,6 @@
     "pinia": "^4.0.3",
     "vue": "^3.5.42"
   },
-  "overrides": {
-    "fast-uri": "^3.1.7"
-  },
   "browserslist": [
     "extends @nextcloud/browserslist-config"
   ],


### PR DESCRIPTION
## What this does

Removes the `fast-uri` override from `package.json`. It no longer changes anything.

The only requester is `ajv`, through `table`, and it asks for `^3.0.1`. Since 3.1.7 is
the newest release of the 3.x line, npm resolves the same version with or without the
override — and the lock file proves it: removing the entry leaves `package-lock.json`
byte for byte unchanged.

## Why remove it rather than leave it

It was added as a floor against an advisory that 3.1.7 closes. A floor that the natural
resolution already meets is not a guard, it is debt: the next reader has to work out
what it protects against before touching anything near it. Should a 3.1.8 appear, npm
picks it up on its own.

## The other overrides, checked

- **`esbuild` on `release/3.3` stays.** There two requesters ask for ranges that do not
  overlap (`^0.25.3` and `^0.27.0 || ^0.28.0`), so only the override keeps the tree on
  one copy.
- **`postcss` in the 2.x line stays.** `@vue/component-compiler-utils` asks for
  `^7.0.36`, so only the override keeps that tree on 8.x.

The same entry is removed from the 2.x line in a pull request of its own.

## Testing

`npm ci` resolves `fast-uri@3.1.7` as before; lint, stylelint, the 86 unit tests and the
build are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
