### PR TITLE
Support Nextcloud 35

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,17 +1,9 @@
 # SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-# UNTESTED. Read this before trusting a green or a red result.
-#
-# The script it drives is exercised locally against both supported server versions, but
-# THIS WORKFLOW HAS NEVER RUN: a workflow can only be proven by pushing it, so its
-# first run is the one on the pull request that adds it. Expect one or two rounds of
-# adjustment — the likely candidates are the krankerl download, the PHP extensions
-# needed by the build, and how long the image pull takes on a runner.
-#
-# What it does: runs the smoke test against every Nextcloud version the app declares
-# support for. The version list comes from appinfo/info.xml, so it cannot drift from
-# what info.xml claims. Roughly 5 minutes per version.
+# Runs the smoke test against every Nextcloud version the app declares support for.
+# The version list comes from appinfo/info.xml, so it cannot drift from what info.xml
+# claims. Roughly 5 minutes per version.
 
 name: Smoke test
 
@@ -42,14 +34,47 @@ jobs:
       - name: Read the supported server range from info.xml
         id: read
         run: |
+          # 404 means the tag does not exist. Anything else — Docker Hub rate-limiting
+          # the shared runner IPs, a timeout, a 5xx — is a broken answer, not an
+          # absent image, and must not be read as one: that would either skip a
+          # version the app promises or fail the range on a network hiccup.
+          has_image() {
+            code=$(curl -s -o /dev/null -m 20 -w '%{http_code}' \
+              "https://hub.docker.com/v2/repositories/library/nextcloud/tags/$1")
+            case "$code" in
+              200) return 0 ;;
+              404) return 1 ;;
+              *) echo "::error::Docker Hub answered $code for $1, so whether the image exists is unknown."
+                 exit 1 ;;
+            esac
+          }
+
           spec=$(grep -oP '<nextcloud[^>]*' appinfo/info.xml)
           min=$(printf '%s' "$spec" | grep -oP 'min-version="\K[0-9]+')
           max=$(printf '%s' "$spec" | grep -oP 'max-version="\K[0-9]+')
-          if [ "$min" = "$max" ]; then
-            tags="\"$min-apache\""
-          else
-            tags="\"$min-apache\", \"$max-apache\""
-          fi
+
+          # Every version in the declared range, not only its ends: a range of three
+          # would otherwise leave the middle one — usually the most widely installed
+          # server — untested.
+          #
+          # A declared version without an official image cannot be tested here. That
+          # happens while the app already supports a server that Docker Hub has not
+          # published yet, which is a deliberate state: the version was then verified
+          # by hand instead. The image appears on release day and the gate closes
+          # again by itself, so this weakens nothing for any released server. The
+          # oldest declared version is the exception — no image there means the range
+          # itself is wrong.
+          tags=""
+          for v in $(seq "$min" "$max"); do
+            if has_image "$v-apache"; then
+              tags="${tags:+$tags, }\"$v-apache\""
+            elif [ "$v" = "$min" ]; then
+              echo "::error::Nextcloud $min is the oldest version the app declares, and there is no $min-apache image."
+              exit 1
+            else
+              echo "::warning::No image for Nextcloud $v yet, so the smoke test skips it. Verify that version by hand until the image is published."
+            fi
+          done
 
           # The server after the declared range, if the official image already has
           # it. Nextcloud publishes a tag when a version is released, so this stays
@@ -57,7 +82,7 @@ jobs:
           # edit needed here when 35, then 36, then 37 appears. Nothing depends on
           # it: the run is allowed to fail, see continue-on-error below.
           next=$((max + 1))
-          if curl -sf "https://hub.docker.com/v2/repositories/library/nextcloud/tags/$next-apache" > /dev/null; then
+          if has_image "$next-apache"; then
             echo "next-tag=$next-apache" >> "$GITHUB_OUTPUT"
             tags="$tags, \"$next-apache\""
             echo "the next server already has an image: $next-apache"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support Nextcloud 35
 - Administrator documentation for occ, enforcement, email addresses and a FAQ
 - Contributing guidelines, a code of conduct and an overview of the licences used
 - Fresh screenshots in the documentation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ only. [`doc/architecture.md`](doc/architecture.md) explains how the pieces fit;
 
 | | |
 |---|---|
-| Nextcloud | 33–34 (`appinfo/info.xml`) |
+| Nextcloud | 33–35 (`appinfo/info.xml`) |
 | PHP | 8.2–8.5 |
 | Node | `^24 \|\| ^26` |
 
@@ -26,7 +26,15 @@ the oldest supported server. Raising the PHP floor therefore means dropping the
 Nextcloud versions that still allow the older PHP. When you touch the range, change
 `info.xml` (both), `composer.json` (`require.php`, `config.platform.php`,
 `nextcloud/ocp`) and `psalm.xml` together, then check that CI agrees. Nextcloud 35
-requires PHP 8.3, so supporting it means dropping every server that still allows 8.2.
+requires PHP 8.3 **on the server**, which says nothing about the app's own floor: the
+app supports 33 to 35 at once because its code runs on 8.2.
+
+**`nextcloud/ocp` cannot follow `info.xml` past 34.** Its `v35` requires
+`~8.3 || ~8.4 || ~8.5`, and `config.platform.php` here is 8.2, so `^35` will not resolve
+for as long as the app supports PHP 8.2 — which is for as long as it supports Nextcloud
+33. That is not a problem: it is a development dependency, and psalm analyses against
+the *oldest* supported OCP anyway. The CI's `ocp max` job installs the newest branch
+separately.
 
 ## Layout
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -64,7 +64,7 @@ at the bottom of "Personal Settings/Security").]]></description>
     </screenshot>
     <dependencies>
         <php min-version="8.2" max-version="8.5"/>
-        <nextcloud min-version="33" max-version="34"/>
+        <nextcloud min-version="33" max-version="35"/>
     </dependencies>
     <background-jobs>
         <job>OCA\TwoFactorEMail\BackgroundJob\CleanUpExpiredCodes</job>

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -47,7 +47,7 @@ change it was meant to verify.
 
 ## Testing before publishing
 
-Run `tests/smoke/smoke.sh` against the built package. It covers **both ends of the
+Run `tests/smoke/smoke.sh` against the built package. It covers **every version in the
 supported server range**, which is not pedantry: 3.4.0 shipped a resend endpoint that
 was dead on Nextcloud 33 and fine on 34, because the exemption from the two-factor
 gate is taken from the docblock on 33 and from the PHP attribute on 34, and that

--- a/psalm.xml
+++ b/psalm.xml
@@ -47,17 +47,7 @@
         <DeprecatedClass errorLevel="error"/>
         <DeprecatedConstant errorLevel="error"/>
         <DeprecatedInterface errorLevel="error"/>
-        <!-- Nextcloud 35 deprecates ISecureRandom::generate in favour of PHP's
-             Randomizer::getBytesFromString, which needs PHP 8.3. The app's floor is 8.2,
-             because Nextcloud 33 allows it, so the replacement is out of reach and the
-             deprecated call is the only way to generate the code. One method, named on
-             purpose: any other deprecated call still has to be an error.
-             CompatibilityShimsTest fails as soon as the floor reaches 8.3. -->
-        <DeprecatedMethod errorLevel="error">
-            <errorLevel type="suppress">
-                <referencedMethod name="OCP\Security\ISecureRandom::generate"/>
-            </errorLevel>
-        </DeprecatedMethod>
+        <DeprecatedMethod errorLevel="error"/>
         <DeprecatedProperty errorLevel="error"/>
         <DeprecatedTrait errorLevel="error"/>
         <DeprecatedFunction errorLevel="error"/>

--- a/tests/Unit/CompatibilityShimsTest.php
+++ b/tests/Unit/CompatibilityShimsTest.php
@@ -26,65 +26,6 @@ use PHPUnit\Framework\TestCase;
 final class CompatibilityShimsTest extends TestCase {
 	private const ROOT = __DIR__ . '/../..';
 
-	/**
-	 * From psalm.xml, not from info.xml. The `<php min-version>` in info.xml is
-	 * maintained by hand and nothing checks it, while the psalm job verifies that
-	 * `phpVersion` equals the floor derived from the oldest supported server. Reading
-	 * the value CI already enforces makes this trigger as reliable as that check.
-	 */
-	private function minimumPhpVersion(): string {
-		$psalm = file_get_contents(self::ROOT . '/psalm.xml');
-		self::assertIsString($psalm, 'psalm.xml is not readable');
-		self::assertSame(1, preg_match('/phpVersion="([0-9.]+)"/', $psalm, $m));
-		return $m[1];
-	}
-
-	/**
-	 * Nextcloud 35 deprecates ISecureRandom::generate in favour of PHP's
-	 * Randomizer::getBytesFromString, which needs PHP 8.3. While the app supports
-	 * PHP 8.2 the replacement is out of reach, so psalm is told to accept that one
-	 * call. The moment the floor moves, the suppression hides a call that should
-	 * have changed — and nothing else would say so.
-	 */
-	public function testTheSecureRandomSuppressionGoesWhenPhp82Does(): void {
-		$psalm = file_get_contents(self::ROOT . '/psalm.xml');
-		$generator = file_get_contents(self::ROOT . '/lib/Service/NumericalCodeGenerator.php');
-		self::assertIsString($psalm);
-		self::assertIsString($generator);
-
-		// Both sides, like the Nextcloud 33 pair below. A suppression that outlives the
-		// call it was written for is not reported by psalm either, because the unused
-		// check is off — so it would sit here widening what is accepted, unseen.
-		//
-		// The interface and the call, not the property name: renaming the property is a
-		// refactor that says nothing about the deprecation, and it must not read as
-		// "this carve-out can go".
-		self::assertStringContainsString('ISecureRandom', $generator);
-		$this->assertStringContainsString(
-			'->generate(',
-			$generator,
-			'Nothing calls ISecureRandom::generate any more: remove its suppression from '
-			. 'psalm.xml and this test with it.',
-		);
-
-		// The handler itself, not the comment beside it: a bare class name would also
-		// match the explanation and stay green after the handler was deleted.
-		$handler = '<referencedMethod name="OCP\Security\ISecureRandom::generate"/>';
-
-		if (version_compare($this->minimumPhpVersion(), '8.3', '>=')) {
-			$this->assertStringNotContainsString(
-				$handler,
-				$psalm,
-				'PHP 8.2 is no longer supported: generate the code with '
-				. 'Random\Randomizer::getBytesFromString() and remove the suppression '
-				. 'for ISecureRandom::generate from psalm.xml.',
-			);
-			return;
-		}
-
-		$this->assertStringContainsString($handler, $psalm);
-	}
-
 	private function minimumNextcloudVersion(): int {
 		$info = file_get_contents(self::ROOT . '/appinfo/info.xml');
 		self::assertIsString($info, 'appinfo/info.xml is not readable');
@@ -134,11 +75,11 @@ final class CompatibilityShimsTest extends TestCase {
 	/**
 	 * A suppression here exists because the app spans several versions, and in any one
 	 * analysis run it may simply not be triggered: the Nextcloud 33 one is idle against
-	 * the newest OCP, the ISecureRandom one against every OCP in the range until 35
-	 * enters it. Psalm would report each such run's idle suppression as unused, so the
-	 * check stays off while any suppression is left and comes back once none is. Tying
-	 * it to one particular suppression was wrong the moment a second one existed, which
-	 * is how this test earned its own place.
+	 * the newest OCP, and the two Controller.php ones depend on which OCP is installed.
+	 * Psalm would report each such run's idle suppression as unused, so the check stays
+	 * off while any suppression is left and comes back once none is. Tying it to one
+	 * particular suppression was wrong the moment a second one existed, which is how
+	 * this test earned its own place.
 	 */
 	public function testTheUnusedSuppressionCheckFollowsTheSuppressions(): void {
 		$psalm = file_get_contents(self::ROOT . '/psalm.xml');

--- a/tests/smoke/README.md
+++ b/tests/smoke/README.md
@@ -25,7 +25,7 @@ Linux, or macOS with GNU coreutils and grep ahead of the stock ones in `PATH`.
 
 ```bash
 cd tests/smoke
-./smoke.sh                   # both ends of the supported server range
+./smoke.sh                   # every version in the supported server range
 NC_TAG=33-apache ./smoke.sh  # one specific server version
 SLOW=0 ./smoke.sh            # skip the successful resend, saving 65 s per version
 KEEP=1 ./smoke.sh            # leave the instance up to look at it

--- a/tests/smoke/smoke.sh
+++ b/tests/smoke/smoke.sh
@@ -6,12 +6,12 @@
 # the mail, and a full login with the code from it. Runs against a disposable
 # Nextcloud built from the packaged app.
 #
-# By default it tests BOTH ends of the supported server range, taken from
+# By default it tests EVERY version of the supported server range, taken from
 # appinfo/info.xml. That is not thoroughness for its own sake: a route that was
 # exempt from the two-factor gate on the newest server only, and dead on the oldest,
 # shipped in 3.4.0 and was found exactly this way.
 #
-#   ./smoke.sh                   # min and max supported Nextcloud version
+#   ./smoke.sh                   # every supported Nextcloud version
 #   NC_TAG=33-apache ./smoke.sh  # one specific server version
 #   SLOW=0 ./smoke.sh            # skip the successful resend, saving 65 s per version
 #   KEEP=1 ./smoke.sh            # leave the instance running afterwards
@@ -505,15 +505,45 @@ run_checks() {
 	is "the address was restored" "$(occ user:setting admin settings email | tr -d ' \r')" "$address"
 }
 
-# Which server versions? Default: both ends of the declared range, because that is
-# where the differences bite.
+# Which server versions? Default: every version in the declared range. A version the
+# app claims to support but Docker Hub has not published yet is skipped with a notice —
+# that happens while support was verified by hand on a real instance instead, and the
+# image closes the gap by itself on release day. The oldest declared version is the
+# exception: no image there means the declared range is wrong.
 if [ -n "${NC_TAG:-}" ]; then
 	TAGS=("$NC_TAG")
 else
 	spec=$(grep -oP '<nextcloud[^>]*' "$ROOT/appinfo/info.xml")
 	min=$(printf '%s' "$spec" | grep -oP 'min-version="\K[0-9]+')
 	max=$(printf '%s' "$spec" | grep -oP 'max-version="\K[0-9]+')
-	if [ "$min" = "$max" ]; then TAGS=("$min-apache"); else TAGS=("$min-apache" "$max-apache"); fi
+	# Without this, a range that failed to parse leaves seq with nothing to do, the
+	# loop below never runs, and the script reports a clean pass over no versions.
+	if ! [ "${min:-}" -ge 1 ] 2>/dev/null || ! [ "${max:-}" -ge "$min" ] 2>/dev/null; then
+		echo "appinfo/info.xml does not declare a usable server range (min='$min', max='$max')." >&2
+		exit 1
+	fi
+	# 404 means the tag does not exist. Anything else — Docker Hub rate-limiting this
+	# address, a timeout, a 5xx — says nothing about the image and must not be read as
+	# an answer.
+	TAGS=()
+	for v in $(seq "$min" "$max"); do
+		code=$(curl -s -o /dev/null -m 20 -w '%{http_code}' \
+			"https://hub.docker.com/v2/repositories/library/nextcloud/tags/$v-apache")
+		case "$code" in
+			200) TAGS+=("$v-apache") ;;
+			404)
+				if [ "$v" = "$min" ]; then
+					echo "Nextcloud $min is the oldest version the app declares, and there is no $min-apache image." >&2
+					exit 1
+				fi
+				note "Nextcloud $v has no image yet and was not tested"
+				;;
+			*)
+				echo "Docker Hub answered $code for $v-apache, so whether the image exists is unknown." >&2
+				exit 1
+				;;
+		esac
+	done
 fi
 
 # Refuse to test a package that cannot contain the current work. krankerl packages the


### PR DESCRIPTION
## What this does

Adds Nextcloud 35 to the supported range and makes the smoke test able to keep that
promise honest.

## Why nothing in the code had to change

Every critical change of the 35 cycle was checked one by one:

| Change in 35 | Effect here |
|---|---|
| PHP 8.3 minimum **on the server** | None. The app's own floor stays 8.2 for as long as Nextcloud 33 is supported, and its code runs on 8.2 — psalm analyses against that. |
| Symfony Console 7 requires a return type on `execute()` | Already satisfied: all three commands declare `: int`, and the same signature is valid in 6.4. |
| `\OCP\Remote\*` removed | Not used. |
| Preview `registerProvider()` removed | No preview providers. |
| `AutoCompleteEvent` → `AutoCompleteFilterEvent` | Not used. |
| `ISignedCloudFederationProvider` | No federation. |
| Frontend globals removed (`moment`, `_`, `dav`, `oc_*`, `OCDialogs`, clipboard) | Not used. |
| MariaDB 10.11 / MySQL 8.4 | No tables, no SQL of its own. |
| phpseclib 2 → 3 | Not installed. |

`nextcloud/ocp` stays at `^33 || ^34`. There is no stable `v35` tag yet, only
`35.0.0.x-dev`, and it is a development dependency that only has to resolve — so it is
free to lag what `info.xml` promises. It moves to `^35` when the tag appears.

## The two changes to the smoke test

**It tested the two ends of the declared range.** That was the whole range while the
range was 33 to 34. With 35 in it, 34 would silently have dropped out of CI — the most
widely installed of the three. It now runs every version in the range.

**It turned a declared version into a required image.** Docker Hub publishes a tag on
release day, so `35-apache` does not exist before 2026-09-16, and the gate would have
failed on a missing image rather than on the app. A declared version without an image
is now skipped with a warning, and the gate closes again by itself once the image
appears. The oldest declared version stays a hard error: no image there means the
declared range is wrong.

Both changes are in the workflow and in `tests/smoke/smoke.sh`, so a local run and a CI
run still pick the same versions.

The workflow header still warned that it had never run. It has, many times.

## How Nextcloud 35 was verified instead

By hand, on a real instance running 35.0.0.8: the login challenge end to end, the code
bound to its address, the masked address on the challenge and enrolment screens, the
"no new code went out" case, and an account whose only other factor is backup codes.

## A carve-out that turned out to rest on nothing

`psalm.xml` suppressed `DeprecatedMethod` for `ISecureRandom::generate`, and
`CompatibilityShimsTest` kept that suppression alive until the PHP floor reaches 8.3.
The stated reason was that Nextcloud 35 deprecates the method in favour of
`Random\Randomizer::getBytesFromString`.

It does not. `ISecureRandom::generate` carries no `@deprecated` in `nextcloud-deps/ocp`
on `stable34`, `stable35` or `master`, nor in the server's own
`lib/public/Security/ISecureRandom.php`. Taking 35 into the range is the moment that
premise had to be checked, so the suppression and its test are gone.

Proven both ways: with the suppression removed, psalm stays clean on the call it was
written for — and a deliberately added call to a genuinely deprecated method
(`IUserManager::search`) is reported as an error, so `DeprecatedMethod errorLevel="error"`
still bites. Should Nextcloud ever add the annotation, that is exactly how it will
surface.

## Testing

- `composer test:unit:dev` — 300 tests green
- `composer psalm`, `composer psalm:taint` — clean
- `composer cs:check`, `reuse lint` — clean
- `tests/smoke/smoke.sh` — 33 and 34 green, 35 skipped with the expected notice
- CI on the pull request — unit tests against `stable35` on PHP 8.3, 8.4 and 8.5 pass,
  as does psalm against the newest OCP

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
