### PR TITLE
Drop the ISecureRandom carve-out: upstream took the deprecation back

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -75,11 +75,6 @@ factor be skipped, accepted twice or brute-forced outweighs any question of styl
   run it may simply not be triggered — and psalm would then report it as unused. The
   flag belongs to all of them and goes with the last one, which is a check of its own,
   not to the handler it was first added for.
-- **`ISecureRandom::generate` is deprecated in Nextcloud 35 and still used.** Its
-  replacement, `Random\Randomizer::getBytesFromString()`, needs PHP 8.3, and the app's
-  floor is 8.2 because Nextcloud 33 allows it. Psalm is told to accept that one method
-  by name, so every other deprecated call stays an error, and
-  `CompatibilityShimsTest` fails as soon as the floor reaches 8.3.
 - **`symfony/console` at `^6.4.42`**: Nextcloud bundles Symfony 6.4 and `occ` commands
   must match its major. This one has no expiry — it moves when Nextcloud moves.
 - **`@nextcloud/vite-config` pinned to a pre-release**: it is the only version that

--- a/doc/developers.md
+++ b/doc/developers.md
@@ -53,6 +53,32 @@ What these mechanisms promise, and against whom, is bounded by the [threat model
 - **SAST beyond PHP:** CodeQL via the repository's default setup, covering the frontend JavaScript and the GitHub Actions workflows.
 - **Supply chain:** `roave/security-advisories` blocks known-vulnerable composer packages; Dependabot tracks npm/composer updates; the release package ships only runtime files.
 
+## When an OCP method the app needs is deprecated
+
+Nextcloud marks a public interface deprecated long before it removes it, and `psalm.xml` files every `Deprecated*` issue as an error so that window is not missed. Sometimes the replacement is out of reach — typically because it needs a newer PHP than the app's floor, which follows the oldest supported server. The path taken in that case, once, in August 2026:
+
+1. **Show the annotation and name its source.** The `@deprecated` tag in [`nextcloud-deps/ocp`](https://github.com/nextcloud-deps/ocp) or in the server's `lib/public/`, plus the pull request that added it, and **which branch carries it**. The pull request number goes into the commit message: an upstream decision can be reversed, and the next reader must be able to check it without repeating the search.
+2. **Suppress the one method by name** in `psalm.xml`, never the whole issue type, so every other deprecated call stays an error:
+
+   ```xml
+   <DeprecatedMethod errorLevel="error">
+       <errorLevel type="suppress">
+           <referencedMethod name="OCP\Some\IInterface::method"/>
+       </errorLevel>
+   </DeprecatedMethod>
+   ```
+
+3. **Register it in `CompatibilityShimsTest`** with the condition that ends it, and assert both sides: that the call still exists and that the suppression is gone once the condition is met. A suppression that outlives its call is not reported by psalm either, because `findUnusedIssueHandlerSuppression` is off while any suppression exists.
+4. **Watch the branch the suppression is actually needed for.** This is the step that went wrong the first time. The guard was tied to the app's PHP floor — a number this repository controls — while the real condition was an upstream decision, so it could not notice when Nextcloud reversed it. Reading the installed `vendor/nextcloud/ocp` instead is no fix and would have been wrong here too: the annotation only ever lived on the server's `master`, which is the non-blocking "Nextcloud next" run, and no stable OCP the app installs ever carried it. A vendor-reading guard would have demanded the suppression's removal from day one, and its verdict would change with the OCP version of each matrix job. Check the source the suppression exists for — `master` when that is where the annotation is.
+5. **Record it in [`REVIEW.md`](../REVIEW.md)** so a reviewer does not raise it again, and remove that entry with the carve-out.
+
+A missing annotation does not mean there never was one. Before deleting a carve-out, look for the reversal:
+
+```bash
+gh api "search/issues?q=repo:nextcloud/server+<Symbol>+is:pull-request&sort=created&order=desc" \
+  --jq '.items[] | "#\(.number) \(.created_at[0:10]) \(.title)"'
+```
+
 ## Licensing
 
 The app is licensed [AGPL-3.0-or-later](../LICENSES/AGPL-3.0-or-later.txt); bundled assets keep their own licences (e.g. the app icon). [LICENSE.md](../LICENSE.md) lists every licence used here and how the REUSE/SPDX metadata is applied. Add an SPDX header to each new file, or an entry in `REUSE.toml` where a header is impossible; CI verifies it.


### PR DESCRIPTION
## What this does

Removes the `ISecureRandom::generate` entry from `REVIEW.md`, the last piece of a
carve-out whose reason upstream withdrew.

## The short history

- **24 June 2026** — Nextcloud deprecates `ISecureRandom::generate` in favour of
  `Random\Randomizer::getBytesFromString()`
  ([server#61538](https://github.com/nextcloud/server/pull/61538)). That call needs
  PHP 8.3; this app's floor is 8.2 for as long as it supports Nextcloud 33.
- **13 August 2026** — psalm is told to accept that one method, `CompatibilityShimsTest`
  holds the exception until the PHP floor reaches 8.3, and `REVIEW.md` records it.
- **20 August 2026** — Nextcloud takes the deprecation back
  ([server#63412](https://github.com/nextcloud/server/pull/63412)): the interface is a
  service and therefore mockable in tests, the default character list would have to be
  copied to every caller, and it is used throughout the code base.

The annotation only ever lived on `master`. `stable34` had branched off before it
landed, and `stable35` branched on 5 September, after it was gone — so the suppression
never actually suppressed anything on an OCP version this app analyses against.

## Why it still had to go

The psalm handler and its test went with #253. This `REVIEW.md` entry was left behind,
and a `REVIEW.md` entry exists to stop a reviewer raising a settled question — one that
states a withdrawn deprecation as current does the opposite.

Should Nextcloud deprecate the method again, `DeprecatedMethod errorLevel="error"` says
so on the next run; that was counter-proved in #253.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.

## The path is written down now

`doc/developers.md` gains a section on what to do when an OCP method the app needs is
deprecated: show the annotation and name the pull request that added it, suppress the one
method by name rather than the issue type, register it in `CompatibilityShimsTest` with
the condition that ends it, and watch the branch the suppression is
actually needed for. The last step is the one that failed here: the guard was tied to this
repository's PHP floor while the real condition was an upstream decision. Reading the
installed `vendor/nextcloud/ocp` instead would have been wrong too — the annotation only
ever lived on the server's `master`, so such a guard would have demanded the suppression's
removal from day one, and its verdict would change with the OCP version of each matrix
job. The section also carries the search that finds a reversal, so that a missing
annotation is not read as one that never existed.
