### PR TITLE
Release 3.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 3.3.3 (2026-09-05)
 
 ### Added
 
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The app store screenshot is visible inside Nextcloud instances again
 - A code was reported as sent when the mail server refused the address (#202)
 - Reloading the challenge page no longer retries a failing mail server without limit
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -42,7 +42,7 @@ Mind that, once a user enabled any 2FA provider, they can no longer use their
 password in applications that don't support the web-based 2FA login flow. For
 such applications, the user needs to create and use app passwords (to be found
 at the bottom of "Personal Settings/Security").]]></description>
-    <version>3.3.2</version>
+    <version>3.3.3</version>
     <licence>agpl</licence>
     <author mail="twofactor-email@datenschutz-individuell.de">
         Olav Seyfarth (datenschutz-individuell) [see CONTRIBUTORS.md for more]
@@ -59,8 +59,8 @@ at the bottom of "Personal Settings/Security").]]></description>
     <bugs>https://github.com/datenschutz-individuell/twofactor_email/issues</bugs>
     <repository>https://github.com/datenschutz-individuell/twofactor_email.git</repository>
     <screenshot
-            small-thumbnail="https://raw.githubusercontent.com/datenschutz-individuell/twofactor_email/3.3.1/screenshots/select-auth_thumb.webp">
-        https://raw.githubusercontent.com/datenschutz-individuell/twofactor_email/3.3.1/screenshots/challenge.webp
+            small-thumbnail="https://raw.githubusercontent.com/datenschutz-individuell/twofactor_email/release/3.3/screenshots/select-auth_thumb.webp">
+        https://raw.githubusercontent.com/datenschutz-individuell/twofactor_email/release/3.3/screenshots/challenge.png
     </screenshot>
     <dependencies>
         <php min-version="8.1" max-version="8.5"/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "twofactor_email",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "twofactor_email",
-      "version": "3.3.2",
+      "version": "3.3.3",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "twofactor_email",
   "description": "Two-Factor Email Provider",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "type": "module",
   "author": {
     "name": "Christoph Wurst",


### PR DESCRIPTION
## What this does

Releases 3.3.3 from the maintenance line: the version bump, the changelog date, and the
store pictures.

## The store pictures

`appinfo/info.xml` named two URLs frozen at tag `3.3.1`, and gave the **lossless webp** as
the screenshot. That is the one picture Nextcloud fetches through its own image proxy, and
the proxy refuses lossless webp — so inside an instance the app showed no picture at all.

Both URLs now follow the `release/3.3` branch, and the screenshot is `challenge.png`,
which has been sitting next to the webp in `screenshots/` all along at the same
855×479. The thumbnail stays `select-auth_thumb.webp`: the store's app grid reads it
directly, never through the proxy, so the smaller lossless file is right there.

Both URLs answer 200 on the branch as it stands.

## Testing

`composer test:unit:dev` (170 tests), `composer cs:check`, `reuse lint` and `npm test`
(80 tests) are green; the four places a version lives agree on 3.3.3 and the lock file
changed in nothing else. The single PHPUnit deprecation notice predates this change — it
is there on `release/3.3` without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
