### PR TITLE
Fix the broken links on the landing page

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -40,7 +40,8 @@
 * Contributors may use AI to refactor or verify code snippets. This led to more robust code!
 * All code proposed by an AI is thoroughly manually verified and adjusted by the maintainers.
 * Major AI contributions are commented in the source code near the AI enhanced code parts.
-* Many thanks to both DuckDuckGo and OpenAI. It is fun using duck.ai with GPT-5 mini.
+* Many thanks to Anthropic, whose Claude Code does most of that work today, and to
+  DuckDuckGo and OpenAI for duck.ai with GPT-5 mini.
 
 ____
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,39 +2,37 @@
 
 ### Sponsor
 
-* [Datenschutz Individuell](mailto:Datenschutz
-  Individuell <kontakt@datenschutz-individuell.de>) (https://www.datenschutz-individuell.de)
+* [Datenschutz Individuell](mailto:kontakt@datenschutz-individuell.de) ([datenschutz-individuell.de](https://www.datenschutz-individuell.de))
   Development sponsor for twofactor_email ≥3.0.0
 
 ### Current Maintainer
 
-* [Olav Seyfarth](mailto:Olav Seyfarth <olav@seyfarth.de>) ([nursoda](https://github.com/nursoda))
-* [Niklas Seyfarth](mailto:Niklas Seyfarth <niklas@seyfarth.de>) ([seyfahni](https://github.com/seyfahni))
+* [Olav Seyfarth](mailto:olav@seyfarth.de) ([nursoda](https://github.com/nursoda))
+* [Niklas Seyfarth](mailto:niklas@seyfarth.de) ([seyfahni](https://github.com/seyfahni))
 
 ### Previous Authors
 
-* [Nico Kluge](mailto:Nico Kluge <nico.kluge@klugecoded.com>) ([KlugeNico](https://github.com/KlugeNico))
+* [Nico Kluge](mailto:nico.kluge@klugecoded.com) ([KlugeNico](https://github.com/KlugeNico))
   New author of twofactor_email ≥3.0.0. Cloned and adjusted twofactor_totp project
 
 ### Original Authors
 
-* [Christoph Wurst](mailto:Christoph
-  Wurst <christoph@winzerhof-wurst.at>) ([christophwurst](https://github.com/christophwurst))
+* [Christoph Wurst](mailto:christoph@winzerhof-wurst.at) ([christophwurst](https://github.com/christophwurst))
   Author of [twofactor_totp](https://github.com/nextcloud/twofactor_totp) that ≥3.0.0 was cloned from
-* [Roeland Jago Douma](mailto:Roeland Jago Douma <roeland@famdouma.nl>) ([rullzer](https://github.com/rullzer))
-  Original author of twofactor_email ≤3.0.0
+* [Roeland Jago Douma](mailto:roeland@famdouma.nl) ([rullzer](https://github.com/rullzer))
+  Original author of twofactor_email ≤2.8.11
 
 ### Code, Automation, Reviews, Tests, Documentation, Discussion/Input
 
-* [Florian Doersch](mailto:Florian Doersch <sf-team@siedler25.org>) ([Flow86](https://github.com/Flow86))
+* [Florian Doersch](mailto:sf-team@siedler25.org) ([Flow86](https://github.com/Flow86))
 * Stanislav Zapolsky ([stszap](https://github.com/stszap))
-* [Sascha Wiswedel](mailto:Sascha Wiswedel <sascha.wiswedel@nextcloud.com>) ([wiswedel](https://github.com/wiswedel))
+* [Sascha Wiswedel](mailto:sascha.wiswedel@nextcloud.com) ([wiswedel](https://github.com/wiswedel))
 * Morris Jobke ([MorrisJobke](https://github.com/MorrisJobke))
-* [Andy Xheli](mailto:Andy Xheli <axheli@axtsolutions.com>) ([andyxheli](https://github.com/andyxheli))
-* [Niklas Seyfarth](mailto:Niklas Seyfarth  <niklas@seyfarth.de>) ([seyfahni](https://github.com/seyfahni))
-* [Barbara Seyfarth](mailto:Barbara Seyfarth <barbara@seyfarth.de>) ([firlefunke](https://github.com/firlefunke))
-* [Anna Larch](mailto:Anna Larch <anna@nextcloud.com>) ([miaulalala](https://github.com/miaulalala))
-* [Felix Pütsch](mailto:Felix Pütsch <felix@puetsch.net>) ([puetsch](https://github.com/puetschs))
+* [Andy Xheli](mailto:axheli@axtsolutions.com) ([andyxheli](https://github.com/andyxheli))
+* [Niklas Seyfarth](mailto:niklas@seyfarth.de) ([seyfahni](https://github.com/seyfahni))
+* [Barbara Seyfarth](mailto:barbara@seyfarth.de) ([firlefunke](https://github.com/firlefunke))
+* [Anna Larch](mailto:anna@nextcloud.com) ([miaulalala](https://github.com/miaulalala))
+* [Felix Pütsch](mailto:felix@puetsch.net) ([puetsch](https://github.com/puetsch))
 * ElonSmokes ([ElonSmokes](https://github.com/ElonSmokes))
 
 ### AI usage to enhance code
@@ -46,5 +44,5 @@
 
 ____
 
-*Please [tell me](mailto:Olav Seyfarth <olav@seyfarth.de>?subject=[twofactor_email] CONTRIBUTORS.md) if I forgot to
+*Please [tell me](mailto:olav@seyfarth.de?subject=%5Btwofactor_email%5D%20CONTRIBUTORS.md) if I forgot to
 include you or somebody or if I shall correct or delete contact details.*

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [Nextcloud](https://nextcloud.com/) supports web logins with a second factor ([two-factor authentication](https://en.wikipedia.org/wiki/Multi-factor_authentication#Factors), 2FA). To support a certain type of 2FA, a "2FA provider" (server-)app must be installed. 2FA kicks in after the primary authentication stage (typically username and password) were successful. This provider challenges the user to enter a randomly generated authentication code (aka one-time password, OTP, currently six digits). It sends that code to the user's primary email address and expects the user to enter it on an additional second step web login page.
 
+![The code entry screen, showing the masked address the code went to and when a new one can be requested](doc/img/challenge-initial.webp)
+
 ## Installation, activation and usage
 
 As with any 2FA provider, two-factor email must be installed from the [Nextcloud app store](https://apps.nextcloud.com/apps/twofactor_email) and enabled by a Nextcloud server admin. Additionally, the Nextcloud must have a working email server configured.


### PR DESCRIPTION
Fixes what the repository's landing page and its contributor list get wrong.

**Links that never worked.** Several `mailto:` links carried a display name, and three of them wrapped over two lines. A link destination cannot contain a line break, so those entries rendered as plain text instead of links. Plain addresses cannot break that way. The closing line had the same problem through the spaces and brackets in its `subject`, now percent-encoded.

**Two wrong facts.** Felix Pütsch's profile link pointed at `puetschs`, a user that does not exist. Roeland Jago Douma is credited as the original author "≤3.0.0", which overlaps with the next entry: 3.0.0 is where Nico Kluge started, so his own line ends at 2.8.11.

**A picture.** The README had none, although `doc/img` carries current screenshots. The code entry screen shows what the app does.

**Today's tools.** The AI credits named only duck.ai, which no longer matches how the work is done.

Repository metadata is being corrected alongside this, outside the repository: the "Website" field pointed at the app store page of `twofactor_totp`, a different app.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
