### PR TITLE
Run the repair steps in a fresh process, not in the one that updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.5.1 (2026-09-05)
+
+### Changed
+
+- The checks on the stored email texts run on the next cron run after an update, and report to the log
+
+### Fixed
+
+- The update to 3.5.0 aborted with a fatal error: a repair step ran against the classes of the version it replaced
+
 ## 3.5.0 (2026-09-05)
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,14 @@ treating them as background noise, and re-check whether the existing pins and
   **both** version fields in `package-lock.json` — plus a `CHANGELOG.md` section with
   the release date. Change the values in place; do not re-resolve the lock file during
   a release.
+- **A repair step that names a class of this app is a `<live-migration>`.** Pre- and
+  post-migration steps run inside the process that updated the app, and that process
+  still holds the previous version's classes — `<commands>` alone makes Nextcloud load
+  `AppSettings` and `SettingsValidator` before the update starts. A live migration runs
+  as a background job in a fresh process. Nothing reads a background job's output, so
+  such a step logs what it found. A **schema migration** has no such escape —
+  `MigrationService` always runs it in that same process — so it names nothing from this
+  app at all and spells the values out. `RepairStepProcessTest` enforces both rules.
 - **Decide for every new file whether it belongs in the release package.**
   `.nextcloudignore` keeps the package to runtime files; a new file at the root ships
   unless it is listed there.

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -42,7 +42,7 @@ Mind that, once a user enabled any 2FA provider, they can no longer use their
 password in applications that don't support the web-based 2FA login flow. For
 such applications, the user needs to create and use app passwords (to be found
 at the bottom of "Personal Settings/Security").]]></description>
-    <version>3.5.0</version>
+    <version>3.5.1</version>
     <licence>agpl</licence>
     <author mail="twofactor-email@datenschutz-individuell.de">
         Olav Seyfarth (datenschutz-individuell) [see CONTRIBUTORS.md for more]
@@ -70,10 +70,13 @@ at the bottom of "Personal Settings/Security").]]></description>
         <job>OCA\TwoFactorEMail\BackgroundJob\CleanUpExpiredCodes</job>
     </background-jobs>
     <repair-steps>
-        <post-migration>
+        <!-- Both steps use classes of this app, so they must not run in the process that
+             performed the update: that process still has the previous version's classes
+             loaded. A live migration runs as a background job, in a fresh process. -->
+        <live-migration>
             <step>OCA\TwoFactorEMail\Migration\RemovePersistedDefaultTemplate</step>
             <step>OCA\TwoFactorEMail\Migration\RepairEmailTexts</step>
-        </post-migration>
+        </live-migration>
     </repair-steps>
     <two-factor-providers>
         <provider>OCA\TwoFactorEMail\Provider\TwoFactorEMail</provider>

--- a/lib/Migration/RemovePersistedDefaultTemplate.php
+++ b/lib/Migration/RemovePersistedDefaultTemplate.php
@@ -12,6 +12,7 @@ namespace OCA\TwoFactorEMail\Migration;
 use OCA\TwoFactorEMail\Service\IAppSettings;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
+use Psr\Log\LoggerInterface;
 
 /**
  * In 3.1.x the admin UI showed the default email body as the field value and
@@ -23,6 +24,11 @@ use OCP\Migration\IRepairStep;
  * This step deletes the stored template if and only if it is byte-identical
  * to the 3.1 default text (which was never localized), so the current
  * default applies again. Real customizations are left untouched.
+ *
+ * Registered as a live migration, so it runs as a background job rather than inside
+ * the process that updated the app — that process still holds the classes of the
+ * previous version. Nothing listens to a background job's IOutput, so what was
+ * changed goes to the log as well.
  */
 final readonly class RemovePersistedDefaultTemplate implements IRepairStep {
 
@@ -35,6 +41,7 @@ final readonly class RemovePersistedDefaultTemplate implements IRepairStep {
 
 	public function __construct(
 		private IAppSettings $appSettings,
+		private LoggerInterface $logger,
 	) {
 	}
 
@@ -50,6 +57,8 @@ final readonly class RemovePersistedDefaultTemplate implements IRepairStep {
 		}
 		// Empty means: use the localized default (which contains {logo})
 		$this->appSettings->setEMailTemplate('');
-		$output->info('Removed the persisted 3.1 default email template; the current default (with {logo}) applies again.');
+		$message = 'Removed the persisted 3.1 default email template; the current default (with {logo}) applies again.';
+		$output->info($message);
+		$this->logger->info($message, ['app' => 'twofactor_email']);
 	}
 }

--- a/lib/Migration/RepairEmailTexts.php
+++ b/lib/Migration/RepairEmailTexts.php
@@ -16,6 +16,7 @@ use OCA\TwoFactorEMail\Service\SettingsValidator;
 use OCP\IAppConfig;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
+use Psr\Log\LoggerInterface;
 
 /**
  * Names the settings that do not do what their admin intended, and removes the one
@@ -33,11 +34,18 @@ use OCP\Migration\IRepairStep;
  * irrecoverably, and there is no backup key.
  *
  * Reads the raw values, since AppSettings already hides an unusable one.
+ *
+ * Registered as a live migration, so it runs as a background job rather than inside
+ * the process that updated the app — that process still holds the classes of the
+ * previous version. Nothing listens to a background job's IOutput, so every message
+ * goes to the log as well; that is where an admin finds it after an update nobody
+ * watched.
  */
 final readonly class RepairEmailTexts implements IRepairStep {
 
 	public function __construct(
 		private IAppConfig $appConfig,
+		private LoggerInterface $logger,
 	) {
 	}
 
@@ -58,6 +66,11 @@ final readonly class RepairEmailTexts implements IRepairStep {
 			AppSettings::DEFAULT_RESEND_MIN_MINUTES, SettingsValidator::MIN_RESEND_MINUTES, SettingsValidator::MAX_RESEND_MINUTES);
 	}
 
+	private function warn(IOutput $output, string $message): void {
+		$output->warning($message);
+		$this->logger->warning($message, ['app' => Application::APP_ID]);
+	}
+
 	/**
 	 * A value outside its range is corrected on every read, so the app works — but it
 	 * does not do what the admin wrote, and every reading of it shows the corrected
@@ -66,7 +79,7 @@ final readonly class RepairEmailTexts implements IRepairStep {
 	private function checkNumber(IOutput $output, string $key, string $name, int $default, int $min, int $max): void {
 		$stored = $this->appConfig->getValueInt(Application::APP_ID, $key, $default);
 		if ($stored < $min || $stored > $max) {
-			$output->warning(
+			$this->warn($output,
 				'The stored ' . $name . ' (' . $stored . ') is outside the allowed range of ' . $min . ' to '
 				. $max . '. The nearest allowed value is used instead. Set it with occ twofactor_email:settings.',
 			);
@@ -81,7 +94,7 @@ final readonly class RepairEmailTexts implements IRepairStep {
 
 		if (!mb_check_encoding($stored, 'UTF-8')) {
 			$this->appConfig->deleteKey(Application::APP_ID, $key);
-			$output->warning('The email ' . $part . ' was not valid text and has been reset to the default.');
+			$this->warn($output, 'The email ' . $part . ' was not valid text and has been reset to the default.');
 			return;
 		}
 
@@ -89,7 +102,7 @@ final readonly class RepairEmailTexts implements IRepairStep {
 		// messages ask for different repairs, and an admin who fixes one and hears
 		// about the next only at the following upgrade has been told half the story.
 		if ($needsCode && !str_contains($stored, '{code}')) {
-			$output->warning(
+			$this->warn($output,
 				'The email ' . $part . ' does not contain {code}. No mail delivers a code in the ' . $part . ', '
 				. 'and no settings can be saved until this is fixed. Edit it with occ twofactor_email:settings.',
 			);
@@ -98,21 +111,21 @@ final readonly class RepairEmailTexts implements IRepairStep {
 		// The same conditions SettingsValidator refuses, because each one blocks every
 		// settings change until it is fixed — and this output is where an admin looks.
 		if (mb_strlen($stored) > ($needsCode ? SettingsValidator::MAX_EMAIL_TEMPLATE_LENGTH : SettingsValidator::MAX_EMAIL_SUBJECT_LENGTH)) {
-			$output->warning(
+			$this->warn($output,
 				'The email ' . $part . ' is longer than allowed. No settings can be saved until this is '
 				. 'fixed. Edit it with occ twofactor_email:settings.',
 			);
 		}
 
 		if (!$needsCode && preg_match('/[\r\n]/', $stored) === 1) {
-			$output->warning(
+			$this->warn($output,
 				'The email ' . $part . ' contains a line break, which is not allowed in a mail header. '
 				. 'No settings can be saved until this is fixed. Edit it with occ twofactor_email:settings.',
 			);
 		}
 
 		if (LinkScanner::hasPlaceholderInUrl($stored)) {
-			$output->warning(
+			$this->warn($output,
 				'The email ' . $part . ' puts a placeholder inside a web address. Such a mail would carry the '
 				. 'code in a link, so the default text is sent instead. No settings can be saved in the '
 				. 'web interface until this is fixed. Edit it with occ twofactor_email:settings.',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "twofactor_email",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "twofactor_email",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "twofactor_email",
   "description": "Two-Factor Email Provider",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "type": "module",
   "author": {
     "name": "Christoph Wurst",

--- a/tests/Unit/Migration/RemovePersistedDefaultTemplateTest.php
+++ b/tests/Unit/Migration/RemovePersistedDefaultTemplateTest.php
@@ -15,6 +15,7 @@ use OCP\Migration\IOutput;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 final class RemovePersistedDefaultTemplateTest extends TestCase {
 	private const OLD_DEFAULT_TEMPLATE
@@ -24,6 +25,8 @@ final class RemovePersistedDefaultTemplateTest extends TestCase {
 		. 'or username – and your password!';
 
 	private IAppSettings&MockObject $appSettings;
+
+	private LoggerInterface&MockObject $logger;
 
 	private RemovePersistedDefaultTemplate $step;
 
@@ -35,15 +38,23 @@ final class RemovePersistedDefaultTemplateTest extends TestCase {
 
 		$this->appSettings = $this->createMock(IAppSettings::class);
 
-		$this->step = new RemovePersistedDefaultTemplate($this->appSettings);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$this->step = new RemovePersistedDefaultTemplate($this->appSettings, $this->logger);
 	}
 
 	/**
+	 * Nothing listens to the IOutput of a live migration, so the log is the only record
+	 * that the stored template was deleted.
+	 *
 	 * @throws Exception
 	 */
-	public function testRemovesThePersistedOldDefault(): void {
+	public function testRemovesThePersistedOldDefaultAndLogsIt(): void {
 		$this->appSettings->method('getEMailTemplate')->willReturn(self::OLD_DEFAULT_TEMPLATE);
 		$this->appSettings->expects($this->once())->method('setEMailTemplate')->with('');
+		$this->logger->expects($this->once())
+			->method('info')
+			->with($this->stringContains('Removed the persisted 3.1 default email template'), ['app' => 'twofactor_email']);
 
 		$this->step->run($this->createMock(IOutput::class));
 	}

--- a/tests/Unit/Migration/RepairEmailTextsTest.php
+++ b/tests/Unit/Migration/RepairEmailTextsTest.php
@@ -15,11 +15,14 @@ use OCP\Migration\IOutput;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 final class RepairEmailTextsTest extends TestCase {
 	private IAppConfig&MockObject $appConfig;
 
 	private IOutput&MockObject $output;
+
+	private LoggerInterface&MockObject $logger;
 
 	private RepairEmailTexts $step;
 
@@ -30,7 +33,8 @@ final class RepairEmailTextsTest extends TestCase {
 		parent::setUp();
 		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->output = $this->createMock(IOutput::class);
-		$this->step = new RepairEmailTexts($this->appConfig);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->step = new RepairEmailTexts($this->appConfig, $this->logger);
 	}
 
 	private function stored(string $subject, string $template): void {
@@ -48,6 +52,19 @@ final class RepairEmailTextsTest extends TestCase {
 			['twofactor_email', 'code_valid_minutes', 10, false, $validMinutes],
 			['twofactor_email', 'resend_min_minutes', 1, false, $resendMinutes],
 		]);
+	}
+
+	/**
+	 * Nothing listens to the IOutput of a live migration, so the log is where an admin
+	 * reads what was found — every message has to go there too.
+	 */
+	public function testLogsEveryMessageItReports(): void {
+		$this->logger->expects($this->once())
+			->method('warning')
+			->with($this->stringContains('does not contain {code}'), ['app' => 'twofactor_email']);
+
+		$this->stored('', 'No code here');
+		$this->step->run($this->output);
 	}
 
 	/** Corrected on every read, so this output is the only place it is visible. */

--- a/tests/Unit/Migration/RepairStepProcessTest.php
+++ b/tests/Unit/Migration/RepairStepProcessTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Test\Unit\Migration;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A schema migration and a pre- or post-migration repair step run inside the process
+ * that updated the app, and that process still has the previous version's classes
+ * loaded: the files on disk are new, the declared classes are not. Touching a class of
+ * this app from there therefore runs new code against an old class — which killed the
+ * update to 3.5.0 with "Cannot access private constant AppSettings::KEY_EMAIL_SUBJECT".
+ *
+ * A live migration is queued as a background job and runs in a fresh process, so it
+ * sees the new classes. This test holds the two rules that follow: a repair step that
+ * uses anything from this app is a live migration, and a schema migration — which has
+ * no such escape, MigrationService always runs it in that same process — uses nothing
+ * from this app at all.
+ */
+final class RepairStepProcessTest extends TestCase {
+	private const ROOT = __DIR__ . '/../../..';
+
+	/** The phases that run in the process that performed the update. */
+	private const STALE_PHASES = ['pre-migration', 'post-migration'];
+
+	public function testStepsUsingAppClassesAreLiveMigrations(): void {
+		// Read and parse in two steps: Nextcloud's bootstrap installs an entity loader
+		// that returns null, and libxml then refuses to load the document itself, so
+		// simplexml_load_file() fails under the app's own test suite.
+		$xml = file_get_contents(self::ROOT . '/appinfo/info.xml');
+		self::assertNotFalse($xml, 'appinfo/info.xml could not be read');
+
+		$info = simplexml_load_string($xml);
+		self::assertNotFalse($info, 'appinfo/info.xml could not be parsed');
+
+		$steps = $info->{'repair-steps'};
+		self::assertNotEmpty($steps, 'no repair steps found — has the element been renamed?');
+
+		foreach ($steps->children() as $phase => $phaseSteps) {
+			// An install or uninstall step is not affected: an install has no previous
+			// version, and an uninstall cannot be a background job, because the app is
+			// gone before the job would run.
+			if (!in_array($phase, self::STALE_PHASES, true)) {
+				continue;
+			}
+			foreach ($phaseSteps->step as $step) {
+				$class = (string)$step;
+				self::assertSame(
+					[],
+					$this->appClassesUsedBy($this->sourceOf($class)),
+					$class . ' uses classes of this app, so it must be a live migration and not run in the '
+					. 'process that updated the app, which still holds the previous version of those classes.',
+				);
+			}
+		}
+	}
+
+	public function testSchemaMigrationsUseNoAppClasses(): void {
+		$files = glob(self::ROOT . '/lib/Migration/Version*.php');
+		self::assertNotFalse($files);
+
+		foreach ($files as $file) {
+			$source = file_get_contents($file);
+			self::assertNotFalse($source);
+			self::assertSame(
+				[],
+				$this->appClassesUsedBy($source),
+				basename($file) . ' uses classes of this app. A schema migration always runs in the process '
+				. 'that performed the update, where those classes are still the previous version — spell the '
+				. 'values out instead.',
+			);
+		}
+	}
+
+	private function sourceOf(string $class): string {
+		$file = self::ROOT . '/lib' . str_replace(['OCA\\TwoFactorEMail', '\\'], ['', '/'], $class) . '.php';
+		self::assertFileExists($file, $class . ' is registered as a repair step but has no source file');
+
+		$source = file_get_contents($file);
+		self::assertNotFalse($source);
+
+		return $source;
+	}
+
+	/** The source without comments and string contents, so only real code is read. */
+	private function codeOnly(string $source): string {
+		$ignored = [T_COMMENT, T_DOC_COMMENT, T_CONSTANT_ENCAPSED_STRING, T_ENCAPSED_AND_WHITESPACE, T_INLINE_HTML];
+
+		$code = '';
+		foreach (token_get_all($source) as $token) {
+			$code .= is_array($token) ? (in_array($token[0], $ignored, true) ? '' : $token[1]) : $token;
+		}
+
+		return $code;
+	}
+
+	/**
+	 * The classes of this app that the given source names. Imports are read as written;
+	 * a name that is neither imported nor written with a leading backslash resolves to
+	 * the file's own namespace, which is this app — so a sibling used without an import
+	 * is found as well.
+	 *
+	 * @return list<string>
+	 */
+	private function appClassesUsedBy(string $source): array {
+		$source = $this->codeOnly($source);
+		$namespace = preg_match('~^namespace\s+([^;]+);~m', $source, $match) === 1 ? $match[1] . '\\' : '';
+
+		preg_match_all('~^use\s+([^\s;]+)(?:\s+as\s+(\w+))?;~m', $source, $imports, PREG_SET_ORDER);
+		$imported = [];
+		foreach ($imports as $import) {
+			$imported[$import[2] ?? substr(strrchr('\\' . $import[1], '\\'), 1)] = $import[1];
+		}
+
+		// Every way a class is named in a body: static access, instantiation, a type in
+		// front of a variable, an instanceof test. A leading backslash means the global
+		// namespace and is not ours.
+		preg_match_all(
+			'~(?<!\\\\)\b(?:new\s+|instanceof\s+)?([A-Z]\w*)(?=::|\s*\(|\s+\$|\s*;)~',
+			$source,
+			$used,
+		);
+
+		$found = [];
+		foreach (array_unique($used[1]) as $name) {
+			if (in_array($name, ['self', 'static', 'parent'], true)) {
+				continue;
+			}
+			$resolved = $imported[$name] ?? $namespace . $name;
+			if (str_starts_with($resolved, 'OCA\\TwoFactorEMail\\')) {
+				$found[] = $resolved;
+			}
+		}
+		sort($found);
+
+		return $found;
+	}
+}


### PR DESCRIPTION
Updating from 3.4.x to 3.5.0 aborts:

```
Error: Cannot access private constant OCA\TwoFactorEMail\Service\AppSettings::KEY_EMAIL_SUBJECT
in .../apps/twofactor_email/lib/Migration/RepairEmailTexts.php:51
```

### Why

`occ app:update` replaces the app's files **inside a running process** that has already
loaded the previous version's classes. Nextcloud builds every command listed in
`<commands>` from the DI container at startup, and `Command\Settings` injects
`IAppSettings` — so `AppSettings` and `SettingsValidator` are declared before the update
begins. On a 3.4.2 instance, `occ status` alone declares `Application`, all three
commands, `AppSettings`, `CodeStorage` and `SettingsValidator`.

`AppManager::upgradeApp()` then runs the **new** `RepairEmailTexts` as a post-migration
step against the **old** `AppSettings`, whose `KEY_EMAIL_SUBJECT` was still private. It
became public in 3.5.0.

opcache is not involved: a CLI process starts with an empty cache, so a fresh `occ` run
always compiles the current files. That is also why the update completes on the next
request — only the `occ app:update` run itself fails.

### What changes

`AppManager::upgradeApp()` runs pre- and post-migration steps inline, but queues
`live-migration` steps as `BackgroundRepair` jobs that run later in a fresh process.
Both repair steps move there.

Nothing listens to a background job's `IOutput` — `occ app:update` attaches no listener
either, only `occ upgrade` and the web updater do — so both steps now write their
findings to the log as well. The checks on the stored email texts therefore run on the
next cron run after an update instead of during it.

`RepairStepProcessTest` holds the two rules that follow:

- A repair step that names a class of this app is a live migration. Install and
  uninstall steps are exempt: an install has no previous version, and an uninstall
  cannot become a background job, because the app is gone before it would run.
- A schema migration has no such escape — `MigrationService` always runs it in the
  process that performed the update — so it names nothing from this app at all.

Both checks read the source without comments and strings and resolve every unqualified
name against the file's own namespace, so a sibling used without an import is found too.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
