### PR TITLE
Run the repair step in a fresh process, not in the one that updated

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -70,9 +70,12 @@ at the bottom of "Personal Settings/Security").]]></description>
         <job>OCA\TwoFactorEMail\BackgroundJob\CleanUpExpiredCodes</job>
     </background-jobs>
     <repair-steps>
-        <post-migration>
+        <!-- The step uses classes of this app, so it must not run in the process that
+             performed the update: that process still has the previous version's classes
+             loaded. A live migration runs as a background job, in a fresh process. -->
+        <live-migration>
             <step>OCA\TwoFactorEMail\Migration\RemovePersistedDefaultTemplate</step>
-        </post-migration>
+        </live-migration>
     </repair-steps>
     <two-factor-providers>
         <provider>OCA\TwoFactorEMail\Provider\TwoFactorEMail</provider>

--- a/lib/Migration/RemovePersistedDefaultTemplate.php
+++ b/lib/Migration/RemovePersistedDefaultTemplate.php
@@ -9,9 +9,11 @@ declare(strict_types=1);
 
 namespace OCA\TwoFactorEMail\Migration;
 
+use OCA\TwoFactorEMail\AppInfo\Application;
 use OCA\TwoFactorEMail\Service\IAppSettings;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
+use Psr\Log\LoggerInterface;
 
 /**
  * In 3.1.x the admin UI showed the default email body as the field value and
@@ -23,6 +25,11 @@ use OCP\Migration\IRepairStep;
  * This step deletes the stored template if and only if it is byte-identical
  * to the 3.1 default text (which was never localized), so the current
  * default applies again. Real customizations are left untouched.
+ *
+ * Registered as a live migration, so it runs as a background job rather than inside
+ * the process that updated the app — that process still holds the classes of the
+ * previous version. Nothing listens to a background job's IOutput, so what was
+ * changed goes to the log as well.
  */
 final class RemovePersistedDefaultTemplate implements IRepairStep {
 
@@ -35,6 +42,7 @@ final class RemovePersistedDefaultTemplate implements IRepairStep {
 
 	public function __construct(
 		private readonly IAppSettings $appSettings,
+		private readonly LoggerInterface $logger,
 	) {
 	}
 
@@ -48,6 +56,8 @@ final class RemovePersistedDefaultTemplate implements IRepairStep {
 		}
 		// Empty means: use the localized default (which contains {logo})
 		$this->appSettings->setEMailTemplate('');
-		$output->info('Removed the persisted 3.1 default email template; the current default (with {logo}) applies again.');
+		$message = 'Removed the persisted 3.1 default email template; the current default (with {logo}) applies again.';
+		$output->info($message);
+		$this->logger->info($message, ['app' => Application::APP_ID]);
 	}
 }

--- a/tests/Unit/Migration/RemovePersistedDefaultTemplateTest.php
+++ b/tests/Unit/Migration/RemovePersistedDefaultTemplateTest.php
@@ -15,6 +15,7 @@ use OCP\Migration\IOutput;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 class RemovePersistedDefaultTemplateTest extends TestCase {
 	private const OLD_DEFAULT_TEMPLATE
@@ -24,6 +25,8 @@ class RemovePersistedDefaultTemplateTest extends TestCase {
 		. 'or username – and your password!';
 
 	private IAppSettings&MockObject $appSettings;
+
+	private LoggerInterface&MockObject $logger;
 
 	private RemovePersistedDefaultTemplate $step;
 
@@ -35,15 +38,20 @@ class RemovePersistedDefaultTemplateTest extends TestCase {
 
 		$this->appSettings = $this->createMock(IAppSettings::class);
 
-		$this->step = new RemovePersistedDefaultTemplate($this->appSettings);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$this->step = new RemovePersistedDefaultTemplate($this->appSettings, $this->logger);
 	}
 
 	/**
 	 * @throws Exception
 	 */
-	public function testRemovesThePersistedOldDefault(): void {
+	public function testRemovesThePersistedOldDefaultAndLogsIt(): void {
 		$this->appSettings->method('getEMailTemplate')->willReturn(self::OLD_DEFAULT_TEMPLATE);
 		$this->appSettings->expects($this->once())->method('setEMailTemplate')->with('');
+		$this->logger->expects($this->once())
+			->method('info')
+			->with($this->stringContains('Removed the persisted 3.1 default email template'), ['app' => 'twofactor_email']);
 
 		$this->step->run($this->createMock(IOutput::class));
 	}

--- a/tests/Unit/Migration/RepairStepProcessTest.php
+++ b/tests/Unit/Migration/RepairStepProcessTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Olav and Niklas Seyfarth, Contributors <https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorEMail\Test\Unit\Migration;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A schema migration and a pre- or post-migration repair step run inside the process
+ * that updated the app, and that process still has the previous version's classes
+ * loaded: the files on disk are new, the declared classes are not. Touching a class of
+ * this app from there therefore runs new code against an old class — which killed the
+ * update to 3.5.0 with "Cannot access private constant AppSettings::KEY_EMAIL_SUBJECT".
+ *
+ * A live migration is queued as a background job and runs in a fresh process, so it
+ * sees the new classes. This test holds the two rules that follow: a repair step that
+ * uses anything from this app is a live migration, and a schema migration — which has
+ * no such escape, MigrationService always runs it in that same process — uses nothing
+ * from this app at all.
+ */
+final class RepairStepProcessTest extends TestCase {
+	private const ROOT = __DIR__ . '/../../..';
+
+	/** The phases that run in the process that performed the update. */
+	private const STALE_PHASES = ['pre-migration', 'post-migration'];
+
+	public function testStepsUsingAppClassesAreLiveMigrations(): void {
+		// Read and parse in two steps: Nextcloud's bootstrap installs an entity loader
+		// that returns null, and libxml then refuses to load the document itself, so
+		// simplexml_load_file() fails under the app's own test suite.
+		$xml = file_get_contents(self::ROOT . '/appinfo/info.xml');
+		self::assertNotFalse($xml, 'appinfo/info.xml could not be read');
+
+		$info = simplexml_load_string($xml);
+		self::assertNotFalse($info, 'appinfo/info.xml could not be parsed');
+
+		$steps = $info->{'repair-steps'};
+		self::assertNotEmpty($steps, 'no repair steps found — has the element been renamed?');
+
+		foreach ($steps->children() as $phase => $phaseSteps) {
+			// An install or uninstall step is not affected: an install has no previous
+			// version, and an uninstall cannot be a background job, because the app is
+			// gone before the job would run.
+			if (!in_array($phase, self::STALE_PHASES, true)) {
+				continue;
+			}
+			foreach ($phaseSteps->step as $step) {
+				$class = (string)$step;
+				self::assertSame(
+					[],
+					$this->appClassesUsedBy($this->sourceOf($class)),
+					$class . ' uses classes of this app, so it must be a live migration and not run in the '
+					. 'process that updated the app, which still holds the previous version of those classes.',
+				);
+			}
+		}
+	}
+
+	public function testSchemaMigrationsUseNoAppClasses(): void {
+		$files = glob(self::ROOT . '/lib/Migration/Version*.php');
+		self::assertNotFalse($files);
+
+		foreach ($files as $file) {
+			$source = file_get_contents($file);
+			self::assertNotFalse($source);
+			self::assertSame(
+				[],
+				$this->appClassesUsedBy($source),
+				basename($file) . ' uses classes of this app. A schema migration always runs in the process '
+				. 'that performed the update, where those classes are still the previous version — spell the '
+				. 'values out instead.',
+			);
+		}
+	}
+
+	private function sourceOf(string $class): string {
+		$file = self::ROOT . '/lib' . str_replace(['OCA\\TwoFactorEMail', '\\'], ['', '/'], $class) . '.php';
+		self::assertFileExists($file, $class . ' is registered as a repair step but has no source file');
+
+		$source = file_get_contents($file);
+		self::assertNotFalse($source);
+
+		return $source;
+	}
+
+	/** The source without comments and string contents, so only real code is read. */
+	private function codeOnly(string $source): string {
+		$ignored = [T_COMMENT, T_DOC_COMMENT, T_CONSTANT_ENCAPSED_STRING, T_ENCAPSED_AND_WHITESPACE, T_INLINE_HTML];
+
+		$code = '';
+		foreach (token_get_all($source) as $token) {
+			$code .= is_array($token) ? (in_array($token[0], $ignored, true) ? '' : $token[1]) : $token;
+		}
+
+		return $code;
+	}
+
+	/**
+	 * The classes of this app that the given source names. Imports are read as written;
+	 * a name that is neither imported nor written with a leading backslash resolves to
+	 * the file's own namespace, which is this app — so a sibling used without an import
+	 * is found as well.
+	 *
+	 * @return list<string>
+	 */
+	private function appClassesUsedBy(string $source): array {
+		$source = $this->codeOnly($source);
+		$namespace = preg_match('~^namespace\s+([^;]+);~m', $source, $match) === 1 ? $match[1] . '\\' : '';
+
+		preg_match_all('~^use\s+([^\s;]+)(?:\s+as\s+(\w+))?;~m', $source, $imports, PREG_SET_ORDER);
+		$imported = [];
+		foreach ($imports as $import) {
+			$imported[$import[2] ?? substr(strrchr('\\' . $import[1], '\\'), 1)] = $import[1];
+		}
+
+		// Every way a class is named in a body: static access, instantiation, a type in
+		// front of a variable, an instanceof test. A leading backslash means the global
+		// namespace and is not ours.
+		preg_match_all(
+			'~(?<!\\\\)\b(?:new\s+|instanceof\s+)?([A-Z]\w*)(?=::|\s*\(|\s+\$|\s*;)~',
+			$source,
+			$used,
+		);
+
+		$found = [];
+		foreach (array_unique($used[1]) as $name) {
+			if (in_array($name, ['self', 'static', 'parent'], true)) {
+				continue;
+			}
+			$resolved = $imported[$name] ?? $namespace . $name;
+			if (str_starts_with($resolved, 'OCA\\TwoFactorEMail\\')) {
+				$found[] = $resolved;
+			}
+		}
+		sort($found);
+
+		return $found;
+	}
+}


### PR DESCRIPTION
The sister change to #259 on this line. **Nothing is broken here today** — this closes
the same trap before it opens, and adds the test that keeps it closed.

### Why

`occ app:update` replaces the app's files **inside a running process** that has already
loaded the previous version's classes. Nextcloud builds every command listed in
`<commands>` from the DI container at startup, and `Command\Settings` injects
`IAppSettings` — so `AppSettings` and `SettingsValidator` are declared before the update
begins. `AppManager::upgradeApp()` then runs the **new** post-migration step against
those **old** classes.

On the 3.5 line that was fatal: the step read `AppSettings::KEY_EMAIL_SUBJECT`, which
had been private in the version it replaced, and every update from 3.4.x to 3.5.0
aborted. Here `RemovePersistedDefaultTemplate` survives only because it calls
`IAppSettings` methods whose signatures have not changed — the trap opens the moment a
release on this line touches those classes.

### What changes

`AppManager::upgradeApp()` queues `live-migration` steps as `BackgroundRepair` jobs that
run later in a fresh process. The step moves there.

Nothing listens to a background job's `IOutput` — `occ app:update` attaches no listener
either, only `occ upgrade` and the web updater do — so the step now writes to the log
what it changed. It therefore runs on the next cron run after an update instead of
during it.

`RepairStepProcessTest` holds the two rules that follow:

- A repair step that names a class of this app is a live migration. Install and
  uninstall steps are exempt: an install has no previous version, and an uninstall
  cannot become a background job, because the app is gone before it would run.
- A schema migration has no such escape — `MigrationService` always runs it in the
  process that performed the update — so it names nothing from this app at all.

Both checks read the source without comments and strings and resolve every unqualified
name against the file's own namespace, so a sibling used without an import is found too.

No version bump and no changelog entry: this line gets no release of its own for it. The
entry belongs to whichever release next goes out from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
