### PR TITLE
Say the 3.5.1 change in the words of the people who read it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 3.5.1 (2026-09-05)
 
-### Changed
-
-- The checks on the stored email texts run on the next cron run after an update, and report to the log
-
 ### Fixed
 
-- The update to 3.5.0 aborted with a fatal error: a repair step ran against the classes of the version it replaced
+- Updating the app to 3.5.0 stopped with an error message
 
 ## 3.5.0 (2026-09-05)
 


### PR DESCRIPTION
The changelog is read by administrators, not by the people who wrote the code. The 3.5.1
entry named a repair step, the process it runs in and the classes it loads — none of
which is their concern. What happened to them is that the update stopped.

The second line is dropped rather than reworded: when the email texts are checked is not
a change anybody can observe. `occ app:update` never printed those warnings, and an
administrator still meets the same refusal when saving the settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
