### PR TITLE
Carry the landing-page rewrite into the 3.3 line

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,9 +46,9 @@ This app uses Transifex. If it's not yet available in your language, join the
 
 ## Security issues
 
-Please don't report security vulnerabilities as public issues if they could
-affect many users — see [SECURITY.md](SECURITY.md) for how to report them
-responsibly.
+[SECURITY.md](SECURITY.md) says when a vulnerability may be reported as a
+public issue and when it should reach the maintainers privately. Please
+follow it rather than guessing.
 
 ## Questions
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -37,9 +37,9 @@
 
 ### AI usage to enhance code
 
-* Contributors may use AI to refactor or verify code snippets. This led to more robust code!
+* Contributors may use AI to refactor or verify code snippets, which made the code more robust.
 * All code proposed by an AI is thoroughly manually verified and adjusted by the maintainers.
-* Major AI contributions are commented in the source code near the AI enhanced code parts.
+* Major AI contributions are commented in the source code next to the AI-enhanced parts.
 * Many thanks to Anthropic, whose Claude Code does most of that work today, and to
   DuckDuckGo and OpenAI for duck.ai with GPT-5 mini.
 

--- a/README.md
+++ b/README.md
@@ -1,59 +1,50 @@
 # Two-Factor Email Provider for Nextcloud
 
-[Nextcloud](https://nextcloud.com/) supports web logins with a second factor
+[Nextcloud](https://nextcloud.com/) can ask for a second factor after the password
 ([two-factor authentication](https://en.wikipedia.org/wiki/Multi-factor_authentication#Factors),
-2FA). To support a certain type of 2FA, a "2FA provider" (server-)app must be
-installed. 2FA kicks in after the primary authentication stage (typically
-username and password) were successful. This provider challenges the user to
-enter a randomly generated authentication code (aka one-time password, OTP,
-currently six digits). It sends that code to the user's primary email address
-and expects the user to enter it on an additional second step web login page.
+2FA). Each kind of second factor comes from a provider app that a server admin
+installs. This one emails a one-time code (OTP) — six digits by default — and asks for
+it on a second login page.
 
-## Installation, activation and usage
+## Installation and setup
 
-As with any 2FA provider, two-factor email must be installed from the
-[Nextcloud app store](https://apps.nextcloud.com/apps/twofactor_email) and
-enabled by a Nextcloud server admin. Additionally, the Nextcloud must have a
-working email server configured.
+An admin installs **Two-Factor Email** from the
+[Nextcloud app store](https://apps.nextcloud.com/apps/twofactor_email) and enables it.
+The server needs a working mail setup — the code travels by email.
 
-The user may set up any of the installed providers or even multiple. This
-provider uses email to send the code and thus can only be enabled if an email
-address is set in 'Personal info'. Mind that a user may not be able to log in
-if that email address is invalid (or email server setup of the Nextcloud is
-not working properly).
+A user then switches it on under *Personal settings › Security*, which needs an email
+address in *Personal info*: that is where the code goes. If the address is wrong, or
+the server cannot send mail, the user cannot log in. An admin can switch it on for
+someone instead, from the console: `occ twofactorauth:enable <uid> email`.
 
-Admins with console access may enable and disable this provider for specified
-users via OCC command. Admins may also enforce 2FA for all users (or specific
-groups) via Admin Settings. This is a Nextcloud feature and not specific to
-this provider. If enforced, users with no 2FA are prompted to enable any
-installed provider (that supports AtLogin setup – this provider supports it
-since v3). If the admin installs this provider and enforces 2FA, it should be
-ensured that each user does have a valid email address.
+Nextcloud can also enforce a second factor for everyone or per group, though never one
+particular method. Email is a low-friction choice there: the user confirms one code and
+is done, with no device to enrol. Check first that every account has a working address —
+a user whose address does not work cannot log in.
 
-Mind that, once a user enabled any 2FA provider, they can no longer use their
-password in applications that don't support the web-based 2FA login flow. For
-such applications, the user needs to create and use
-[app passwords](https://docs.nextcloud.com/server/stable/user_manual/en/session_management.html#managing-devices)
-(to be found at the bottom of Personal Settings/Security).
+Any second factor stops desktop and mobile clients from signing in with the normal
+password. Each of them needs an
+[app password](https://docs.nextcloud.com/server/stable/user_manual/en/session_management.html#managing-devices)
+instead, created under *Personal settings › Security*.
 
-## State of the app
+## Versions
 
-This version 3.x.x ("v3") is the successor of the
-deprecated [twofactor_email](https://github.com/nursoda/twofactor_email/)
-app 2.x.x ("v2"). v2 will remain in the [Nextcloud App Store](https://apps.nextcloud.com/apps/twofactor_email) alongside
-v3 as
-long as upcoming security issues may be fixed with reasonable effort. After
-that, or after all supported Nextcloud versions may use v3, it will be pulled
-from the App Store. v3 is based on [twofactor_totp](https://github.com/nextcloud/twofactor_totp/) but has been
-refactored.
-v2 is installable on NC ≤33, v3 on NC ≥32.
+Every Nextcloud version that Nextcloud itself still supports is served by a line of
+this app that gets security fixes. An older Nextcloud keeps the last line that ran on
+it, for as long as maintaining it stays reasonable — that is an offer, not a promise.
+New features go first into the line built for the newest released Nextcloud, which is
+**not** this one; an older 3.x line gets them where that is easy.
 
-The code is stable now. There are plans for further enhancements. See open tasks in the
-[roadmap](https://github.com/datenschutz-individuell/twofactor_email/issues/7). It keeps the status of whether this
-provider is enabled for a specific
-user or not when migrating from v2 to v3. However, from 3.1.1 onwards, v2 codes are no
-longer migrated to v3 since most of them were obsolete. Mind that the look and some
-behaviour changed or was enhanced.
+| Line | Use it on | Security fixes | New features |
+|---|---|---|---|
+| 3.5 | Nextcloud 33–35 | yes | yes |
+| **3.3** (this branch) | Nextcloud 32 | while reasonable | best effort |
+| [2.8](https://github.com/nursoda/twofactor_email/) | Nextcloud 30–31 | while reasonable | no |
+
+Version 3 is a refactored successor of version 2 and started out from
+[twofactor_totp](https://github.com/nextcloud/twofactor_totp/). An upgrade from 2 to 3
+keeps the provider switched on for each user; stored codes are not carried over, as
+they expire within minutes anyway.
 
 ## Contributions welcome
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,24 +2,29 @@
 
 ## Supported Versions
 
-We only support the latest released version of the app for any Nextcloud version that still has official (not extended)
-support.
+**What we promise:** every Nextcloud version that Nextcloud itself still supports is
+served by a line of this app that gets security fixes. Today that is the **3.5** line,
+for Nextcloud 33 to 35.
+
+**What we offer beyond it:** an older Nextcloud keeps the last line that ran on it —
+**3.3** for Nextcloud 32, version **2.8** below that — for as long as fixing it stays
+reasonable. We judge that per case, and nothing here commits us to it.
+
+Within a line only its latest release is fixed, so update to that one before reporting.
 
 ## Reporting a Vulnerability
 
-You may create an issue in GitHub to report security vulnerabilities unless you think that it is not easily fixable and
-would affect many users. In this case, please email Olav directly using olav at seyfarth dot de. Olav's OpenPGP key
+Report a vulnerability as a GitHub issue unless **both** of these apply: you see no easy fix, and many users would be
+affected. In that case email Olav directly at olav at seyfarth dot de. Olav's OpenPGP key
 0x6AE1EF56 is available on [the website](https://seyfarth.de/gnupg/6AE1EF56.asc) as well as on the
 [OpenPGP keyserver](https://keys.openpgp.org/search?q=olav%40seyfarth.de).
 
-We will timely review your report and fix it if we know how and if it's not an upstream issue. Please provide contact
-details so that we may get in touch with you. Once we publish the fixed code, we would like to pay credits to you. So
-please also include details on how we shall mention you.
+We review reports promptly and fix what we can, unless the cause is upstream. Please give us contact details so we can
+reach you. When the fix is published we would like to credit you, so tell us how you want to be named.
 See [CONTRIBUTORS](https://github.com/datenschutz-individuell/twofactor_email/blob/main/CONTRIBUTORS.md) for examples.
 
 ## Bounty
 
 We cannot provide any bounty for reporting. But if you feel that it would affect many users or Nextcloud as a platform,
 you may use their channel to report it, see the [security](https://nextcloud.com/security/) on the Nextcloud website. They used to use Hacker One
-as a reporting platform and provide a bounty if the report met their criteria. Due to too many AI generated reports,
-they abandoned it.
+as a reporting platform and provide a bounty if the report met their criteria. They abandoned it after too many AI-generated reports.

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,40 +8,31 @@
     <id>twofactor_email</id>
     <name>Two-Factor email provider</name>
     <summary>Email two-factor provider</summary>
-    <description><![CDATA[### A Two-Factor-Auth Provider using email
+    <description><![CDATA[### A two-factor provider using email
 
-Nextcloud supports web logins with a second factor (two-factor authentication,
-2FA). To support a certain type of 2FA, a "2FA provider" server app must be
-installed. 2FA kicks in after the primary authentication stage (typically
-username and password) were successful. This provider challenges the user to
-enter a randomly generated authentication code (aka one-time password, OTP,
-default: six digits). It sends that code to the user's primary email address
-and expects the user to enter it on an additional second step web login page.
+Nextcloud can ask for a second factor after the password (two-factor
+authentication, 2FA). Each kind of second factor comes from a provider app
+that a server admin installs. This one emails a one-time code (OTP) - six
+digits by default - and asks for it on a second login page.
 
-### Installation, activation and usage
+### Installation and setup
 
-As with any 2FA provider, two-factor email must be installed and enabled by a
-Nextcloud server admin. Additionally, the Nextcloud must have a working email
-server configured.
+An admin installs and enables this app. The server needs a working mail
+setup, because the code travels by email.
 
-The user may set up any of the installed providers or even multiple. This
-provider uses email to send the code and thus can only be enabled if an email
-address is set in "Personal info". Mind that a user may not be able to log in
-if that email address is invalid (or email server setup of the Nextcloud is
-not working properly).
+A user then switches it on under "Personal settings / Security", which needs
+an email address in "Personal info". An admin can switch it on for someone
+instead: "occ twofactorauth:enable USERID email".
 
-Admins with console access may enable and disable this provider for specified
-users via "occ" command. Admins may also enforce 2FA for all users (or specific
-groups) via "Admin Settings". This is a Nextcloud feature and not specific to
-this provider. If enforced, users with no 2FA are prompted to enable any
-installed provider (if they support that feature). This provider supports it
-since v3. If the admin installs this provider and enforces 2FA, it should be
-ensured that each user does have a valid email address.
+Nextcloud can also enforce a second factor for everyone or per group, though
+never one particular method. Email is a low-friction choice there: the user
+confirms one code and is done, with no device to enrol. Check first that
+every account has a working address - a user whose address does not work
+cannot log in.
 
-Mind that, once a user enabled any 2FA provider, they can no longer use their
-password in applications that don't support the web-based 2FA login flow. For
-such applications, the user needs to create and use app passwords (to be found
-at the bottom of "Personal Settings/Security").]]></description>
+Any second factor stops desktop and mobile clients from signing in with the
+normal password. Each of them needs an app password instead, created under
+"Personal settings / Security".]]></description>
     <version>3.3.3</version>
     <licence>agpl</licence>
     <author mail="twofactor-email@datenschutz-individuell.de">


### PR DESCRIPTION
Pulls the root-file half of #265 into the 3.3 line, as `release/3.3` is fully maintained — documentation included.

**What came across:** the shortened landing page, the version table that replaces "State of the app", the support policy in `SECURITY.md`, the reporting rule in `CONTRIBUTING.md`, the wording in `CONTRIBUTORS.md`, and the `<description>` in `appinfo/info.xml` — the app store's landing page, which is a twin of the README text and had drifted from it.

**What is deliberately different here**, because this branch is not `main`:

- **There is no `doc/` directory on this line.** The README cannot link guides that do not exist, so its installation section keeps the detail that `main` hands off to `doc/users.md` and `doc/admins.md`. None of #265's `doc/` fixes apply.
- **The version table marks this branch** and says outright that new features go to the 3.5 line. Someone who lands here should learn that at a glance rather than by comparing branches.
- **Nextcloud 32 is what this line exists for**, so the table points 32 here and 33–35 at 3.5.

`reuse lint` clean, `info.xml` well-formed. Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.