### PR TITLE
Name the app the way the app list reads it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- The app is named "Two-Factor Email", like the other two-factor providers in the app list
+
 ## 3.5.1 (2026-09-05)
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -6,8 +6,8 @@
 <info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
     <id>twofactor_email</id>
-    <name>Two-Factor email provider</name>
-    <summary>Email two-factor provider</summary>
+    <name>Two-Factor Email</name>
+    <summary>A login code sent to the user's email address</summary>
     <description><![CDATA[### A two-factor provider using email
 
 Nextcloud can ask for a second factor after the password (two-factor

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -6,7 +6,7 @@
 <template>
 	<div id="twofactor_email-admin_settings">
 		<NcSettingsSection
-			:name="t('twofactor_email', 'Two-Factor email provider')"
+			:name="t('twofactor_email', 'Two-Factor Email')"
 			:description="t('twofactor_email', 'These system wide settings are saved automatically shortly after the last keypress.')">
 			<!-- Group: authentication code -->
 			<fieldset class="settings-group">


### PR DESCRIPTION
Among the two-factor providers a server admin sees under Apps, four read
"Two-Factor \<method\>" and this one read "Two-Factor email provider" — the odd one
out, and the only one that spends a word on being a provider, which every app in
that list is. The summary said the name a second time; it now says what the app
does.

The name reaches three places, and only one of them is instant.

- The **installed apps list** reads the local `appinfo/info.xml` verbatim, so it
  changes with the update.
- The **app store** overwrites an app's name, summary, description and screenshots
  only when the uploaded release is stable and the newest one it holds
  (`AppImporter._should_update_everything`). The store page therefore keeps the old
  name until the next release from this line; a release on the 3.3 line will not
  move it.
- **Translations** are read by neither. The server picks a translated name only from
  a `<name lang="...">` element in `info.xml`, of which there is none, and the store
  holds an English translation only — which the German store page proves by showing
  the English name today. So the German name in `l10n/` was never displayed anywhere.

The admin settings heading is the exception: it is a real translated string, and
renaming it drops the existing translations until Transifex has the new one.

The file still validates against the store schema, and the new summary stays inside
its 128-character limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
