### PR TITLE
Name the app the way the app list reads it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- The app is named "Two-Factor Email", like the other two-factor providers in the app list
+
 ## 3.3.3 (2026-09-05)
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -6,8 +6,8 @@
 <info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
     <id>twofactor_email</id>
-    <name>Two-Factor email provider</name>
-    <summary>Email two-factor provider</summary>
+    <name>Two-Factor Email</name>
+    <summary>A login code sent to the user's email address</summary>
     <description><![CDATA[### A two-factor provider using email
 
 Nextcloud can ask for a second factor after the password (two-factor

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -6,7 +6,7 @@
 <template>
 	<div id="twofactor_email-admin_settings">
 		<NcSettingsSection
-			:name="t('twofactor_email', 'Two-Factor email provider')"
+			:name="t('twofactor_email', 'Two-Factor Email')"
 			:description="t('twofactor_email', 'These system wide settings are saved automatically shortly after the last keypress.')">
 			<!-- Group: authentication code -->
 			<fieldset class="settings-group">


### PR DESCRIPTION
Every change on main reaches this branch. The 3.5 line renamed the app because
"Two-Factor email provider" was the odd one out among the two-factor providers a
server admin sees under Apps, and because the summary only said the name a second
time. A Nextcloud 32 shows this line in that same list, so both changes belong
here.

What differs is the reach. The app store overwrites an app's name only from the
newest stable release it holds (`AppImporter._should_update_everything`), so
nothing this line uploads will move the store page: the new name arrives in the
installed apps list of a Nextcloud 32 and nowhere else. The admin settings heading
is a translated string here too, and reads English until Transifex has the new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
