### PR TITLE
Let the editor wrap the prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
@@ -134,8 +133,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- When updating the app from v2 to v3, authentication codes are no longer migrated, see
-  https://github.com/datenschutz-individuell/twofactor_email/issues/69#issuecomment-4588492017
+- When updating the app from v2 to v3, authentication codes are no longer migrated, see https://github.com/datenschutz-individuell/twofactor_email/issues/69#issuecomment-4588492017
 
 ## 3.1.0 (2026-05-31)
 
@@ -148,17 +146,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- First non-beta release of v3. Please note that there still are translations
-  missing and that there still are tasks that you may want to help out with,
-  see https://github.com/datenschutz-individuell/twofactor_email/issues/7
+- First non-beta release of v3. Please note that there still are translations missing and that there still are tasks that you may want to help out with, see https://github.com/datenschutz-individuell/twofactor_email/issues/7
 
 ## 3.0.9-beta.2 (2026-05-10)
 
 ### Added
 
 - Support for Nextcloud 34
-- New translations: de, de_DE, en_GB, et_EE, ga, lt_LT, pl, pt_BR, ru, sv, uz, zh_HK, zh_TW – a BIG "Thank you!" to all
-  translators on transifex!
+- New translations: de, de_DE, en_GB, et_EE, ga, lt_LT, pl, pt_BR, ru, sv, uz, zh_HK, zh_TW – a BIG "Thank you!" to all translators on transifex!
 
 ## 3.0.8-beta.1 (2026-04-22)
 
@@ -225,8 +220,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- twofactor_email versions 3.0.0-dev - 3.0.2-dev used their own database table.
-  This table is dropped. When updating from these dev versions, pending codes are lost.
+- twofactor_email versions 3.0.0-dev - 3.0.2-dev used their own database table. This table is dropped. When updating from these dev versions, pending codes are lost.
 
 ### Removed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,16 +1,10 @@
 # Working on this app
 
-Notes for AI agents. Facts and conventions only — the reasoning lives in
-[`doc/`](doc/), and this file should stay short enough that reading it is never a
-detour. [`REVIEW.md`](REVIEW.md) says what review pays attention to here and which
-questions are already settled.
+Notes for AI agents. Facts and conventions only — the reasoning lives in [`doc/`](doc/), and this file should stay short enough that reading it is never a detour. [`REVIEW.md`](REVIEW.md) says what review pays attention to here and which questions are already settled.
 
 ## What it is
 
-A two-factor provider for Nextcloud that mails a one-time code. It plugs into
-Nextcloud's two-factor framework and is built against the public `OCP` interfaces
-only. [`doc/architecture.md`](doc/architecture.md) explains how the pieces fit;
-[`doc/threat-model.md`](doc/threat-model.md) states what the app defends against.
+A two-factor provider for Nextcloud that mails a one-time code. It plugs into Nextcloud's two-factor framework and is built against the public `OCP` interfaces only. [`doc/architecture.md`](doc/architecture.md) explains how the pieces fit; [`doc/threat-model.md`](doc/threat-model.md) states what the app defends against.
 
 ## Supported versions
 
@@ -20,40 +14,18 @@ only. [`doc/architecture.md`](doc/architecture.md) explains how the pieces fit;
 | PHP | 8.2–8.5 |
 | Node | `^24 \|\| ^26` |
 
-**The CI's PHP range comes from `icewind1991/nextcloud-version-matrix`**, which reads
-both dependencies. Per supported server it narrows that server's PHP range with
-`<php min-version>`/`<max-version>` — the higher minimum, the lower maximum — and drops a
-server whose range no longer intersects. The workflows then read the `php-min` and
-`php-max` outputs, which are the minimum and maximum **over all** servers. So the CI
-floor is the higher of two numbers: the PHP minimum of the oldest supported server, and
-`<php min-version>`. Raising the latter does move the floor, but bluntly — it raises it
-for every server at once, and Nextcloud then refuses to install the app below that
-version at all. Up to v1.3.2 the action did not read `<php>` at all, so the floor came
-from the oldest server alone; since v1.3.3 the older servers stay in the matrix and are
-tested from the app's PHP version up. When you touch the range, change
-`info.xml` (both), `composer.json` (`require.php`, `config.platform.php`,
-`nextcloud/ocp`) and `psalm.xml` together, then check that CI agrees. Nextcloud 35
-requires PHP 8.3 **on the server**, which says nothing about the app's own floor: the
-app supports 33 to 35 at once because its code runs on 8.2.
+**The CI's PHP range comes from `icewind1991/nextcloud-version-matrix`**, which reads both dependencies. Per supported server it narrows that server's PHP range with `<php min-version>`/`<max-version>` — the higher minimum, the lower maximum — and drops a server whose range no longer intersects. The workflows then read the `php-min` and `php-max` outputs, which are the minimum and maximum **over all** servers. So the CI floor is the higher of two numbers: the PHP minimum of the oldest supported server, and `<php min-version>`. Raising the latter does move the floor, but bluntly — it raises it for every server at once, and Nextcloud then refuses to install the app below that version at all. Up to v1.3.2 the action did not read `<php>` at all, so the floor came from the oldest server alone; since v1.3.3 the older servers stay in the matrix and are tested from the app's PHP version up. When you touch the range, change `info.xml` (both), `composer.json` (`require.php`, `config.platform.php`, `nextcloud/ocp`) and `psalm.xml` together, then check that CI agrees. Nextcloud 35 requires PHP 8.3 **on the server**, which says nothing about the app's own floor: the app supports 33 to 35 at once because its code runs on 8.2.
 
-**`nextcloud/ocp` cannot follow `info.xml` past 34.** Its `v35` requires
-`~8.3 || ~8.4 || ~8.5`, and `config.platform.php` here is 8.2, so `^35` will not resolve
-for as long as the app supports PHP 8.2 — which is for as long as it supports Nextcloud
-33. That is not a problem: it is a development dependency, and psalm analyses against
-the *oldest* supported OCP anyway. The CI's `ocp max` job installs the newest branch
-separately.
+**`nextcloud/ocp` cannot follow `info.xml` past 34.** Its `v35` requires `~8.3 || ~8.4 || ~8.5`, and `config.platform.php` here is 8.2, so `^35` will not resolve for as long as the app supports PHP 8.2 — which is for as long as it supports Nextcloud
+33. That is not a problem: it is a development dependency, and psalm analyses against the *oldest* supported OCP anyway. The CI's `ocp max` job installs the newest branch separately.
 
 ## Layout
 
-- `lib/` — PHP, namespace `OCA\TwoFactorEMail`. Controllers use routing attributes
-  (`#[FrontpageRoute]`); there is no `appinfo/routes.php` any more.
+- `lib/` — PHP, namespace `OCA\TwoFactorEMail`. Controllers use routing attributes (`#[FrontpageRoute]`); there is no `appinfo/routes.php` any more.
 - `src/` — Vue 3 with Pinia, tested with Vitest.
-- `templates/` — four templates: the login challenge, the enrolment step shown during
-  login (`LoginSetup`, an `ILoginSetupProvider`), and the admin and personal settings.
+- `templates/` — four templates: the login challenge, the enrolment step shown during login (`LoginSetup`, an `ILoginSetupProvider`), and the admin and personal settings.
 - `tests/Unit/` — PHPUnit, mirrors `lib/`.
-- `tests/smoke/` — the app running in a disposable Nextcloud; use it for anything
-  touching routes, controllers or the challenge flow. See its
-  [README](tests/smoke/README.md).
+- `tests/smoke/` — the app running in a disposable Nextcloud; use it for anything touching routes, controllers or the challenge flow. See its [README](tests/smoke/README.md).
 
 ## Commands
 
@@ -66,105 +38,38 @@ npm run lint && npm run stylelint && npm test && npm run build
 krankerl package                  # release package
 ```
 
-Psalm **analyses** against the app's minimum PHP version — `phpVersion` in `psalm.xml`,
-and the CI checks that the two agree. That is independent of the interpreter it **runs**
-on: Psalm 6.16.1 runs fine on PHP 8.5, verified on 8.5.9 for both the normal and the
-taint pass. If a future version does cap the runtime, the error says so; do not reach
-for an older interpreter without one.
+Psalm **analyses** against the app's minimum PHP version — `phpVersion` in `psalm.xml`, and the CI checks that the two agree. That is independent of the interpreter it **runs** on: Psalm 6.16.1 runs fine on PHP 8.5, verified on 8.5.9 for both the normal and the taint pass. If a future version does cap the runtime, the error says so; do not reach for an older interpreter without one.
 
-Run the checks that match your diff **before** opening a pull request. CI is the gate,
-but finding it locally is cheaper for everyone.
+Run the checks that match your diff **before** opening a pull request. CI is the gate, but finding it locally is cheaper for everyone.
 
-**`composer outdated` in the root does not see `vendor-bin/*`.** The bamarni plugin
-gives those their own projects — use `composer bin all outdated`.
+**`composer outdated` in the root does not see `vendor-bin/*`.** The bamarni plugin gives those their own projects — use `composer bin all outdated`.
 
-**A root `composer install` also installs `vendor-bin/*`**, through a hook that exists
-so working in the repo takes one command instead of two. CI and the package build do
-not need the tooling and pass `--no-scripts`; the only job that keeps it is the one
-running `cs:check`. A new workflow that installs dependencies should pass
-`--no-scripts` too.
+**A root `composer install` also installs `vendor-bin/*`**, through a hook that exists so working in the repo takes one command instead of two. CI and the package build do not need the tooling and pass `--no-scripts`; the only job that keeps it is the one running `cs:check`. A new workflow that installs dependencies should pass `--no-scripts` too.
 
-**Query npm with `--all`.** `npm ls <package>` and friends traverse shallowly without
-it and silently miss deeper paths, which is how a dependency once looked dev-only when
-it was not. After an update, read the warnings and remove their cause rather than
-treating them as background noise, and re-check whether the existing pins and
-`overrides` still change anything — every one of them is debt.
+**Query npm with `--all`.** `npm ls <package>` and friends traverse shallowly without it and silently miss deeper paths, which is how a dependency once looked dev-only when it was not. After an update, read the warnings and remove their cause rather than treating them as background noise, and re-check whether the existing pins and `overrides` still change anything — every one of them is debt.
 
 ## Conventions
 
-- **Every new file needs licensing.** Either an SPDX header or an entry in
-  `REUSE.toml`; the `reuse` CI job fails otherwise. Root-level Markdown is licensed
-  through an **explicit filename entry** in `REUSE.toml` — only `doc/**` and `l10n/**`
-  are globbed, so a new root file has to be added there by hand.
-- **GitHub Actions are pinned to a commit SHA** with a version comment, and every
-  checkout sets `persist-credentials: false`. Follow the existing workflows.
-- **A `pull_request` trigger carries no branch filter.** A pull request based on
-  another pull request's branch is still a change that has to be tested, and it is the
-  one where a missing check goes unnoticed.
-- **A method that overrides or implements anything carries `#[\Override]`** — an
-  interface, an abstract class, a parent method, whether from OCP, Symfony or this app.
-  Psalm requires it (`ensureOverrideAttribute`) and names every method missing one. It
-  is what turns a method Nextcloud has renamed into an analysis error instead of code
-  that is quietly never called again.
-- **A version bump touches four places:** `appinfo/info.xml`, `package.json`, and
-  **both** version fields in `package-lock.json` — plus a `CHANGELOG.md` section with
-  the release date. Change the values in place; do not re-resolve the lock file during
-  a release.
-- **A repair step that names a class of this app is a `<live-migration>`.** Pre- and
-  post-migration steps run inside the process that updated the app, and that process
-  still holds the previous version's classes — `<commands>` alone makes Nextcloud load
-  `AppSettings` and `SettingsValidator` before the update starts. A live migration runs
-  as a background job in a fresh process. Nothing reads a background job's output, so
-  such a step logs what it found. A **schema migration** has no such escape —
-  `MigrationService` always runs it in that same process — so it names nothing from this
-  app at all and spells the values out. `RepairStepProcessTest` enforces both rules.
-- **Decide for every new file whether it belongs in the release package.**
-  `.nextcloudignore` keeps the package to runtime files; a new file at the root ships
-  unless it is listed there.
-- **Write texts for translation.** Comments, docblocks and user-facing strings in
-  plain, simple English — short sentences, no idioms, nothing that only makes sense in
-  German. Translators and non-native readers both benefit.
-- **Changelog entries are one terse line each**; the reasoning belongs in the commit
-  message, not in `CHANGELOG.md`.
-- **Parametrise a test only when setup *and* expected result are identical** across the
-  cases. Differing expectations, or a different mock mechanism per case, mean separate
-  tests — a parametrised test with a branch inside it hides what it checks.
-- **SOLID pragmatically, not dogmatically.** Single-purpose classes, no abstraction
-  introduced for a second implementation that does not exist yet. Maintainability first.
+- **Every new file needs licensing.** Either an SPDX header or an entry in `REUSE.toml`; the `reuse` CI job fails otherwise. Root-level Markdown is licensed through an **explicit filename entry** in `REUSE.toml` — only `doc/**` and `l10n/**` are globbed, so a new root file has to be added there by hand.
+- **GitHub Actions are pinned to a commit SHA** with a version comment, and every checkout sets `persist-credentials: false`. Follow the existing workflows.
+- **A `pull_request` trigger carries no branch filter.** A pull request based on another pull request's branch is still a change that has to be tested, and it is the one where a missing check goes unnoticed.
+- **A method that overrides or implements anything carries `#[\Override]`** — an interface, an abstract class, a parent method, whether from OCP, Symfony or this app. Psalm requires it (`ensureOverrideAttribute`) and names every method missing one. It is what turns a method Nextcloud has renamed into an analysis error instead of code that is quietly never called again.
+- **A version bump touches four places:** `appinfo/info.xml`, `package.json`, and **both** version fields in `package-lock.json` — plus a `CHANGELOG.md` section with the release date. Change the values in place; do not re-resolve the lock file during a release.
+- **A repair step that names a class of this app is a `<live-migration>`.** Pre- and post-migration steps run inside the process that updated the app, and that process still holds the previous version's classes — `<commands>` alone makes Nextcloud load `AppSettings` and `SettingsValidator` before the update starts. A live migration runs as a background job in a fresh process. Nothing reads a background job's output, so such a step logs what it found. A **schema migration** has no such escape — `MigrationService` always runs it in that same process — so it names nothing from this app at all and spells the values out. `RepairStepProcessTest` enforces both rules.
+- **Decide for every new file whether it belongs in the release package.** `.nextcloudignore` keeps the package to runtime files; a new file at the root ships unless it is listed there.
+- **Write texts for translation.** Comments, docblocks and user-facing strings in plain, simple English — short sentences, no idioms, nothing that only makes sense in German. Translators and non-native readers both benefit.
+- **Changelog entries are one terse line each**; the reasoning belongs in the commit message, not in `CHANGELOG.md`.
+- **Parametrise a test only when setup *and* expected result are identical** across the cases. Differing expectations, or a different mock mechanism per case, mean separate tests — a parametrised test with a branch inside it hides what it checks.
+- **SOLID pragmatically, not dogmatically.** Single-purpose classes, no abstraction introduced for a second implementation that does not exist yet. Maintainability first.
 - Do not reformat code you are not otherwise changing.
 
 ## Things that look wrong and are not
 
-- **`ChallengeController::resend()` carries both `#[NoTwoFactorRequired]` and a
-  `@NoTwoFactorRequired` docblock annotation.** Nextcloud 33 reads the exemption from
-  the docblock only; the attribute is `@since 34`. Removing either one breaks a
-  supported server. Nextcloud 35 still reads both, so this is never urgent —
-  `CompatibilityShimsTest` fails as soon as `min-version` reaches 34 and names the two
-  pieces that go together: the annotation and the `UndefinedAttributeClass` handler in
-  `psalm.xml`. **That test is the register of every such carve-out**, each with the
-  condition that ends it. A new workaround the app carries only because it spans
-  several server or PHP versions belongs there, so that dropping a version is a sweep
-  and not a search.
-- **`symfony/console` is held at `^6.4.42`.** Nextcloud bundles Symfony 6.4, and `occ`
-  commands must build against the same major.
-- **`allowScripts` in `package.json` lists `fsevents`, which is never installed here.**
-  It is darwin-only; the entry exists for macOS machines, where npm would otherwise
-  warn about its install script. `npm install-scripts prune` reports it as unused and
-  removes it on Linux — do not run that blindly, and note that
-  `npm install-scripts deny fsevents` cannot recreate it here (`ENOMATCH`).
-- **`@nextcloud/vite-config` is pinned to a pre-release.** Only that version allows
-  Vite 8; the stable line is still on Vite 7. **This one expires:** switch as soon as a
-  stable release supports Vite 8, and treat the pin as a finding from then on. Two
-  things ride along with it and were accepted deliberately. It pulls the `yuku-*`
-  parser family, young and single-maintainer, through `rolldown-plugin-dts` — dev-only,
-  no install script, and only `libConfig` ever imports the plugin, so an app built
-  through `createAppConfig` never loads it. And its chunk splitting is overridden in
-  `vite.config.js`, which keeps the login challenge off the settings bundle; that file
-  says when to compare the groups against upstream again.
+- **`ChallengeController::resend()` carries both `#[NoTwoFactorRequired]` and a `@NoTwoFactorRequired` docblock annotation.** Nextcloud 33 reads the exemption from the docblock only; the attribute is `@since 34`. Removing either one breaks a supported server. Nextcloud 35 still reads both, so this is never urgent — `CompatibilityShimsTest` fails as soon as `min-version` reaches 34 and names the two pieces that go together: the annotation and the `UndefinedAttributeClass` handler in `psalm.xml`. **That test is the register of every such carve-out**, each with the condition that ends it. A new workaround the app carries only because it spans several server or PHP versions belongs there, so that dropping a version is a sweep and not a search.
+- **`symfony/console` is held at `^6.4.42`.** Nextcloud bundles Symfony 6.4, and `occ` commands must build against the same major.
+- **`allowScripts` in `package.json` lists `fsevents`, which is never installed here.** It is darwin-only; the entry exists for macOS machines, where npm would otherwise warn about its install script. `npm install-scripts prune` reports it as unused and removes it on Linux — do not run that blindly, and note that `npm install-scripts deny fsevents` cannot recreate it here (`ENOMATCH`).
+- **`@nextcloud/vite-config` is pinned to a pre-release.** Only that version allows Vite 8; the stable line is still on Vite 7. **This one expires:** switch as soon as a stable release supports Vite 8, and treat the pin as a finding from then on. Two things ride along with it and were accepted deliberately. It pulls the `yuku-*` parser family, young and single-maintainer, through `rolldown-plugin-dts` — dev-only, no install script, and only `libConfig` ever imports the plugin, so an app built through `createAppConfig` never loads it. And its chunk splitting is overridden in `vite.config.js`, which keeps the login challenge off the settings bundle; that file says when to compare the groups against upstream again.
 
 ## Releasing
 
-`krankerl package` packages the **committed** state, not the working tree — an
-uncommitted fix is not in the package, and a test against it proves the old behaviour.
-The rest, including why a published release stays invisible to instances for a while,
-is in [`doc/releasing.md`](doc/releasing.md).
+`krankerl package` packages the **committed** state, not the working tree — an uncommitted fix is not in the package, and a test against it proves the old behaviour. The rest, including why a published release stays invisible to instances for a while, is in [`doc/releasing.md`](doc/releasing.md).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,29 +2,16 @@
 
 ## Commitment
 
-This is a community effort, maintained by volunteers. We want everyone to feel
-comfortable contributing — whether through code, bug reports, feature requests,
-documentation, or discussion. This Code of Conduct outlines how we expect people
-to treat one another here.
+This is a community effort, maintained by volunteers. We want everyone to feel comfortable contributing — whether through code, bug reports, feature requests, documentation, or discussion. This Code of Conduct outlines how we expect people to treat one another here.
 
 ## Standards
 
-- **Communicate respectfully.** Treat others with courtesy and kindness, even
-  when you disagree.
-- **Value different opinions.** People have different backgrounds, needs, and
-  perspectives. Listen to other viewpoints and give them fair consideration.
-- **Be constructive.** Suggestions, questions, and answers should aim to move
-  things forward — offer reasoning, be specific, and focus on the issue rather
-  than the person.
-- **De-escalate.** If a discussion gets heated or the tone turns harsh, take a
-  step back, stay calm, and help bring the conversation back to a constructive
-  level.
-- **Own your mistakes.** Everyone makes mistakes. If you get something wrong or
-  cause offence, acknowledge it, apologise, and aim to avoid making the same
-  mistake again.
-- **Accept decisions.** In any project, decisions have to be made. Maintainers
-  listen to concerns but have the final say. Respect that. Feel free to fork if
-  you don't agree.
+- **Communicate respectfully.** Treat others with courtesy and kindness, even when you disagree.
+- **Value different opinions.** People have different backgrounds, needs, and perspectives. Listen to other viewpoints and give them fair consideration.
+- **Be constructive.** Suggestions, questions, and answers should aim to move things forward — offer reasoning, be specific, and focus on the issue rather than the person.
+- **De-escalate.** If a discussion gets heated or the tone turns harsh, take a step back, stay calm, and help bring the conversation back to a constructive level.
+- **Own your mistakes.** Everyone makes mistakes. If you get something wrong or cause offence, acknowledge it, apologise, and aim to avoid making the same mistake again.
+- **Accept decisions.** In any project, decisions have to be made. Maintainers listen to concerns but have the final say. Respect that. Feel free to fork if you don't agree.
 
 ## Unacceptable behaviour
 
@@ -35,19 +22,12 @@ to treat one another here.
 
 ## Scope
 
-This Code of Conduct applies to all project-related communication and
-publications — including issue trackers, pull requests, discussions, chats, and
-emails — and to everyone involved in the project, including the maintainers.
+This Code of Conduct applies to all project-related communication and publications — including issue trackers, pull requests, discussions, chats, and emails — and to everyone involved in the project, including the maintainers.
 
 ## Enforcement
 
-Instances of unacceptable behaviour may be reported to the project maintainers.
-All complaints will be reviewed and handled fairly and with discretion. In
-response to violations of this Code of Conduct, maintainers may take any action
-they deem appropriate.
+Instances of unacceptable behaviour may be reported to the project maintainers. All complaints will be reviewed and handled fairly and with discretion. In response to violations of this Code of Conduct, maintainers may take any action they deem appropriate.
 
 ## Attribution
 
-This Code of Conduct was written for this project and kept intentionally short
-and practical. It draws inspiration from common open-source community
-guidelines.
+This Code of Conduct was written for this project and kept intentionally short and practical. It draws inspiration from common open-source community guidelines.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,36 +1,25 @@
 # Contributing
 
-Thanks for your interest in improving this app! It's a community effort, and
-contributions of all kinds are welcome — code, tests, documentation,
-translations, bug reports, and ideas.
+Thanks for your interest in improving this app! It's a community effort, and contributions of all kinds are welcome — code, tests, documentation, translations, bug reports, and ideas.
 
 By participating, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Before you start
 
-Please discuss non-trivial ideas in the
-[idea collection](https://github.com/datenschutz-individuell/twofactor_email/issues/8)
-before opening a pull request, so nobody spends time on something that won't
-be merged.
+Please discuss non-trivial ideas in the [idea collection](https://github.com/datenschutz-individuell/twofactor_email/issues/8) before opening a pull request, so nobody spends time on something that won't be merged.
 
 ## Development
 
-Setting up a dev environment, running the test suite, coding standards,
-commit messages, SPDX headers, and the pull request workflow are all
-described in [doc/developers.md](doc/developers.md).
+Setting up a dev environment, running the test suite, coding standards, commit messages, SPDX headers, and the pull request workflow are all described in [doc/developers.md](doc/developers.md).
 
 ## Translations
 
-This app uses Transifex. If it's not yet available in your language, join the
-[Nextcloud translators community](https://explore.transifex.com/nextcloud/).
+This app uses Transifex. If it's not yet available in your language, join the [Nextcloud translators community](https://explore.transifex.com/nextcloud/).
 
 ## Security issues
 
-[SECURITY.md](SECURITY.md) says when a vulnerability may be reported as a
-public issue and when it should reach the maintainers privately. Please
-follow it rather than guessing.
+[SECURITY.md](SECURITY.md) says when a vulnerability may be reported as a public issue and when it should reach the maintainers privately. Please follow it rather than guessing.
 
 ## Questions
 
-If you have any questions, reach out to the maintainers listed in
-[CONTRIBUTORS.md](CONTRIBUTORS.md).
+If you have any questions, reach out to the maintainers listed in [CONTRIBUTORS.md](CONTRIBUTORS.md).

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,8 +2,7 @@
 
 ### Sponsor
 
-* [Datenschutz Individuell](mailto:kontakt@datenschutz-individuell.de) ([datenschutz-individuell.de](https://www.datenschutz-individuell.de))
-  Development sponsor for twofactor_email ≥3.0.0
+* [Datenschutz Individuell](mailto:kontakt@datenschutz-individuell.de) ([datenschutz-individuell.de](https://www.datenschutz-individuell.de)) Development sponsor for twofactor_email ≥3.0.0
 
 ### Current Maintainer
 
@@ -12,15 +11,12 @@
 
 ### Previous Authors
 
-* [Nico Kluge](mailto:nico.kluge@klugecoded.com) ([KlugeNico](https://github.com/KlugeNico))
-  New author of twofactor_email ≥3.0.0. Cloned and adjusted twofactor_totp project
+* [Nico Kluge](mailto:nico.kluge@klugecoded.com) ([KlugeNico](https://github.com/KlugeNico)) New author of twofactor_email ≥3.0.0. Cloned and adjusted twofactor_totp project
 
 ### Original Authors
 
-* [Christoph Wurst](mailto:christoph@winzerhof-wurst.at) ([christophwurst](https://github.com/christophwurst))
-  Author of [twofactor_totp](https://github.com/nextcloud/twofactor_totp) that ≥3.0.0 was cloned from
-* [Roeland Jago Douma](mailto:roeland@famdouma.nl) ([rullzer](https://github.com/rullzer))
-  Original author of twofactor_email ≤2.8.11
+* [Christoph Wurst](mailto:christoph@winzerhof-wurst.at) ([christophwurst](https://github.com/christophwurst)) Author of [twofactor_totp](https://github.com/nextcloud/twofactor_totp) that ≥3.0.0 was cloned from
+* [Roeland Jago Douma](mailto:roeland@famdouma.nl) ([rullzer](https://github.com/rullzer)) Original author of twofactor_email ≤2.8.11
 
 ### Code, Automation, Reviews, Tests, Documentation, Discussion/Input
 
@@ -40,10 +36,8 @@
 * Contributors may use AI to refactor or verify code snippets, which made the code more robust.
 * All code proposed by an AI is thoroughly verified and adjusted by the maintainers by hand.
 * Major AI contributions are commented in the source code next to the AI-enhanced parts.
-* Many thanks to Anthropic, whose Claude Code does most of that work today, and to
-  DuckDuckGo and OpenAI for duck.ai with GPT-5 mini.
+* Many thanks to Anthropic, whose Claude Code does most of that work today, and to DuckDuckGo and OpenAI for duck.ai with GPT-5 mini.
 
 ____
 
-*Please [tell me](mailto:olav@seyfarth.de?subject=%5Btwofactor_email%5D%20CONTRIBUTORS.md) if I forgot to
-include you or somebody or if I shall correct or delete contact details.*
+*Please [tell me](mailto:olav@seyfarth.de?subject=%5Btwofactor_email%5D%20CONTRIBUTORS.md) if I forgot to include you or somebody or if I shall correct or delete contact details.*

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,18 +1,10 @@
 # License
 
-This project is [REUSE](https://reuse.software/) compliant: every file carries
-clear copyright and license metadata, either inline (in its own header) or
-via [`REUSE.toml`](REUSE.toml) for files that cannot carry a header (e.g.
-binaries, lockfiles). This is verified in CI. Full license texts are in
-[`/LICENSES`](LICENSES).
+This project is [REUSE](https://reuse.software/) compliant: every file carries clear copyright and license metadata, either inline (in its own header) or via [`REUSE.toml`](REUSE.toml) for files that cannot carry a header (e.g. binaries, lockfiles). This is verified in CI. Full license texts are in [`/LICENSES`](LICENSES).
 
 ## Code
 
-Unless stated otherwise in a file's own header, the application is licensed
-under the **GNU Affero General Public License v3.0 or later
-([AGPL-3.0-or-later](LICENSES/AGPL-3.0-or-later.txt))**. This is also the
-default applied via `REUSE.toml` to files that cannot carry a header (docs,
-config, lockfiles, screenshots, translations).
+Unless stated otherwise in a file's own header, the application is licensed under the **GNU Affero General Public License v3.0 or later ([AGPL-3.0-or-later](LICENSES/AGPL-3.0-or-later.txt))**. This is also the default applied via `REUSE.toml` to files that cannot carry a header (docs, config, lockfiles, screenshots, translations).
 
 ## Other licenses used in this repository
 
@@ -23,7 +15,4 @@ config, lockfiles, screenshots, translations).
 | MIT License | [`MIT`](LICENSES/MIT.txt) | Most GitHub Actions workflows and `codecov.yml`, kept permissive so other projects can freely reuse this CI setup. The app-specific `smoke.yml` and the remaining files under `.github` stay AGPL |
 | Creative Commons Zero v1.0 Universal | [`CC0-1.0`](LICENSES/CC0-1.0.txt) | `.github/workflows/reuse.yml`, the REUSE-compliance check template provided by the FSFE |
 
-Every file decides its own license. The table above is a quick overview, not
-a substitute for checking the file itself. To see exactly which license
-applies to a given file, check its header, or run `reuse spdx` for a full,
-file-by-file report.
+Every file decides its own license. The table above is a quick overview, not a substitute for checking the file itself. To see exactly which license applies to a given file, check its header, or run `reuse spdx` for a full, file-by-file report.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,186 +1,51 @@
 # Review guidance
 
-For automated review. It says what is worth flagging here, and what has already been
-decided so that it does not get re-litigated in every pull request.
+For automated review. It says what is worth flagging here, and what has already been decided so that it does not get re-litigated in every pull request.
 
-The general facts about the project — supported versions, layout, commands — are in
-[`CLAUDE.md`](CLAUDE.md).
+The general facts about the project — supported versions, layout, commands — are in [`CLAUDE.md`](CLAUDE.md).
 
 ## Worth flagging
 
-**Correctness comes first here.** This app guards a login, so a defect that lets a second
-factor be skipped, accepted twice or brute-forced outweighs any question of style.
+**Correctness comes first here.** This app guards a login, so a defect that lets a second factor be skipped, accepted twice or brute-forced outweighs any question of style.
 
-- **Security-relevant attributes on controllers.** A route reachable by a **fully
-  logged-in** user that changes state without `#[PasswordConfirmationRequired]`; a
-  public or challenge-time endpoint without `#[BruteForceProtection]` or a rate limit;
-  an admin route without `#[AuthorizedAdminSetting]`. Also flag an exemption that is
-  broader than the comment next to it claims. Routes that run *during* the challenge
-  cannot use password confirmation — see the settled list below.
-- **Codes and their lifetime.** Anything that stores a code in clear text, keeps it
-  after a **successful** verification, compares it without constant-time semantics, or
-  widens its validity beyond the configured window.
-- **An empty result treated as success.** `for` over nothing, a filter that matches
-  nothing, a check whose loop body never runs — if "found nothing to test" can report a
-  pass, that is a bug. This has happened here.
-- **An array key used as a value.** PHP converts a key of digits only to `int`, whatever
-  the docblock promises — and OCP promises `array<string, …>` for user ids and provider
-  ids alike. Psalm believes the promise and cannot see this, so a key that reaches a
-  `string` parameter needs a cast. Nextcloud allows an all-digit user id, so this is a
-  real id, not a contrived one. This has happened here too.
-- **Failure paths that cannot work.** Diagnostics after a teardown, a log dump that
-  runs when the container is gone, `|| true` swallowing the very error the step exists
-  to surface.
-- **Shell portability in dev tooling.** Scripts under `tests/` are run by contributors
-  on macOS, whose stock `/bin/bash` is 3.2: expanding a possibly-empty array under
-  `set -u` aborts there.
-- **Version-range shims that outlived their reason.** When the supported Nextcloud
-  range changes, workarounds for the dropped version become dead weight around
-  security-relevant code. Flag them. Flag a **new** one too if it is not registered in
-  `CompatibilityShimsTest`: that class is meant to list every workaround the app carries
-  only because it spans several versions, so that dropping a version is a sweep rather
-  than a search.
-- **Repository conventions**, because they exist for a reason and are easy to miss when
-  adding a file of a kind that already exists: SPDX/REUSE coverage for new files, a
-  decision about `.nextcloudignore` for anything new at the root, GitHub Actions pinned
-  to a commit SHA with a version comment, `persist-credentials: false` on checkouts,
-  and `-f` on any `curl` that **downloads a tool or artefact** (not on the test
-  requests in `tests/smoke/`, where the status code is the assertion). Psalm enforces
-  `#[\Override]` on every override, so that one reports itself.
-- **Texts that will not survive translation.** User-facing strings, comments and
-  docblocks should be plain, short English. Idioms, nested clauses and German sentence
-  structure in English words all make translation worse.
-- **Parametrised tests that hide differences.** `it.each` is right only when setup and
-  expected result are identical across cases; a branch inside the case, or a different
-  mock mechanism per case, means it should have been separate tests.
-- **Abstraction without a second implementation.** An interface, factory or base class
-  introduced for a case that does not exist yet.
-- **A version bump that misses one of its four places** (`appinfo/info.xml`,
-  `package.json`, both fields in `package-lock.json`) or a missing changelog section.
+- **Security-relevant attributes on controllers.** A route reachable by a **fully logged-in** user that changes state without `#[PasswordConfirmationRequired]`; a public or challenge-time endpoint without `#[BruteForceProtection]` or a rate limit; an admin route without `#[AuthorizedAdminSetting]`. Also flag an exemption that is broader than the comment next to it claims. Routes that run *during* the challenge cannot use password confirmation — see the settled list below.
+- **Codes and their lifetime.** Anything that stores a code in clear text, keeps it after a **successful** verification, compares it without constant-time semantics, or widens its validity beyond the configured window.
+- **An empty result treated as success.** `for` over nothing, a filter that matches nothing, a check whose loop body never runs — if "found nothing to test" can report a pass, that is a bug. This has happened here.
+- **An array key used as a value.** PHP converts a key of digits only to `int`, whatever the docblock promises — and OCP promises `array<string, …>` for user ids and provider ids alike. Psalm believes the promise and cannot see this, so a key that reaches a `string` parameter needs a cast. Nextcloud allows an all-digit user id, so this is a real id, not a contrived one. This has happened here too.
+- **Failure paths that cannot work.** Diagnostics after a teardown, a log dump that runs when the container is gone, `|| true` swallowing the very error the step exists to surface.
+- **Shell portability in dev tooling.** Scripts under `tests/` are run by contributors on macOS, whose stock `/bin/bash` is 3.2: expanding a possibly-empty array under `set -u` aborts there.
+- **Version-range shims that outlived their reason.** When the supported Nextcloud range changes, workarounds for the dropped version become dead weight around security-relevant code. Flag them. Flag a **new** one too if it is not registered in `CompatibilityShimsTest`: that class is meant to list every workaround the app carries only because it spans several versions, so that dropping a version is a sweep rather than a search.
+- **Repository conventions**, because they exist for a reason and are easy to miss when adding a file of a kind that already exists: SPDX/REUSE coverage for new files, a decision about `.nextcloudignore` for anything new at the root, GitHub Actions pinned to a commit SHA with a version comment, `persist-credentials: false` on checkouts, and `-f` on any `curl` that **downloads a tool or artefact** (not on the test requests in `tests/smoke/`, where the status code is the assertion). Psalm enforces `#[\Override]` on every override, so that one reports itself.
+- **Texts that will not survive translation.** User-facing strings, comments and docblocks should be plain, short English. Idioms, nested clauses and German sentence structure in English words all make translation worse.
+- **Parametrised tests that hide differences.** `it.each` is right only when setup and expected result are identical across cases; a branch inside the case, or a different mock mechanism per case, means it should have been separate tests.
+- **Abstraction without a second implementation.** An interface, factory or base class introduced for a case that does not exist yet.
+- **A version bump that misses one of its four places** (`appinfo/info.xml`, `package.json`, both fields in `package-lock.json`) or a missing changelog section.
 
 ## Already decided — please do not flag
 
-- **The duplicated `NoTwoFactorRequired`** in `ChallengeController::resend()`: the
-  docblock annotation serves Nextcloud 33, the attribute serves 34 and is `@since 34`.
-  Both are needed until `min-version` reaches 34. The docblock explains it, and so
-  does the `UndefinedAttributeClass` handler in `psalm.xml` — the attribute does not
-  exist in the oldest supported server's OCP, which the analysis now checks against.
-  That handler names the **one** class on purpose; a suppression in the method's
-  docblock silenced every undefined attribute on the route that skips the second
-  factor, including a typo. Both go when `min-version` reaches 34 — and
-  `CompatibilityShimsTest` fails until they do, so this is enforced rather than
-  remembered.
-- **`findUnusedIssueHandlerSuppression="false"` outlives that pair.** A suppression in
-  `psalm.xml` exists because the app spans several versions, so in any single analysis
-  run it may simply not be triggered — and psalm would then report it as unused. The
-  flag belongs to all of them and goes with the last one, which is a check of its own,
-  not to the handler it was first added for.
-- **`symfony/console` at `^6.4.42`**: Nextcloud bundles Symfony 6.4 and `occ` commands
-  must match its major. This one has no expiry — it moves when Nextcloud moves.
-- **`@nextcloud/vite-config` pinned to a pre-release**: it is the only version that
-  allows Vite 8. **This one does expire** — once a stable release supports Vite 8, the
-  pin becomes exactly the kind of leftover the rule above asks you to flag.
-- **`ChallengeController::resend()` has no `#[PasswordConfirmationRequired]`.** It runs
-  before the second factor is complete, where password confirmation cannot be
-  satisfied. Its protection is the rate limit, brute-force protection and the service
-  cooldown.
-- **A wrong code does not invalidate the stored one.** Deleting it only on success is a
-  deliberate trade: users may mistype. Documented at the decision in
-  `LoginChallenge`.
-- **The remaining `npm audit` low findings.** They come from `elliptic` beneath the
-  Vite config's polyfill plugin; its latest release is the flagged one, nothing in the
-  chain has a fix, and none of it reaches the built bundle. Likewise the `EBADENGINE`
-  warnings, which appear because the `@nextcloud/*` packages have not declared Node 26
-  yet.
-- **The inline `${{ ... }}` versions in the workflows that pull requests trigger, and
-  CodeQL's cache poisoning alerts.** `npm-audit.yml` passes the npm version through the
-  environment because it audits a branch other than the default one. The other workflows
-  keep the template's inline form on purpose: they run on `pull_request`, where a fork
-  gets a read-only token and no secrets, and they execute the pull request's own code
-  anyway — `npm ci` and the build, or the `psalm` script from its `composer.json`.
-  Injection wins nothing there. The two `actions/cache-poisoning/poisonable-step` alerts
-  on `npm-audit.yml` are dismissed for that reason and a stronger one: no workflow in
-  this repository writes or restores an Actions cache, so there is nothing to poison.
-  Hardening the checkout was considered and rejected: a `sparse-checkout` does not
-  close the path. `package.json` has to stay, because the version step reads it, and
-  its `engines.npm` is what reaches `npm i -g`; keeping a root-level `.npmrc` off the
-  runner would need `sparse-checkout-cone-mode: false` on top, because cone mode always
-  materialises the repository root. Both refs are branches of this repository anyway —
-  whoever could poison one could edit this workflow instead — and the alert would stay,
-  because the rule follows the ref, not the files on disk. Revisit if this job ever
-  gains a secret, writes or restores a cache, or runs on a fork trigger.
-- **Formatting.** `php-cs-fixer` with `nextcloud/coding-standard` owns it, ESLint and
-  Stylelint own the frontend. Tabs, brace placement and import order are not review
-  material.
-- **There is no Rector configuration, on purpose.** Its Nextcloud sets for 33, 34 and
-  35 are the same file, and running them against `lib/` changes nothing. Keeping the
-  tool would add a dependency project that only earns its keep when a future server
-  renames an API. Run it from a throwaway checkout when the supported range moves —
-  `doc/development-setup.md` says how — rather than carrying it here.
-- **`package-lock.json` churn** in a dependency update, and generated translation
-  files.
-- **Test doubles that look over-specific.** Assertions on exact mock calls are
-  deliberate here; the unit tests are meant to pin behaviour, not to be flexible.
+- **The duplicated `NoTwoFactorRequired`** in `ChallengeController::resend()`: the docblock annotation serves Nextcloud 33, the attribute serves 34 and is `@since 34`. Both are needed until `min-version` reaches 34. The docblock explains it, and so does the `UndefinedAttributeClass` handler in `psalm.xml` — the attribute does not exist in the oldest supported server's OCP, which the analysis now checks against. That handler names the **one** class on purpose; a suppression in the method's docblock silenced every undefined attribute on the route that skips the second factor, including a typo. Both go when `min-version` reaches 34 — and `CompatibilityShimsTest` fails until they do, so this is enforced rather than remembered.
+- **`findUnusedIssueHandlerSuppression="false"` outlives that pair.** A suppression in `psalm.xml` exists because the app spans several versions, so in any single analysis run it may simply not be triggered — and psalm would then report it as unused. The flag belongs to all of them and goes with the last one, which is a check of its own, not to the handler it was first added for.
+- **`symfony/console` at `^6.4.42`**: Nextcloud bundles Symfony 6.4 and `occ` commands must match its major. This one has no expiry — it moves when Nextcloud moves.
+- **`@nextcloud/vite-config` pinned to a pre-release**: it is the only version that allows Vite 8. **This one does expire** — once a stable release supports Vite 8, the pin becomes exactly the kind of leftover the rule above asks you to flag.
+- **`ChallengeController::resend()` has no `#[PasswordConfirmationRequired]`.** It runs before the second factor is complete, where password confirmation cannot be satisfied. Its protection is the rate limit, brute-force protection and the service cooldown.
+- **A wrong code does not invalidate the stored one.** Deleting it only on success is a deliberate trade: users may mistype. Documented at the decision in `LoginChallenge`.
+- **The remaining `npm audit` low findings.** They come from `elliptic` beneath the Vite config's polyfill plugin; its latest release is the flagged one, nothing in the chain has a fix, and none of it reaches the built bundle. Likewise the `EBADENGINE` warnings, which appear because the `@nextcloud/*` packages have not declared Node 26 yet.
+- **The inline `${{ ... }}` versions in the workflows that pull requests trigger, and CodeQL's cache poisoning alerts.** `npm-audit.yml` passes the npm version through the environment because it audits a branch other than the default one. The other workflows keep the template's inline form on purpose: they run on `pull_request`, where a fork gets a read-only token and no secrets, and they execute the pull request's own code anyway — `npm ci` and the build, or the `psalm` script from its `composer.json`. Injection wins nothing there. The two `actions/cache-poisoning/poisonable-step` alerts on `npm-audit.yml` are dismissed for that reason and a stronger one: no workflow in this repository writes or restores an Actions cache, so there is nothing to poison. Hardening the checkout was considered and rejected: a `sparse-checkout` does not close the path. `package.json` has to stay, because the version step reads it, and its `engines.npm` is what reaches `npm i -g`; keeping a root-level `.npmrc` off the runner would need `sparse-checkout-cone-mode: false` on top, because cone mode always materialises the repository root. Both refs are branches of this repository anyway — whoever could poison one could edit this workflow instead — and the alert would stay, because the rule follows the ref, not the files on disk. Revisit if this job ever gains a secret, writes or restores a cache, or runs on a fork trigger.
+- **Formatting.** `php-cs-fixer` with `nextcloud/coding-standard` owns it, ESLint and Stylelint own the frontend. Tabs, brace placement and import order are not review material.
+- **There is no Rector configuration, on purpose.** Its Nextcloud sets for 33, 34 and 35 are the same file, and running them against `lib/` changes nothing. Keeping the tool would add a dependency project that only earns its keep when a future server renames an API. Run it from a throwaway checkout when the supported range moves — `doc/development-setup.md` says how — rather than carrying it here.
+- **`package-lock.json` churn** in a dependency update, and generated translation files.
+- **Test doubles that look over-specific.** Assertions on exact mock calls are deliberate here; the unit tests are meant to pin behaviour, not to be flexible.
 
-- **Precision where a mistake is cosmetic, caution where it is fatal.** URL detection
-  in `TemplateRenderer` serves the auto-linking, where getting a boundary wrong costs
-  a link. It is deliberately **not** the security boundary: where a URL ends in free
-  text is not decidable, and every mail client answers it differently. The one check
-  that decides whether the code may be sent runs on the **finished** mail
-  (`LinkScanner::couldLeakCode()`), is cruder than everything before it, and cannot
-  fail. When in doubt it says yes, because sending the default text for one mail
-  without need is better than letting one code slip through.
-  Making the template checks carry that job produced eleven review rounds of boundary
-  bugs (2026-08-06); do not move it back. `hasPlaceholderInUrl()` and
-  `couldLeakCode()` read a text into addresses through the **same** function, and
-  must keep doing so: if the write-side check were the narrower one, an admin could
-  save a text that is then never sent.
-  `LinkScanner` is where both live, so neither the renderer nor the validator depends
-  on the other (2026-08-26).
+- **Precision where a mistake is cosmetic, caution where it is fatal.** URL detection in `TemplateRenderer` serves the auto-linking, where getting a boundary wrong costs a link. It is deliberately **not** the security boundary: where a URL ends in free text is not decidable, and every mail client answers it differently. The one check that decides whether the code may be sent runs on the **finished** mail (`LinkScanner::couldLeakCode()`), is cruder than everything before it, and cannot fail. When in doubt it says yes, because sending the default text for one mail without need is better than letting one code slip through. Making the template checks carry that job produced eleven review rounds of boundary bugs (2026-08-06); do not move it back. `hasPlaceholderInUrl()` and `couldLeakCode()` read a text into addresses through the **same** function, and must keep doing so: if the write-side check were the narrower one, an admin could save a text that is then never sent. `LinkScanner` is where both live, so neither the renderer nor the validator depends on the other (2026-08-26).
 
-- **The check on the finished mail asks about the one-time code, nothing else.** It is
-  the last stop before sending, and it exists for the secret that logging in depends
-  on. Any other value in a web address — a display name in a tracking link, say — is
-  refused when the text is written and reported on upgrade, but it is not stopped
-  again at send time: it is not a secret, and replacing the admin's whole text over a
-  privacy nuisance they can fix themselves is the worse trade. `doc/developers.md`
-  states the limit. Decided 2026-08-06; widening it is a product decision, not a bug.
+- **The check on the finished mail asks about the one-time code, nothing else.** It is the last stop before sending, and it exists for the secret that logging in depends on. Any other value in a web address — a display name in a tracking link, say — is refused when the text is written and reported on upgrade, but it is not stopped again at send time: it is not a secret, and replacing the admin's whole text over a privacy nuisance they can fix themselves is the worse trade. `doc/developers.md` states the limit. Decided 2026-08-06; widening it is a product decision, not a bug.
 
-- **A stored text with a placeholder in a web address saves without a warning in
-  the admin UI.** The save is deliberately not blocked — an instance can carry such
-  a text without anyone having typed it there, and blocking would freeze every other
-  setting. Reporting it *without* blocking needs a second channel next to `errors`
-  in the JSON and a warning state in the field component; that is a UI change with
-  its own cut, not an oversight. Until then the condition is named by `occ upgrade`,
-  by the log on every affected mail, and by the validator as soon as the text is
-  touched. Known since 2026-08-06.
+- **A stored text with a placeholder in a web address saves without a warning in the admin UI.** The save is deliberately not blocked — an instance can carry such a text without anyone having typed it there, and blocking would freeze every other setting. Reporting it *without* blocking needs a second channel next to `errors` in the JSON and a warning state in the field component; that is a UI change with its own cut, not an oversight. Until then the condition is named by `occ upgrade`, by the log on every affected mail, and by the validator as soon as the text is touched. Known since 2026-08-06.
 
-- **`{logo}` inside a web address is allowed.** It expands to an image tag or to
-  nothing and never inserts a value, so it hands no data to whoever owns the address.
-  Only the placeholders in `TemplateRenderer::VALUE_PLACEHOLDERS` are refused there.
-  The list belongs to the renderer, which builds its values by walking it, so a
-  placeholder cannot be substituted without the settings checks knowing it — psalm
-  reports the incomplete match instead of a test comparing two lists.
+- **`{logo}` inside a web address is allowed.** It expands to an image tag or to nothing and never inserts a value, so it hands no data to whoever owns the address. Only the placeholders in `TemplateRenderer::VALUE_PLACEHOLDERS` are refused there. The list belongs to the renderer, which builds its values by walking it, so a placeholder cannot be substituted without the settings checks knowing it — psalm reports the incomplete match instead of a test comparing two lists.
 
-- **The fallback to the default text is not checked again before sending.** The
-  default keeps `{code}` in a paragraph of its own, outside every translatable
-  string, so neither a translation nor an inserted value can move an address next to
-  it. `DefaultEMailTextsTest` asserts both halves of that for **every** shipped
-  language: that the body still contains `"\n\n{code}\n\n"`, and that rendering it
-  with a display name and an instance name that end in an unfinished web address
-  delivers the code and keeps it out of every address. A run-time check of our own
-  text could only fire if that text were changed in the source, which is where a test
-  belongs (2026-08-26).
-  A **theme** can replace a translated string of ours — a translation file under
-  `themes/` that the server merges over the app's own — and the substitution would
-  then run on that text. That needs write access to the instance, which
-  `doc/threat-model.md` puts out of scope: the same access removes the check. It is
-  not a separate attack path.
+- **The fallback to the default text is not checked again before sending.** The default keeps `{code}` in a paragraph of its own, outside every translatable string, so neither a translation nor an inserted value can move an address next to it. `DefaultEMailTextsTest` asserts both halves of that for **every** shipped language: that the body still contains `"\n\n{code}\n\n"`, and that rendering it with a display name and an instance name that end in an unfinished web address delivers the code and keeps it out of every address. A run-time check of our own text could only fire if that text were changed in the source, which is where a test belongs (2026-08-26). A **theme** can replace a translated string of ours — a translation file under `themes/` that the server merges over the app's own — and the substitution would then run on that text. That needs write access to the instance, which `doc/threat-model.md` puts out of scope: the same access removes the check. It is not a separate attack path.
 
 ## What "ready" means here
 
-CI green, no new Psalm or taint findings, and — for anything touching routes,
-controllers or the challenge flow — the smoke test run against **both** ends of the
-supported Nextcloud range. One server version is not a test of a version range: a
-resend endpoint once worked on the newest server and was dead on the oldest, and only
-that two-version run found it.
+CI green, no new Psalm or taint findings, and — for anything touching routes, controllers or the challenge flow — the smoke test run against **both** ends of the supported Nextcloud range. One server version is not a test of a version range: a resend endpoint once worked on the newest server and was dead on the oldest, and only that two-version run found it.

--- a/doc/admins.md
+++ b/doc/admins.md
@@ -103,26 +103,18 @@ If the page instead says a code was sent and none arrives, the mail left Nextclo
 
 ## Frequently asked questions
 
-**Can I enforce email 2FA specifically?**
-Not directly — Nextcloud enforces *a* second factor, never a particular one, and no provider can change that. Installing this provider and no other gets you the same result — see [Enforcing two-factor authentication](#enforcing-two-factor-authentication).
+**Can I enforce email 2FA specifically?** Not directly — Nextcloud enforces *a* second factor, never a particular one, and no provider can change that. Installing this provider and no other gets you the same result — see [Enforcing two-factor authentication](#enforcing-two-factor-authentication).
 
-**Can I switch the provider on for everyone, or for every new account?**
-For everyone, loop over `occ user:list` and call `occ twofactorauth:enable` — see [Scripting](#scripting). For new accounts Nextcloud has no setting for it, and this app deliberately does not switch itself on: at that moment the address is usually unverified, and the invitation mail and the codes travel the same path anyway, so it would add no security.
+**Can I switch the provider on for everyone, or for every new account?** For everyone, loop over `occ user:list` and call `occ twofactorauth:enable` — see [Scripting](#scripting). For new accounts Nextcloud has no setting for it, and this app deliberately does not switch itself on: at that moment the address is usually unverified, and the invitation mail and the codes travel the same path anyway, so it would add no security.
 
-**Can a user receive their codes at some other address than their Nextcloud one?**
-No, and that is a decision, not an omission. A second address is one more value to validate, store and keep in sync, and whoever reads a mailbox can also request a password reset there. If email is not a safe enough channel for an account, use another provider for it.
+**Can a user receive their codes at some other address than their Nextcloud one?** No, and that is a decision, not an omission. A second address is one more value to validate, store and keep in sync, and whoever reads a mailbox can also request a password reset there. If email is not a safe enough channel for an account, use another provider for it.
 
-**A user cannot reach their mailbox any more. How do I let them in?**
-Put the codes where the user can read them: `occ user:setting <uid> settings email <address>`. `occ twofactorauth:disable <uid> email` looks like the shorter way and is the wrong one where 2FA is enforced — the next login sends the user through the setup step, and this provider is usually the only one offering it, so they are asked for a code at the same unreachable mailbox. Switching the factor off also removes the *Use backup code* link, which the login screen shows only while a second factor is enabled. So if the account has backup codes, leave the factor on and let the user log in with one. If the factor really has to go, take the account out of enforcement first. The [Two-Factor Admin Support](https://apps.nextcloud.com/apps/twofactor_admin) app is another way to help such a user.
+**A user cannot reach their mailbox any more. How do I let them in?** Put the codes where the user can read them: `occ user:setting <uid> settings email <address>`. `occ twofactorauth:disable <uid> email` looks like the shorter way and is the wrong one where 2FA is enforced — the next login sends the user through the setup step, and this provider is usually the only one offering it, so they are asked for a code at the same unreachable mailbox. Switching the factor off also removes the *Use backup code* link, which the login screen shows only while a second factor is enabled. So if the account has backup codes, leave the factor on and let the user log in with one. If the factor really has to go, take the account out of enforcement first. The [Two-Factor Admin Support](https://apps.nextcloud.com/apps/twofactor_admin) app is another way to help such a user.
 
-**Do users have to confirm a code at every login?**
-Yes, once per login — but not for every action afterwards: the session stays valid. *Stay logged in* is the exception: Nextcloud then keeps a cookie, valid for 15 days unless `remember_login_cookie_lifetime` says otherwise, and a session restored from that cookie asks for no second factor. Logging out drops it. What Nextcloud does not have is a *trusted device* a user can register; that would be a server feature, not something a provider can add.
+**Do users have to confirm a code at every login?** Yes, once per login — but not for every action afterwards: the session stays valid. *Stay logged in* is the exception: Nextcloud then keeps a cookie, valid for 15 days unless `remember_login_cookie_lifetime` says otherwise, and a session restored from that cookie asks for no second factor. Logging out drops it. What Nextcloud does not have is a *trusted device* a user can register; that would be a server feature, not something a provider can add.
 
-**Our desktop and mobile clients stopped working.**
-That happens with any second factor: those apps cannot show the web login. Each of them needs an app password, created under *Personal settings › Security › Devices & sessions*.
+**Our desktop and mobile clients stopped working.** That happens with any second factor: those apps cannot show the web login. Each of them needs an app password, created under *Personal settings › Security › Devices & sessions*.
 
-**After an update the mail lost its logo or its line breaks.**
-An older version saved the default text into the settings like a text of your own, so later improvements to the default never reached those instances. Clear the field in the admin settings, or run `occ twofactor_email:settings email_template ""`; the same works for `email_subject`.
+**After an update the mail lost its logo or its line breaks.** An older version saved the default text into the settings like a text of your own, so later improvements to the default never reached those instances. Clear the field in the admin settings, or run `occ twofactor_email:settings email_template ""`; the same works for `email_subject`.
 
-**Should I put `{code}` in the subject?**
-Better not. Mail clients show subjects in system notifications, which are readable on a locked screen — a code in the subject can be read there without unlocking the device.
+**Should I put `{code}` in the subject?** Better not. Mail clients show subjects in system notifications, which are readable on a locked screen — a code in the subject can be read there without unlocking the device.

--- a/doc/developers.md
+++ b/doc/developers.md
@@ -20,18 +20,12 @@ Contributions are welcome — see [CONTRIBUTING](../CONTRIBUTING.md).
    composer test:unit:dev && composer psalm && composer cs:check
    npm run lint && npm run stylelint && npm test && npm run build
    ```
-   `composer cs:fix` applies the style fixes automatically. Note that Psalm
-   *analyses* against the minimum PHP version the app supports, set as `phpVersion`
-   in `psalm.xml`; that is not a limit on the interpreter it runs on. Should a tool
-   ever refuse your default PHP, it says so, and an older interpreter next to it
-   helps (on Arch Linux, for example, `php-legacy vendor/bin/psalm.phar`).
+   `composer cs:fix` applies the style fixes automatically. Note that Psalm *analyses* against the minimum PHP version the app supports, set as `phpVersion` in `psalm.xml`; that is not a limit on the interpreter it runs on. Should a tool ever refuse your default PHP, it says so, and an older interpreter next to it helps (on Arch Linux, for example, `php-legacy vendor/bin/psalm.phar`).
 4. **Add SPDX headers to new files.** The project is [REUSE](https://reuse.software/) compliant and CI enforces it; files that cannot carry a header (images, generated files) are annotated centrally in `REUSE.toml`.
 5. **Describe *why* in the commit message**, not *what* — the diff already shows what changed.
 6. **CI is the gate.** All checks have to pass; a red run will not be merged.
 
-If a change affects behaviour, say how you verified it. Unit tests cover the
-services and the frontend logic, but route registration, emails and the login flow
-only show up in a running Nextcloud — see [development-setup.md](development-setup.md).
+If a change affects behaviour, say how you verified it. Unit tests cover the services and the frontend logic, but route registration, emails and the login flow only show up in a running Nextcloud — see [development-setup.md](development-setup.md).
 
 ## Security mechanisms
 

--- a/doc/development-setup.md
+++ b/doc/development-setup.md
@@ -69,10 +69,7 @@ docker compose up --pull always -d nextcloud
 
 ## Throwaway instance for a specific Nextcloud version
 
-The app supports a range of Nextcloud versions, and a bug can be specific to one of
-them. [`tests/smoke/`](../tests/smoke/) holds a disposable instance built from the
-official image — SQLite plus a mail catcher, because without SMTP the challenge email
-never arrives and the login flow cannot be tested at all.
+The app supports a range of Nextcloud versions, and a bug can be specific to one of them. [`tests/smoke/`](../tests/smoke/) holds a disposable instance built from the official image — SQLite plus a mail catcher, because without SMTP the challenge email never arrives and the login flow cannot be tested at all.
 
 ```bash
 krankerl package                  # in the repository root; both start from the package
@@ -82,64 +79,39 @@ cd tests/smoke
 NC_TAG=33-apache ./setup.sh       # or:     one instance, left up to click around in
 ```
 
-The last two are alternatives, not a sequence: `smoke.sh` refuses to run while an
-instance is up rather than pulling it away from whoever is using it. `setup.sh` prints
-the URLs and how to switch the provider on for the user; `docker compose down -v`
-removes everything again.
+The last two are alternatives, not a sequence: `smoke.sh` refuses to run while an instance is up rather than pulling it away from whoever is using it. `setup.sh` prints the URLs and how to switch the provider on for the user; `docker compose down -v` removes everything again.
 
-While you still have uncommitted work, there is no package to test — `krankerl` packages
-the committed state, and `smoke.sh` stops rather than prove the wrong thing. Mount the
-working tree instead:
+While you still have uncommitted work, there is no package to test — `krankerl` packages the committed state, and `smoke.sh` stops rather than prove the wrong thing. Mount the working tree instead:
 
 ```bash
 composer install -o && npm ci && npm run build
 APP_DIR="$(git rev-parse --show-toplevel)" ./smoke.sh
 ```
 
-Prefer the packaged run before a release, though: it is what users get, and it catches
-what a checkout hides — a file missing from the release because of `.nextcloudignore`
-cannot show up when the working tree is mounted.
+Prefer the packaged run before a release, though: it is what users get, and it catches what a checkout hides — a file missing from the release because of `.nextcloudignore` cannot show up when the working tree is mounted.
 
-The options, what the checks cover, and a list of things that behave surprisingly are
-in [tests/smoke/README.md](../tests/smoke/README.md).
+The options, what the checks cover, and a list of things that behave surprisingly are in [tests/smoke/README.md](../tests/smoke/README.md).
 
-If the Docker daemon refuses to start with `error initializing graphdriver: driver not
-supported`, the kernel was updated without a reboot since — the modules of the running
-kernel are gone, so overlayfs cannot be loaded. Rebooting fixes it.
+If the Docker daemon refuses to start with `error initializing graphdriver: driver not supported`, the kernel was updated without a reboot since — the modules of the running kernel are gone, so overlayfs cannot be loaded. Rebooting fixes it.
 
 ## The one check that is not in a lock file
 
-`composer install` brings PHPUnit, Psalm and php-cs-fixer, `npm install` the JavaScript
-side. Both put their tools inside the checkout. The `reuse` check has no such home, so
-it is the one that usually reports itself through a red CI job:
+`composer install` brings PHPUnit, Psalm and php-cs-fixer, `npm install` the JavaScript side. Both put their tools inside the checkout. The `reuse` check has no such home, so it is the one that usually reports itself through a red CI job:
 
 ```
 # on Arch, as root
 pacman -S reuse
 ```
 
-Other systems are covered on [reuse.software](https://reuse.software/) — `pipx install
-reuse` works everywhere Python does. Install it **for the machine, not for one account**:
-unlike the tools above it is not part of the checkout, and a check only one user can run
-is one the next person does not know about.
+Other systems are covered on [reuse.software](https://reuse.software/) — `pipx install reuse` works everywhere Python does. Install it **for the machine, not for one account**: unlike the tools above it is not part of the checkout, and a check only one user can run is one the next person does not know about.
 
-`reuse lint` in the repository root then answers what the CI job answers: does every file
-carry copyright and license information, in an SPDX header or through an entry in
-`REUSE.toml`. A file with neither is the usual reason that job turns red. Watch the
-entries that are globbed — `doc/**` (the screenshots live there), `vendor-bin/*/composer.json`
-and `.lock`, and under `l10n/` only `**.js`, `**.json` and `**.php`. Anything outside those
-patterns, a new file at the root above all, needs a **named** entry or a header of its
-own.
+`reuse lint` in the repository root then answers what the CI job answers: does every file carry copyright and license information, in an SPDX header or through an entry in `REUSE.toml`. A file with neither is the usual reason that job turns red. Watch the entries that are globbed — `doc/**` (the screenshots live there), `vendor-bin/*/composer.json` and `.lock`, and under `l10n/` only `**.js`, `**.json` and `**.php`. Anything outside those patterns, a new file at the root above all, needs a **named** entry or a header of its own.
 
-Rector is the other tool that is not installed here, and CI does not run it either. That
-is deliberate; see below.
+Rector is the other tool that is not installed here, and CI does not run it either. That is deliberate; see below.
 
 ## Rector, when the Nextcloud range moves
 
-Rector can rewrite calls that a new server renamed, but it is not part of this project:
-its Nextcloud sets for 33, 34 and 35 are the same file, and over `lib/` they propose
-nothing at all. Run it from a throwaway directory when the supported range moves, then
-throw the directory away:
+Rector can rewrite calls that a new server renamed, but it is not part of this project: its Nextcloud sets for 33, 34 and 35 are the same file, and over `lib/` they propose nothing at all. Run it from a throwaway directory when the supported range moves, then throw the directory away:
 
 ```bash
 mkdir -p /tmp/rector && cd /tmp/rector
@@ -162,17 +134,8 @@ PHP
 vendor/bin/rector process --dry-run
 ```
 
-`--dry-run` prints the changes without writing them; read them before applying anything
-by hand.
+`--dry-run` prints the changes without writing them; read them before applying anything by hand.
 
-**Both autoload paths are required.** Without the app's own dependencies, Rector cannot
-see the classes the code inherits from, and a rule that needs that information proposes
-the wrong change with the same confidence as a right one — in one run it wanted to delete
-every `parent::setUp()` in the test suite. `nextcloud/ocp` ships no autoload section of
-its own, which is why `tests/bootstrap.php` belongs in the list: it registers the
-autoloader for `OCP\` and `NCU\` that nothing else provides.
+**Both autoload paths are required.** Without the app's own dependencies, Rector cannot see the classes the code inherits from, and a rule that needs that information proposes the wrong change with the same confidence as a right one — in one run it wanted to delete every `parent::setUp()` in the test suite. `nextcloud/ocp` ships no autoload section of its own, which is why `tests/bootstrap.php` belongs in the list: it registers the autoloader for `OCP\` and `NCU\` that nothing else provides.
 
-Read each proposal on its merits rather than applying the run wholesale, and expect to
-reject some. Adding the PHPUnit code-quality set produced four rules over `tests/`, of
-which two were worth taking: `parent::setUp()` is kept here deliberately, and a
-`(string)` cast it suggests is already guaranteed by the declared types.
+Read each proposal on its merits rather than applying the run wholesale, and expect to reject some. Adding the PHPUnit code-quality set produced four rules over `tests/`, of which two were worth taking: `parent::setUp()` is kept here deliberately, and a `(string)` cast it suggests is already guaranteed by the declared types.

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -5,10 +5,7 @@
 
 # Releasing
 
-Notes for whoever publishes a release. The concrete infrastructure — which host signs,
-where the key lives, how the instances are updated — is deliberately not part of this
-document; it is specific to the maintainer's setup. What is here is the part that is
-true for anyone publishing a Nextcloud app, and most of it was learned the hard way.
+Notes for whoever publishes a release. The concrete infrastructure — which host signs, where the key lives, how the instances are updated — is deliberately not part of this document; it is specific to the maintainer's setup. What is here is the part that is true for anyone publishing a Nextcloud app, and most of it was learned the hard way.
 
 ## Before building
 
@@ -18,82 +15,37 @@ true for anyone publishing a Nextcloud app, and most of it was learned the hard 
 npm version <version> --no-git-tag-version
 ```
 
-That updates `package.json` and **both** version fields in `package-lock.json` (the
-top-level one and `packages[""]`) and touches nothing else — verified on a release bump:
-two changed lines in the lock file, all 855 dependency entries byte-identical, integrity
-hashes included. Do not re-resolve the tree during a release, and do not hand-edit the
-lock file either: the second version field is easy to miss, and editing by hand is how
-you end up with a lock whose checksums no longer match what it describes.
+That updates `package.json` and **both** version fields in `package-lock.json` (the top-level one and `packages[""]`) and touches nothing else — verified on a release bump: two changed lines in the lock file, all 855 dependency entries byte-identical, integrity hashes included. Do not re-resolve the tree during a release, and do not hand-edit the lock file either: the second version field is easy to miss, and editing by hand is how you end up with a lock whose checksums no longer match what it describes.
 
 `appinfo/info.xml` and the `CHANGELOG.md` section stay manual.
 
-**Add the changelog section for exactly that version** before building. Release notes
-are generated from it, so a missing section means empty notes.
+**Add the changelog section for exactly that version** before building. Release notes are generated from it, so a missing section means empty notes.
 
-**Check the dependencies:** `composer bin all outdated` (the plain `composer outdated`
-does **not** look into the `vendor-bin/*` sub-projects the bamarni plugin creates) and
-`npm outdated --all`. Also check whether the declared floors can be raised to what is
-actually installed, and whether existing pins and `overrides` are still needed.
+**Check the dependencies:** `composer bin all outdated` (the plain `composer outdated` does **not** look into the `vendor-bin/*` sub-projects the bamarni plugin creates) and `npm outdated --all`. Also check whether the declared floors can be raised to what is actually installed, and whether existing pins and `overrides` are still needed.
 
-**Look at the open security alerts.** Either fix them or close them with a reason —
-"scope: development only" is a judgement that has to be made per case, not assumed.
+**Look at the open security alerts.** Either fix them or close them with a reason — "scope: development only" is a judgement that has to be made per case, not assumed.
 
 ## Building
 
-`krankerl package` packages the **committed** state, not the working tree. An
-uncommitted fix is not in the package, and any test you then run proves the old
-behaviour. This has bitten us: a smoke test once passed on a package that predated the
-change it was meant to verify.
+`krankerl package` packages the **committed** state, not the working tree. An uncommitted fix is not in the package, and any test you then run proves the old behaviour. This has bitten us: a smoke test once passed on a package that predated the change it was meant to verify.
 
 ## Testing before publishing
 
-Run `tests/smoke/smoke.sh` against the built package. It covers **every version in the
-supported server range**, which is not pedantry: 3.4.0 shipped a resend endpoint that
-was dead on Nextcloud 33 and fine on 34, because the exemption from the two-factor
-gate is taken from the docblock on 33 and from the PHP attribute on 34, and that
-attribute is `@since 34`. A single manual pass on a current server cannot see that
-class of bug.
+Run `tests/smoke/smoke.sh` against the built package. It covers **every version in the supported server range**, which is not pedantry: 3.4.0 shipped a resend endpoint that was dead on Nextcloud 33 and fine on 34, because the exemption from the two-factor gate is taken from the docblock on 33 and from the PHP attribute on 34, and that attribute is `@since 34`. A single manual pass on a current server cannot see that class of bug.
 
-What the smoke test cannot check is how it looks. Leave one instance running
-(`KEEP=1`) and look at the challenge dialog, dark mode and a non-English locale.
+What the smoke test cannot check is how it looks. Leave one instance running (`KEEP=1`) and look at the challenge dialog, dark mode and a non-English locale.
 
 ## After publishing: why nobody sees it yet
 
-This is the part that looks like a bug in your instances and is not. Two independent
-caches sit between the app store and an `occ app:update`.
+This is the part that looks like a bug in your instances and is not. Two independent caches sit between the app store and an `occ app:update`.
 
-**The store's own list.** `apps.nextcloud.com` serves
-`api/v1/platform/<ncversion>/apps.json` through a cache, and a freshly published
-version is not in it immediately — in one measured case about 15 minutes. Appending a
-query string bypasses that cache and shows the fresh list, which is useful for
-comparing but is not a fix: instances request the plain URL. There is nothing to flush
-here, only to wait.
+**The store's own list.** `apps.nextcloud.com` serves `api/v1/platform/<ncversion>/apps.json` through a cache, and a freshly published version is not in it immediately — in one measured case about 15 minutes. Appending a query string bypasses that cache and shows the fresh list, which is useful for comparing but is not a fix: instances request the plain URL. There is nothing to flush here, only to wait.
 
-**Each instance's copy.** Nextcloud caches the list in
-`<datadir>/appdata_<instanceid>/appstore/apps.json` for an hour
-(`Fetcher::INVALIDATE_AFTER_SECONDS`), and both `occ app:update` and
-`occ update:check` read it through `Installer::isUpdateAvailable()`. To force a
-refetch, **truncate** that file rather than deleting it: appdata is managed through
-the Files API, so removing the file on disk leaves an orphaned filecache entry. An
-empty file parses as invalid JSON, so Nextcloud fetches again and overwrites it. Do
-every access as the owner of the data directory — it is not readable by anyone else,
-and a check that fails there makes the flush do nothing while looking like it worked.
+**Each instance's copy.** Nextcloud caches the list in `<datadir>/appdata_<instanceid>/appstore/apps.json` for an hour (`Fetcher::INVALIDATE_AFTER_SECONDS`), and both `occ app:update` and `occ update:check` read it through `Installer::isUpdateAvailable()`. To force a refetch, **truncate** that file rather than deleting it: appdata is managed through the Files API, so removing the file on disk leaves an orphaned filecache entry. An empty file parses as invalid JSON, so Nextcloud fetches again and overwrites it. Do every access as the owner of the data directory — it is not readable by anyone else, and a check that fails there makes the flush do nothing while looking like it worked.
 
-**The store rate-limits per IP**, and this is the answer to a puzzle that looked
-random for years: when several instances behind one address fetch the ~4 MB list in
-quick succession, some get `429 Too Many Requests`. Nextcloud catches that exception
-and returns an empty list, so a throttled instance reports "All apps are up-to-date"
-— indistinguishable from "nothing to do". That is why, after a release, a seemingly
-arbitrary subset of instances updates, and a different subset the next time. If you
-run more than one or two instances from the same address, a caching proxy in front of
-the store that serves stale content on `429` would stop a throttle masquerading as "up
-to date" — but it must be a host the instances treat as external. Pointing
-`appstoreurl` at a proxy on the instance's own machine does not work: Nextcloud's SSRF
-protection refuses a loopback address, and the store is simply never asked.
+**The store rate-limits per IP**, and this is the answer to a puzzle that looked random for years: when several instances behind one address fetch the ~4 MB list in quick succession, some get `429 Too Many Requests`. Nextcloud catches that exception and returns an empty list, so a throttled instance reports "All apps are up-to-date" — indistinguishable from "nothing to do". That is why, after a release, a seemingly arbitrary subset of instances updates, and a different subset the next time. If you run more than one or two instances from the same address, a caching proxy in front of the store that serves stale content on `429` would stop a throttle masquerading as "up to date" — but it must be a host the instances treat as external. Pointing `appstoreurl` at a proxy on the instance's own machine does not work: Nextcloud's SSRF protection refuses a loopback address, and the store is simply never asked.
 
-**Silent blockers worth knowing:** an app directory that is a git checkout is never
-updated, and `appstoreenabled=false` stops the store being asked at all. Neither says
-so.
+**Silent blockers worth knowing:** an app directory that is a git checkout is never updated, and `appstoreenabled=false` stops the store being asked at all. Neither says so.
 
 ## The pictures the store shows
 
@@ -106,8 +58,4 @@ so.
 
 ## Signing
 
-The store expects a signature over the tarball, and Nextcloud expects
-`appinfo/signature.json` inside it. These are two different things made by two
-different tools — `occ integrity:sign-app` writes the file, `openssl dgst -sha512
--sign` produces the signature you hand to the store API. `krankerl` does not create
-`signature.json`; expecting it to is a dead end.
+The store expects a signature over the tarball, and Nextcloud expects `appinfo/signature.json` inside it. These are two different things made by two different tools — `occ integrity:sign-app` writes the file, `openssl dgst -sha512 -sign` produces the signature you hand to the store API. `krankerl` does not create `signature.json`; expecting it to is a dead end.

--- a/doc/store/README.md
+++ b/doc/store/README.md
@@ -1,18 +1,12 @@
 # Pictures for the app store
 
-Both are named in `appinfo/info.xml` and are fetched from GitHub by their raw URL, so
-they must stay at these paths once a release names them.
+Both are named in `appinfo/info.xml` and are fetched from GitHub by their raw URL, so they must stay at these paths once a release names them.
 
 | File | Size | Format | Read by |
 |---|---|---|---|
 | `challenge.png` | 855×479 | PNG | the store page, and every Nextcloud instance |
 | `challenge.webp` | 356×200 | lossless webp | the store's app grid only |
 
-Both files show the same picture and share a base name; only the format differs, and
-`info.xml` names each one. The thumbnail is a 1:1 cut-out of the screenshot, not a scaled
-copy: the grid container is 200 pixels high, so a picture of exactly that height is shown
-pixel for pixel and stays readable.
+Both files show the same picture and share a base name; only the format differs, and `info.xml` names each one. The thumbnail is a 1:1 cut-out of the screenshot, not a scaled copy: the grid container is 200 pixels high, so a picture of exactly that height is shown pixel for pixel and stays readable.
 
-**The formats are not interchangeable.** Only the screenshot passes Nextcloud's image
-proxy, and that one refuses a lossless webp — hence PNG. The thumbnail is never proxied,
-so it uses the smaller lossless webp. [releasing.md](../releasing.md) explains why.
+**The formats are not interchangeable.** Only the screenshot passes Nextcloud's image proxy, and that one refuses a lossless webp — hence PNG. The thumbnail is never proxied, so it uses the smaller lossless webp. [releasing.md](../releasing.md) explains why.

--- a/doc/threat-model.md
+++ b/doc/threat-model.md
@@ -35,61 +35,25 @@ Email 2FA is a low-friction, broadly available second factor — a clear improve
 
 ## Verified invariants
 
-These are statements about **Nextcloud's own behaviour** that the app depends on. None
-of them can be read off the public `OCP` interfaces: the code that enforces them lives
-in the server's private classes. So each was checked against the server's source for
-every supported version, and each says where.
+These are statements about **Nextcloud's own behaviour** that the app depends on. None of them can be read off the public `OCP` interfaces: the code that enforces them lives in the server's private classes. So each was checked against the server's source for every supported version, and each says where.
 
-**Checked 2026-08-26**, against pinned commits of
-[nextcloud/server](https://github.com/nextcloud/server) rather than a moving branch, so
-every line number below can still be found:
+**Checked 2026-08-26**, against pinned commits of [nextcloud/server](https://github.com/nextcloud/server) rather than a moving branch, so every line number below can still be found:
 
 | Server line | Commit | Version |
 |-------------|--------|---------|
 | `stable33`  | [`a91897f4`](https://github.com/nextcloud/server/commit/a91897f461c4bd1a1c9eca44147fb3c7366dfa0c) | 33.0.8.2 |
 | `stable34`  | [`a599620e`](https://github.com/nextcloud/server/commit/a599620e9b75dc3c919b39dabd82a4f98b543b74) | 34.0.3.2 |
 
-Adding a server version to the supported range means checking these against the commit
-that version ships, and pinning it here, rather than assuming they still hold.
+Adding a server version to the supported range means checking these against the commit that version ships, and pinning it here, rather than assuming they still hold.
 
-**Nextcloud 35 is in the supported range and not yet checked here.** As of 2026-09-05
-its stable branch carries no released commit, so there is nothing to pin. Check the five
-invariants against the commit 35.0.0 ships and add its row.
+**Nextcloud 35 is in the supported range and not yet checked here.** As of 2026-09-05 its stable branch carries no released commit, so there is nothing to pin. Check the five invariants against the commit 35.0.0 ships and add its row.
 
-**1. Every route of this app requires a completed first factor.** None of them carries
-`#[PublicPage]`, and `SecurityMiddleware` answers a request to a non-public route from
-a session without a user with `NotLoggedInException`
-(`lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php`, line 135 on
-stable33, line 139 on stable34). The two-factor exemption below is read by a different
-middleware and does not touch this: it lifts the *second* factor, never the first.
+**1. Every route of this app requires a completed first factor.** None of them carries `#[PublicPage]`, and `SecurityMiddleware` answers a request to a non-public route from a session without a user with `NotLoggedInException` (`lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php`, line 135 on stable33, line 139 on stable34). The two-factor exemption below is read by a different middleware and does not touch this: it lifts the *second* factor, never the first.
 
-**2. `NoTwoFactorRequired` is read differently per version.** Nextcloud 33 reads the
-exemption from the docblock annotation only (`core/Middleware/TwoFactorMiddleware.php`
-line 46), Nextcloud 34 from the annotation *or* the attribute (line 50, via
-`hasAnnotationOrAttribute`). That is why `ChallengeController::resend()` carries both:
-the attribute is `@since 34`, and removing either one breaks a supported server.
+**2. `NoTwoFactorRequired` is read differently per version.** Nextcloud 33 reads the exemption from the docblock annotation only (`core/Middleware/TwoFactorMiddleware.php` line 46), Nextcloud 34 from the annotation *or* the attribute (line 50, via `hasAnnotationOrAttribute`). That is why `ChallengeController::resend()` carries both: the attribute is `@since 34`, and removing either one breaks a supported server.
 
-**3. Extending `ALoginSetupController` lifts the second-factor gate.** That class is
-empty; its only effect is that `TwoFactorMiddleware` recognises it and skips the gate
-while a user needs a second factor and has no primary provider to complete it with
-(`core/Middleware/TwoFactorMiddleware.php`, line 67 on stable33, line 72 on stable34).
-That state is the enrolment case, and `StateController` needs it — the setup step shown
-during login switches the provider on through it. `AdminSettingsController` therefore
-does **not** extend it: with the base class, changing this app's settings would need
-the password alone while an admin is still being set up.
+**3. Extending `ALoginSetupController` lifts the second-factor gate.** That class is empty; its only effect is that `TwoFactorMiddleware` recognises it and skips the gate while a user needs a second factor and has no primary provider to complete it with (`core/Middleware/TwoFactorMiddleware.php`, line 67 on stable33, line 72 on stable34). That state is the enrolment case, and `StateController` needs it — the setup step shown during login switches the provider on through it. `AdminSettingsController` therefore does **not** extend it: with the base class, changing this app's settings would need the password alone while an admin is still being set up.
 
-**4. A delegated group passes `#[AuthorizedAdminSetting]`.** Being a member of the
-`admin` group is not the only way in. `SecurityMiddleware` also matches the settings
-classes named in the attribute against the classes delegated to the user's groups
-(line 147 on stable33, line 151 on stable34). So an admin who delegates this app's
-settings with `occ admin-delegation:add` grants exactly the routes that attribute
-guards — which is the point of the feature, and worth knowing before delegating.
+**4. A delegated group passes `#[AuthorizedAdminSetting]`.** Being a member of the `admin` group is not the only way in. `SecurityMiddleware` also matches the settings classes named in the attribute against the classes delegated to the user's groups (line 147 on stable33, line 151 on stable34). So an admin who delegates this app's settings with `occ admin-delegation:add` grants exactly the routes that attribute guards — which is the point of the feature, and worth knowing before delegating.
 
-**5. Nextcloud lower-cases and trims an email address before storing it.** The
-fingerprint a stored code is bound to does the same, so an address differing only in
-case or surrounding space does not read as a changed one. Both setters normalise
-(`lib/private/User/User.php`, `setSystemEMailAddress()` line 161 and
-`setPrimaryEMailAddress()` line 184 on stable33, lines 149 and 173 on stable34), and
-`getSystemEMailAddress()` normalises again on the way out (line 529 on stable33, 533 on
-stable34). Should the two ever diverge, a code would die one send early — harmless, and
-named here because it would otherwise be hard to trace.
+**5. Nextcloud lower-cases and trims an email address before storing it.** The fingerprint a stored code is bound to does the same, so an address differing only in case or surrounding space does not read as a changed one. Both setters normalise (`lib/private/User/User.php`, `setSystemEMailAddress()` line 161 and `setPrimaryEMailAddress()` line 184 on stable33, lines 149 and 173 on stable34), and `getSystemEMailAddress()` normalises again on the way out (line 529 on stable33, 533 on stable34). Should the two ever diverge, a code would die one send early — harmless, and named here because it would otherwise be hard to trace.

--- a/tests/smoke/README.md
+++ b/tests/smoke/README.md
@@ -5,21 +5,15 @@
 
 # Smoke test against a real Nextcloud
 
-The unit tests cover the classes. What they cannot cover is whether the app still
-works *inside* a Nextcloud — whether the routes are reachable, whether the mail goes
-out, whether a login with a code from that mail actually gets you in, and whether any
-of that differs between the oldest and the newest supported server.
+The unit tests cover the classes. What they cannot cover is whether the app still works *inside* a Nextcloud — whether the routes are reachable, whether the mail goes out, whether a login with a code from that mail actually gets you in, and whether any of that differs between the oldest and the newest supported server.
 
-These scripts start a disposable Nextcloud from the official image, install **the
-built package** into it, and check exactly that.
+These scripts start a disposable Nextcloud from the official image, install **the built package** into it, and check exactly that.
 
 ## Requirements
 
-Docker with the compose plugin, `python3`, `curl`, and a built package
-(`krankerl package`) — or a directory to mount, see below. Nothing leaves your machine.
+Docker with the compose plugin, `python3`, `curl`, and a built package (`krankerl package`) — or a directory to mount, see below. Nothing leaves your machine.
 
-The scripts use GNU `grep -oP`, `stat -c` and `date -d`, so they need a GNU userland:
-Linux, or macOS with GNU coreutils and grep ahead of the stock ones in `PATH`.
+The scripts use GNU `grep -oP`, `stat -c` and `date -d`, so they need a GNU userland: Linux, or macOS with GNU coreutils and grep ahead of the stock ones in `PATH`.
 
 ## Use
 
@@ -35,29 +29,15 @@ COMPOSE_PROJECT_NAME=tfe-2 HTTP_PORT=8081 MAIL_PORT=8026 ./smoke.sh   # a second
 
 ### The server that is not out yet
 
-`NC_TAG` takes any tag of the official `nextcloud` image, and that is the limit: there
-is **no image for an unreleased version**. Nextcloud published `NN-beta` and `NN-rc`
-tags up to version 18 and stopped; today a tag appears when the version is released.
-So `NC_TAG=master` or `NC_TAG=35-apache` simply will not pull while 35 is in beta.
+`NC_TAG` takes any tag of the official `nextcloud` image, and that is the limit: there is **no image for an unreleased version**. Nextcloud published `NN-beta` and `NN-rc` tags up to version 18 and stopped; today a tag appears when the version is released. So `NC_TAG=master` or `NC_TAG=35-apache` simply will not pull while 35 is in beta.
 
-Two things cover that gap instead. The `Nextcloud next` workflow runs the unit tests
-and Psalm against the server's `master` branch, which needs no image. And this smoke
-test picks the next version up **by itself**: its workflow asks the registry whether
-an image for the version after the declared range exists, and adds it to the run as
-soon as one does — as a warning, never as a gate. Nothing has to be edited for 35,
-then 36, then 37.
+Two things cover that gap instead. The `Nextcloud next` workflow runs the unit tests and Psalm against the server's `master` branch, which needs no image. And this smoke test picks the next version up **by itself**: its workflow asks the registry whether an image for the version after the declared range exists, and adds it to the run as soon as one does — as a warning, never as a gate. Nothing has to be edited for 35, then 36, then 37.
 
-`setup.sh` writes `tests/smoke/.env` (gitignored) with the values compose needs, which is
-why a later `docker compose down -v`, `logs` or `exec` works in that directory without
-setting anything. It records the **last** setup run, so with two instances around name the
-project when tearing one down:
-`COMPOSE_PROJECT_NAME=tfe-smoke docker compose down -v`.
+`setup.sh` writes `tests/smoke/.env` (gitignored) with the values compose needs, which is why a later `docker compose down -v`, `logs` or `exec` works in that directory without setting anything. It records the **last** setup run, so with two instances around name the project when tearing one down: `COMPOSE_PROJECT_NAME=tfe-smoke docker compose down -v`.
 
 ## Without krankerl
 
-`krankerl` is only needed to build the package. If it does not work for you — it has
-been known to fail with `reference 'refs/remotes/origin/master' not found`, which comes
-from libgit2 inside it, not from your repository — mount your working tree instead:
+`krankerl` is only needed to build the package. If it does not work for you — it has been known to fail with `reference 'refs/remotes/origin/master' not found`, which comes from libgit2 inside it, not from your repository — mount your working tree instead:
 
 ```bash
 composer install -o          # only the autoloader is needed at runtime
@@ -65,39 +45,27 @@ npm ci && npm run build      # produces js/ and css/
 APP_DIR="$(git rev-parse --show-toplevel)" ./smoke.sh
 ```
 
-Naming a directory switches the mode: nothing is unpacked, that directory is mounted.
-`setup.sh` takes the same route, and `UNPACK` states it explicitly if you ever need to
-override the default (`UNPACK=0` mount, `UNPACK=1` unpack the package).
+Naming a directory switches the mode: nothing is unpacked, that directory is mounted. `setup.sh` takes the same route, and `UNPACK` states it explicitly if you ever need to override the default (`UNPACK=0` mount, `UNPACK=1` unpack the package).
 
-Everything is checked as usual, except the comparison of the installed version against
-the package: there is no package. The trade-off is stated in the output, and it is
-real — a file missing from the release because of `.nextcloudignore` cannot show up
-this way. Use the packaged run before a release, this one while developing.
+Everything is checked as usual, except the comparison of the installed version against the package: there is no package. The trade-off is stated in the output, and it is real — a file missing from the release because of `.nextcloudignore` cannot show up this way. Use the packaged run before a release, this one while developing.
 
-The exit code is the number of failed checks. Ports and package can be overridden
-with `HTTP_PORT`, `MAIL_PORT` and `APP_TARBALL`.
+The exit code is the number of failed checks. Ports and package can be overridden with `HTTP_PORT`, `MAIL_PORT` and `APP_TARBALL`.
 
-A full run takes about six minutes per server version. Most of the extra time is one
-deliberate 65-second wait: the resend cooldown has to pass before the *successful*
-resend can be checked, and a rejected resend only proves half of that route. `SLOW=0`
-drops it when you are iterating.
+A full run takes about six minutes per server version. Most of the extra time is one deliberate 65-second wait: the resend cooldown has to pass before the *successful* resend can be checked, and a rejected resend only proves half of that route. `SLOW=0` drops it when you are iterating.
 
 ## Switching the provider on without a browser
 
-The app keeps the per-user state in Nextcloud's own two-factor registry, so `occ` can
-do it:
+The app keeps the per-user state in Nextcloud's own two-factor registry, so `occ` can do it:
 
 ```bash
 docker compose exec -T -u www-data nextcloud php occ twofactorauth:enable admin email
 ```
 
-`setup.sh` prints this too. Note that the 2.x branch used a user setting of its own
-instead — `occ user:setting … twofactor_email verified true` does nothing here.
+`setup.sh` prints this too. Note that the 2.x branch used a user setting of its own instead — `occ user:setting … twofactor_email verified true` does nothing here.
 
 ## Why it may refuse to start
 
-The script compares the package against the state of the app and stops if they do not
-match — either because something is uncommitted:
+The script compares the package against the state of the app and stops if they do not match — either because something is uncommitted:
 
 ```
 Uncommitted changes to the app:
@@ -112,64 +80,27 @@ The package is older than the app it should contain:
   sources 2026-07-27 23:05:11 (last commit touching the app)
 ```
 
-This is not pedantry. `krankerl package` packages the **committed** state, so a stale
-package or an uncommitted change means the run proves something other than what you are
-working on — which has happened here: a smoke test once passed against a package built
-before the change it was meant to verify. Rebuild with `krankerl package`, or
-test the working tree instead with `APP_DIR=…`.
+This is not pedantry. `krankerl package` packages the **committed** state, so a stale package or an uncommitted change means the run proves something other than what you are working on — which has happened here: a smoke test once passed against a package built before the change it was meant to verify. Rebuild with `krankerl package`, or test the working tree instead with `APP_DIR=…`.
 
 ## What it checks
 
-Login and challenge, the mail, `challenge/resend` including its cooldown, a wrong and
-then the right code, `admin/save` with its validation path, `admin/reset`,
-`state/save` in both directions with the registry state, every asset the challenge
-page pulls, the server log, and a recipient the mail server refuses.
+Login and challenge, the mail, `challenge/resend` including its cooldown, a wrong and then the right code, `admin/save` with its validation path, `admin/reset`, `state/save` in both directions with the registry state, every asset the challenge page pulls, the server log, and a recipient the mail server refuses.
 
-It also covers what no HTTP route reaches: `admin-delegation:show`, which is where the
-server asks the settings class for its name and priority, and the `twofactor_email:cleanup`
-and `twofactor_email:delete-codes` commands. Those run against a user whose id is digits
-only, because Nextcloud allows such an id and PHP then hands it back as an int.
+It also covers what no HTTP route reaches: `admin-delegation:show`, which is where the server asks the settings class for its name and priority, and the `twofactor_email:cleanup` and `twofactor_email:delete-codes` commands. Those run against a user whose id is digits only, because Nextcloud allows such an id and PHP then hands it back as an int.
 
-**Why both server versions by default:** in 3.4.0 the resend endpoint was dead on
-Nextcloud 33 while working on 34. The exemption from the two-factor gate is read from
-the docblock on 33 and from the attribute on 34, and the attribute is `@since 34`. The
-manual browser pass ran on a 34 instance, so nothing looked wrong. One version is not
-a test of a version *range*.
+**Why both server versions by default:** in 3.4.0 the resend endpoint was dead on Nextcloud 33 while working on 34. The exemption from the two-factor gate is read from the docblock on 33 and from the attribute on 34, and the attribute is `@since 34`. The manual browser pass ran on a 34 instance, so nothing looked wrong. One version is not a test of a version *range*.
 
 ## What it does not check
 
-**Appearance.** Layout, dark mode, translations, whether a dialog is comprehensible.
-That still needs a person with a browser — `KEEP=1` leaves an instance running for it.
+**Appearance.** Layout, dark mode, translations, whether a dialog is comprehensible. That still needs a person with a browser — `KEEP=1` leaves an instance running for it.
 
 ## Things that cost hours, written down so they cost you none
 
-- **"No request token on `/login`" means the server is not answering yet**, not that the
-  login page changed. `occ status` reporting `installed: true` goes through
-  `docker compose exec` and says nothing about Apache. The CI hit this on a loaded
-  runner: the same commit passed in one run and failed in the next, on one server
-  version only, with everything after the first check reporting 401 or an empty
-  response. `setup.sh` now waits for `/login` to answer before it returns.
-- **The request token goes in a header, not in a form field.** It is base64 and often
-  contains a `+`, which PHP turns into a space while decoding a form body. As a form
-  field the same request therefore works about one time in three, which looks like a
-  flaky server rather than a broken client.
-- **`curl` needs an `Origin` header for `POST /login`.** Nextcloud rejects the request
-  before it looks at the password, and answers with a redirect to
-  `?direct=1&user=…` plus a misleading `Logging out` in the log. It looks exactly like
-  a wrong password.
-- **`curl` sends a GET when no `-d` is given**, so a POST-only route answers 405 and
-  it reads like the route is missing.
-- **After a wrong code the redirect target contains the dashboard path**
-  (`/login/selectchallenge?redirect_url=/apps/dashboard/`). Checking the URL for
-  "dashboard" therefore reports a success that never happened — ask the session
-  instead.
-- **`krankerl package` packages the committed state.** An uncommitted fix is not in the
-  package, and the test will keep proving the old behaviour.
-- **"The token expired" on the first login attempt.** Nextcloud's login form is only
-  valid for five minutes (`login_form_timeout`). Opening the page while the instance is
-  still installing and submitting afterwards therefore fails once; reloading is enough.
-  `occ config:system:set login_form_timeout --value=3600 --type=integer` if you want to
-  take your time.
-- **The admin password cannot be changed to a weak one afterwards.**
-  `password_policy` is active in the image; it does not apply during installation,
-  which is why `admin/admin` works at all. Throw the instance away instead.
+- **"No request token on `/login`" means the server is not answering yet**, not that the login page changed. `occ status` reporting `installed: true` goes through `docker compose exec` and says nothing about Apache. The CI hit this on a loaded runner: the same commit passed in one run and failed in the next, on one server version only, with everything after the first check reporting 401 or an empty response. `setup.sh` now waits for `/login` to answer before it returns.
+- **The request token goes in a header, not in a form field.** It is base64 and often contains a `+`, which PHP turns into a space while decoding a form body. As a form field the same request therefore works about one time in three, which looks like a flaky server rather than a broken client.
+- **`curl` needs an `Origin` header for `POST /login`.** Nextcloud rejects the request before it looks at the password, and answers with a redirect to `?direct=1&user=…` plus a misleading `Logging out` in the log. It looks exactly like a wrong password.
+- **`curl` sends a GET when no `-d` is given**, so a POST-only route answers 405 and it reads like the route is missing.
+- **After a wrong code the redirect target contains the dashboard path** (`/login/selectchallenge?redirect_url=/apps/dashboard/`). Checking the URL for "dashboard" therefore reports a success that never happened — ask the session instead.
+- **`krankerl package` packages the committed state.** An uncommitted fix is not in the package, and the test will keep proving the old behaviour.
+- **"The token expired" on the first login attempt.** Nextcloud's login form is only valid for five minutes (`login_form_timeout`). Opening the page while the instance is still installing and submitting afterwards therefore fails once; reloading is enough. `occ config:system:set login_form_timeout --value=3600 --type=integer` if you want to take your time.
+- **The admin password cannot be changed to a weak one afterwards.** `password_policy` is active in the image; it does not apply during installation, which is why `admin/admin` works at all. Throw the instance away instead.


### PR DESCRIPTION
Half the Markdown here was hard-wrapped at about ninety columns and half was not, so every edit to a wrapped paragraph rewrapped the lines below it and the diff showed a paragraph where one word had changed. A soft-wrapped file diffs per sentence instead, and the rendered page is the same either way.

One paragraph is now one line. Untouched: fenced code, tables, headings, list markers and their nesting, HTML comments, and any line ending in two spaces or a backslash, which is a line break the reader sees.

Verified per file rather than by eye: pandoc renders the same HTML before and after, and the text is identical once whitespace is collapsed.

This is the base of a stack of four. The three on top change wording, and their diffs are readable only because this one goes first.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
