### PR TITLE
Say what a server gets, in the row for that server

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,18 @@ Any second factor stops desktop and mobile clients from signing in with the norm
 
 The [user guide](doc/users.md) and the [administrator guide](doc/admins.md) cover all of this in detail.
 
-## Versions
+## Supported versions
 
-Every Nextcloud version that Nextcloud itself still supports is served by a line of this app that gets security fixes. An older Nextcloud keeps the last line that ran on it, for as long as maintaining it stays reasonable — that is an offer, not a promise. New features go first into the line built for the newest released Nextcloud; an older 3.x line gets them where that is easy.
+| Nextcloud | App | Security fixes | New features | App EOL |
+|---|---|---|---|---|
+| 35 | **3.5** | ✅ | ✅ | – |
+| 34 | **3.5** | ✅ | ✅ | – |
+| 33 | **3.5** | ✅ | ✅ | – |
+| 32 | 3.3 | ✅ | ⚠️ | – |
 
-| Line | Use it on | Security fixes | New features |
-|---|---|---|---|
-| **3.5** | Nextcloud 33–35 | yes | yes |
-| 3.3 | Nextcloud 32 | while reasonable | best effort |
-| [2.8](https://github.com/nursoda/twofactor_email/) | Nextcloud 30–31 | while reasonable | no |
+This table is the promise. It changes with every release, and the CHANGELOG says when a line's support ends. ⚠️ means best effort.
 
-Version 3 is a refactored successor of version 2 and started out from [twofactor_totp](https://github.com/nextcloud/twofactor_totp/). An upgrade from 2 to 3 keeps the provider switched on for each user; stored codes are not carried over, as they expire within minutes anyway.
+An upgrade from version 2 of this app keeps the provider switched on for each user; stored codes are not carried over, as they expire within minutes anyway.
 
 ## Documentation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,7 @@ The security model is documented by audience — [users](doc/users.md), [adminis
 
 ## Supported Versions
 
-**What we promise:** every Nextcloud version that Nextcloud itself still supports is served by a line of this app that gets security fixes. Today that is the **3.5** line, for Nextcloud 33 to 35.
-
-**What we offer beyond it:** an older Nextcloud keeps the last line that ran on it — **3.3** for Nextcloud 32, version **2.8** below that — for as long as fixing it stays reasonable. We judge that per case, and nothing here commits us to it.
-
-Within a line only its latest release is fixed, so update to that one before reporting.
+The [versions table in the README](README.md#supported-versions) says which line to install for which Nextcloud server, and what that line gets. It is the promise: a row changes there before anything about it stops. Within a line only the latest release is fixed, so update to it before you report.
 
 ## Reporting a Vulnerability
 

--- a/doc/admins.md
+++ b/doc/admins.md
@@ -7,7 +7,7 @@ This page covers installing, configuring, and running the provider.
 - Install **Two-Factor Email** from the [Nextcloud app store](https://apps.nextcloud.com/apps/twofactor_email). The server needs a working mail setup: the second factor travels that path, so use TLS to the mail server and treat it as part of your security perimeter.
 - Users can enable it themselves in their security settings, or you can enable/disable it per user via `occ` — see [From the command line](#from-the-command-line).
 - You can also **enforce 2FA** server-wide or per group (a Nextcloud feature) — see [Enforcing two-factor authentication](#enforcing-two-factor-authentication).
-- **Keep it updated.** Only the newest release of a line carries the fixes, so install app updates as they appear — in *Administration settings › Apps*, or with `occ app:update twofactor_email`. Which line belongs to your server is in the [README](../README.md#versions).
+- **Keep it updated.** Only the newest release of a line carries the fixes, so install app updates as they appear — in *Administration settings › Apps*, or with `occ app:update twofactor_email`. Which line belongs to your server is in the [README](../README.md#supported-versions).
 
 ## From the command line
 


### PR DESCRIPTION
The versions table asked a reader to work out which line covers their Nextcloud from a range, and answered in a column of yes. It now has one row per server version, so looking up 32 takes one line, and what that line gets stands in the row: green for yes, a warning sign for best effort.

It also has to be true. The old table said "while reasonable" for the 3.3 line while the policy promised security fixes for every server Nextcloud still maintains — which includes Nextcloud 32 until the end of September. That line does get fixes, so the row says so, and it keeps saying so after Nextcloud drops 32: what ends the fixes is an announcement in this table, not a date elsewhere.

Nextcloud 30 and 31 are gone from the table with the 2.8 line, which is not promised what the maintained lines are promised; that line has its own repository and its own documentation.

The promise stands where the table stands, and `SECURITY.md` points at it instead of stating it a second time.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
